### PR TITLE
daemon:connect: don't use FIPS_mode_set with OpenSSL 3

### DIFF
--- a/daemon/connect/TlsSocket.cpp
+++ b/daemon/connect/TlsSocket.cpp
@@ -189,7 +189,11 @@ void TlsSocket::Final()
 
 #ifdef HAVE_OPENSSL
 #ifndef LIBRESSL_VERSION_NUMBER
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 	FIPS_mode_set(0);
+#else
+	EVP_default_properties_enable_fips(NULL, 0);
+#endif
 #endif
 #ifdef NEED_CRYPTO_LOCKING
 	CRYPTO_set_locking_callback(nullptr);


### PR DESCRIPTION
orig PR: https://github.com/nzbget/nzbget/pull/793 by https://github.com/schopin-pro

This function has been removed in OpenSSL 3, replaced by EVP_default_properties_enable_fips. See
https://www.openssl.org/docs/man3.0/man7/migration_guide.html