### PR TITLE
Add native support for Apple Silicon Macs

### DIFF
--- a/osx/NZBGet.xcodeproj/project.pbxproj
+++ b/osx/NZBGet.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -324,7 +325,6 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = NZBGet;
 				SDKROOT = macosx;
-				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
 		};
@@ -332,6 +332,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -347,7 +348,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = NZBGet;
 				SDKROOT = macosx;
-				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
added native support for Apple Silicon Macs by letting Xcode build Universal app
https://github.com/nzbget/nzbget/pull/786 by @nehalvpatel