### PR TITLE
Fix synology spk removal

### DIFF
--- a/synology/package/scripts/postuninst
+++ b/synology/package/scripts/postuninst
@@ -3,6 +3,7 @@
 
 if [ "$wizard_keep_data" != "true" ]; then
     rm $CFG
+    rm $SYNOPKG_PKGVAR/*
 fi
 
 exit 0


### PR DESCRIPTION
## Description

Bug fixed: When a package is uninstalled with data removed, the .lock and .log files remain in the SYNOPKG_PKGVAR folder, preventing the SynoCommunity package from running.
Workaround for older spks: uninstall SynoCommunity package with full cleanup and install again.
