### PR TITLE
Docker fixes: disable OCI mediatypes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         package-owner: nzbgetcom
         package-name: nzbget
-        keep-versions: -1
+        keep-versions: 10
         delete-orphans: true
         dry-run: true
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,16 +42,6 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Cleanup ghcr.io from outdated images
-      uses: miklinux/ghcr-cleanup-action@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        package-owner: nzbgetcom
-        package-name: nzbget
-        keep-versions: 10
-        delete-orphans: true
-        dry-run: true
-
     # - name: Generate image tags
     #   id: gen_tags
     #   run: |
@@ -91,3 +81,12 @@ jobs:
     #     password: ${{ secrets.DOCKERHUB_TOKEN }}
     #     repository: ${{ env.REGISTRY_IMAGE }}
     #     readme-filepath: ./docker/README.md
+
+    - name: Cleanup ghcr.io from outdated images
+      uses: miklinux/ghcr-cleanup-action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        package-owner: nzbgetcom
+        package-name: nzbget
+        delete-orphans: true
+        dry-run: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,6 +48,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         package-owner: nzbgetcom
         package-name: nzbget
+        keep-versions: -1
         delete-orphans: true
         dry-run: true
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,14 +42,14 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Prune old untaggged images
-      uses: vlaurin/action-ghcr-prune@main
+    - name: Cleanup ghcr.io from outdated images
+      uses: miklinux/ghcr-cleanup-action@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        organization: nzbgetcom
-        container: nzbget
+        package-owner: nzbgetcom
+        package-name: nzbget
+        delete-orphans: true
         dry-run: true
-        prune-untagged: true
 
     # - name: Generate image tags
     #   id: gen_tags

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,42 +42,51 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Generate image tags
-      id: gen_tags
-      run: |
-        if [[ "$GITHUB_REF_NAME" == "develop" ]]; then
-          TAG="testing"
-        fi
-        if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-          TAG="latest"
-        fi
-        if [[ $GITHUB_REF == 'refs/tags/'* ]]; then
-          TAG="${GITHUB_REF/refs\/tags\//}"
-        fi
-        if [[ "$TAG" == "" ]]; then
-          TAG="${GITHUB_REF_NAME/\//-}"
-        fi
-        TAGS="${{ env.REGISTRY_IMAGE }}:$TAG,ghcr.io/${{ env.REGISTRY_IMAGE }}:$TAG"
-        echo "tags=$TAGS" >> $GITHUB_OUTPUT
-        echo "version=$TAG" >> $GITHUB_OUTPUT
-    
-    - name: Build and push
-      uses: docker/build-push-action@v5
+    - name: Prune old untaggged images
+      uses: vlaurin/action-ghcr-prune@main
       with:
-        context: docker
-        platforms: linux/amd64,linux/arm64,linux/arm/v7
-        provenance: false
-        push: true
-        tags: ${{ steps.gen_tags.outputs.tags }}
-        outputs: "type=image,oci-mediatypes=false,name=${{ env.REGISTRY_IMAGE }}"
-        build-args: |
-          "NZBGET_RELEASE=${{ github.ref_name }}"
-          "MAKE_JOBS=2"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        organization: nzbgetcom
+        container: nzbget
+        dry-run: true
+        prune-untagged: true
 
-    - name: Update Docker Hub Description
-      uses: peter-evans/dockerhub-description@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-        repository: ${{ env.REGISTRY_IMAGE }}
-        readme-filepath: ./docker/README.md
+    # - name: Generate image tags
+    #   id: gen_tags
+    #   run: |
+    #     if [[ "$GITHUB_REF_NAME" == "develop" ]]; then
+    #       TAG="testing"
+    #     fi
+    #     if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+    #       TAG="latest"
+    #     fi
+    #     if [[ $GITHUB_REF == 'refs/tags/'* ]]; then
+    #       TAG="${GITHUB_REF/refs\/tags\//}"
+    #     fi
+    #     if [[ "$TAG" == "" ]]; then
+    #       TAG="${GITHUB_REF_NAME/\//-}"
+    #     fi
+    #     TAGS="${{ env.REGISTRY_IMAGE }}:$TAG,ghcr.io/${{ env.REGISTRY_IMAGE }}:$TAG"
+    #     echo "tags=$TAGS" >> $GITHUB_OUTPUT
+    #     echo "version=$TAG" >> $GITHUB_OUTPUT
+    
+    # - name: Build and push
+    #   uses: docker/build-push-action@v5
+    #   with:
+    #     context: docker
+    #     platforms: linux/amd64,linux/arm64,linux/arm/v7
+    #     provenance: false
+    #     push: true
+    #     tags: ${{ steps.gen_tags.outputs.tags }}
+    #     outputs: "type=image,oci-mediatypes=false,name=${{ env.REGISTRY_IMAGE }}"
+    #     build-args: |
+    #       "NZBGET_RELEASE=${{ github.ref_name }}"
+    #       "MAKE_JOBS=2"
+
+    # - name: Update Docker Hub Description
+    #   uses: peter-evans/dockerhub-description@v3
+    #   with:
+    #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+    #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+    #     repository: ${{ env.REGISTRY_IMAGE }}
+    #     readme-filepath: ./docker/README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - develop
     - main
-    - bugfix/docker-disable-oci-mediatypes
     tags:
     - v*
 
@@ -42,45 +41,45 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    # - name: Generate image tags
-    #   id: gen_tags
-    #   run: |
-    #     if [[ "$GITHUB_REF_NAME" == "develop" ]]; then
-    #       TAG="testing"
-    #     fi
-    #     if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-    #       TAG="latest"
-    #     fi
-    #     if [[ $GITHUB_REF == 'refs/tags/'* ]]; then
-    #       TAG="${GITHUB_REF/refs\/tags\//}"
-    #     fi
-    #     if [[ "$TAG" == "" ]]; then
-    #       TAG="${GITHUB_REF_NAME/\//-}"
-    #     fi
-    #     TAGS="${{ env.REGISTRY_IMAGE }}:$TAG,ghcr.io/${{ env.REGISTRY_IMAGE }}:$TAG"
-    #     echo "tags=$TAGS" >> $GITHUB_OUTPUT
-    #     echo "version=$TAG" >> $GITHUB_OUTPUT
+    - name: Generate image tags
+      id: gen_tags
+      run: |
+        if [[ "$GITHUB_REF_NAME" == "develop" ]]; then
+          TAG="testing"
+        fi
+        if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+          TAG="latest"
+        fi
+        if [[ $GITHUB_REF == 'refs/tags/'* ]]; then
+          TAG="${GITHUB_REF/refs\/tags\//}"
+        fi
+        if [[ "$TAG" == "" ]]; then
+          TAG="${GITHUB_REF_NAME/\//-}"
+        fi
+        TAGS="${{ env.REGISTRY_IMAGE }}:$TAG,ghcr.io/${{ env.REGISTRY_IMAGE }}:$TAG"
+        echo "tags=$TAGS" >> $GITHUB_OUTPUT
+        echo "version=$TAG" >> $GITHUB_OUTPUT
     
-    # - name: Build and push
-    #   uses: docker/build-push-action@v5
-    #   with:
-    #     context: docker
-    #     platforms: linux/amd64,linux/arm64,linux/arm/v7
-    #     provenance: false
-    #     push: true
-    #     tags: ${{ steps.gen_tags.outputs.tags }}
-    #     outputs: "type=image,oci-mediatypes=false,name=${{ env.REGISTRY_IMAGE }}"
-    #     build-args: |
-    #       "NZBGET_RELEASE=${{ github.ref_name }}"
-    #       "MAKE_JOBS=2"
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: docker
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        provenance: false
+        push: true
+        tags: ${{ steps.gen_tags.outputs.tags }}
+        outputs: "type=image,oci-mediatypes=false,name=${{ env.REGISTRY_IMAGE }}"
+        build-args: |
+          "NZBGET_RELEASE=${{ github.ref_name }}"
+          "MAKE_JOBS=2"
 
-    # - name: Update Docker Hub Description
-    #   uses: peter-evans/dockerhub-description@v3
-    #   with:
-    #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-    #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-    #     repository: ${{ env.REGISTRY_IMAGE }}
-    #     readme-filepath: ./docker/README.md
+    - name: Update Docker Hub Description
+      uses: peter-evans/dockerhub-description@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        repository: ${{ env.REGISTRY_IMAGE }}
+        readme-filepath: ./docker/README.md
 
     - name: Cleanup ghcr.io from outdated images
       uses: miklinux/ghcr-cleanup-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - develop
     - main
+    - bugfix/docker-disable-oci-mediatypes
     tags:
     - v*
 
@@ -68,7 +69,7 @@ jobs:
         provenance: false
         push: true
         tags: ${{ steps.gen_tags.outputs.tags }}
-        outputs: "type=image,name=${{ env.REGISTRY_IMAGE }},annotation-index.org.opencontainers.image.description=NZBGet from nzbget.com - version ${{ steps.gen_tags.outputs.version }}"
+        outputs: "type=image,oci-mediatypes=false,name=${{ env.REGISTRY_IMAGE }},annotation-index.org.opencontainers.image.description=NZBGet from nzbget.com - version ${{ steps.gen_tags.outputs.version }}"
         build-args: |
           "NZBGET_RELEASE=${{ github.ref_name }}"
           "MAKE_JOBS=2"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,7 +69,7 @@ jobs:
         provenance: false
         push: true
         tags: ${{ steps.gen_tags.outputs.tags }}
-        outputs: "type=image,oci-mediatypes=false,name=${{ env.REGISTRY_IMAGE }},annotation-index.org.opencontainers.image.description=NZBGet from nzbget.com - version ${{ steps.gen_tags.outputs.version }}"
+        outputs: "type=image,oci-mediatypes=false,name=${{ env.REGISTRY_IMAGE }}"
         build-args: |
           "NZBGET_RELEASE=${{ github.ref_name }}"
           "MAKE_JOBS=2"


### PR DESCRIPTION
## Description

- for better compatibility with old Docker installations disabled generating OCI annotations and using OCI mediatypes
- added task to cleanup ghcr.io registry from orphaned untagged images
- this update fixes https://github.com/nzbgetcom/nzbget/issues/84#issuecomment-1883689474

## Testing

- smoke testing on aarch64 Debian 12.4 / Docker version 17.03.2-ce