### PR TITLE
Update 7za link in docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN \
   /app/nzbget/share/nzbget/nzbget.conf && \
   mv /app/nzbget/share/nzbget/webui /app/nzbget/ && \
   cp /app/nzbget/share/nzbget/nzbget.conf /app/nzbget/webui/nzbget.conf.template && \
-  ln -s /usr/bin/7za /app/nzbget/7za && \
+  ln -s /usr/bin/7z /app/nzbget/7za && \
   ln -s /usr/bin/unrar /app/nzbget/unrar && \
   cp /nzbget/pubkey.pem /app/nzbget/pubkey.pem && \
   curl -o /app/nzbget/cacert.pem -L "https://curl.se/ca/cacert.pem" && \


### PR DESCRIPTION
## Description

- bad 7za link changed in docker container for better migration from Linuxserver.io container
- fixes https://github.com/nzbgetcom/nzbget/discussions/145

## Testing

Smoke testing by @phnzb (migration from Linuxserver.io container)