### PR TITLE
Fix/sync and save settings on deleting/installing/updating extensions

### DIFF
--- a/webui/config.js
+++ b/webui/config.js
@@ -3536,11 +3536,10 @@ var ExtensionManager = (new function($)
 
 	function deleteGlobalSettings(extName)
 	{
-		var values = Config.config().values;
-		if (!values)
-		{
+		if (!Config.config() || !Config.config()['values'])
 			return;
-		}
+
+		var values = Config.config().values;
 		values.forEach(function(value, i)
 		{
 			if (value.Name == extensionsId)
@@ -3559,11 +3558,10 @@ var ExtensionManager = (new function($)
 
 	function syncGlobalSettings()
 	{
-		var values = Config.config().values;
-		if (!values)
-		{
+		if (!Config.config() || !Config.config()['values'])
 			return;
-		}
+
+		var values = Config.config().values;
 		var changed = false;
 		values.forEach(function(value, i)
 		{
@@ -3728,6 +3726,9 @@ var ExtensionManager = (new function($)
 
 	function deleteSettings(extName)
 	{
+		if (!Config.config() || !Config.config()['values'])
+			return;
+
 		var values = Config.config().values;
 		values.forEach(function(value, i) {
 		{


### PR DESCRIPTION
## Description

- added saving settings on deleting/installing/updating extensions
- deleted unnecessary table re-renderings when the user is not on this page

## Testing

- tested by @dnzbk on Windows/macOS and by @phnzb on Linux