### PR TITLE
Fix/extension unpacking error messages

### DIFF
--- a/daemon/extension/ExtensionManager.cpp
+++ b/daemon/extension/ExtensionManager.cpp
@@ -111,16 +111,16 @@ namespace ExtensionManager
 		};
 		unpacker.SetArgs(std::move(args));
 		
-		int code = unpacker.Execute();
+		int ec = unpacker.Execute();
 
-		if (code < 0)
+		if (ec < 0)
 		{
 			return "Failed to unpack " + filename + ". Make sure that path to 7-Zip is valid.";
 		}
 
-		if (code > 0)
+		if (ec > 0)
 		{
-			return "Failed to unpack " + filename + ". 7-Zip exit code: " + std::to_string(code);
+			return "Failed to unpack " + filename + ". " + UnpackController::DecodeSevenZipExitCode(ec);
 		}
 
 		if (!FileSystem::DeleteFile(filename.c_str()))

--- a/daemon/extension/ExtensionManager.cpp
+++ b/daemon/extension/ExtensionManager.cpp
@@ -115,7 +115,7 @@ namespace ExtensionManager
 
 		if (ec < 0)
 		{
-			return "Failed to unpack " + filename + ". Make sure that path to 7-Zip is valid.";
+			return "Failed to unpack " + filename + ". Make sure that the path to 7-Zip is valid.";
 		}
 
 		if (ec > 0)

--- a/daemon/extension/ExtensionManager.cpp
+++ b/daemon/extension/ExtensionManager.cpp
@@ -111,16 +111,16 @@ namespace ExtensionManager
 		};
 		unpacker.SetArgs(std::move(args));
 		
-		int res = unpacker.Execute();
+		int code = unpacker.Execute();
 
-		if (res != 0)
+		if (code < 0)
 		{
-			if (!FileSystem::DeleteFile(filename.c_str()))
-			{
-				return "Failed to unpack and delete temp file: " + filename;
-			}
+			return "Failed to unpack " + filename + ". Make sure that path to 7-Zip is valid.";
+		}
 
-			return "Failed to unpack " + filename;
+		if (code > 0)
+		{
+			return "Failed to unpack " + filename + ". 7-Zip exit code: " + std::to_string(code);
 		}
 
 		if (!FileSystem::DeleteFile(filename.c_str()))

--- a/daemon/postprocess/Unpack.cpp
+++ b/daemon/postprocess/Unpack.cpp
@@ -961,3 +961,32 @@ bool UnpackController::HasCompletedArchiveFiles(NzbInfo* nzbInfo)
 
 	return false;
 }
+
+const char* UnpackController::DecodeSevenZipExitCode(int ec)
+{
+	// 7-Zip exit codes according to https://documentation.help/7-Zip/exit_codes.htm
+	switch (ec)
+	{
+	case SevenZipExitCodes::NoError:
+		return "No error";
+
+	case SevenZipExitCodes::Warning:
+		return "Warning (Non fatal error(s)). \
+		For example, one or more files were locked by some other application, \
+		so they were not compressed.";
+
+	case SevenZipExitCodes::FatalError:
+		return "Fatal error";
+
+	case SevenZipExitCodes::CmdLineError:
+		return "Command line error";
+
+	case SevenZipExitCodes::NotEnoughMemoryError:
+		return "Not enough memory for operation";
+
+	case SevenZipExitCodes::CanceledByUser:
+		return "User stopped the process";
+
+	default: "Unknown 7-Zip error";
+	};
+}

--- a/daemon/postprocess/Unpack.cpp
+++ b/daemon/postprocess/Unpack.cpp
@@ -987,6 +987,7 @@ const char* UnpackController::DecodeSevenZipExitCode(int ec)
 	case SevenZipExitCodes::CanceledByUser:
 		return "User stopped the process";
 
-	default: "Unknown 7-Zip error";
+	default: 
+		return "Unknown 7-Zip error";
 	};
 }

--- a/daemon/postprocess/Unpack.h
+++ b/daemon/postprocess/Unpack.h
@@ -33,6 +33,7 @@ public:
 	virtual void Stop();
 	static void StartJob(PostInfo* postInfo);
 	static bool HasCompletedArchiveFiles(NzbInfo* nzbInfo);
+	static const char* DecodeSevenZipExitCode(int ec);
 
 protected:
 	virtual bool ReadLine(char* buf, int bufSize, FILE* stream);
@@ -43,6 +44,16 @@ private:
 	{
 		upUnrar,
 		upSevenZip
+	};
+
+	enum SevenZipExitCodes
+	{
+		NoError = 0,
+		Warning = 1,
+		FatalError = 2,
+		CmdLineError = 7,
+		NotEnoughMemoryError = 8,
+		CanceledByUser = 255,
 	};
 
 	typedef std::vector<CString> FileListBase;

--- a/webui/config.js
+++ b/webui/config.js
@@ -3354,7 +3354,7 @@ var ExtensionManager = (new function($)
 			{
 				hideLoadingBanner();
 				render(getAllExtensions());
-				showErrorBanner("Failed to download extensions", error);
+				showErrorBanner("Failed to fetch the list of available extensions", error);
 			}
 		);
 	}

--- a/webui/index.html
+++ b/webui/index.html
@@ -718,6 +718,12 @@
 														<a href="https://github.com/nzbgetcom/nzbget-extensions/blob/main/extensions.json" target="_blank"> list</a>, 
 														it will be removed without the possibility of reinstalling it.
 													</span>
+													<br>
+													<br>
+													<span class="label label-warning">NOTE:</span>
+													<span class="help-option-title">Extension Manager requires 7zip to unpack downloaded extensions.
+														If you are having issues with Extension Manager downloads - please make sure that SevenZipCmd is valid.
+													</span>
 												</p>
 
 												<br>

--- a/webui/index.html
+++ b/webui/index.html
@@ -721,8 +721,8 @@
 													<br>
 													<br>
 													<span class="label label-warning">NOTE:</span>
-													<span class="help-option-title">Extension Manager requires 7zip to unpack downloaded extensions.
-														If you are having issues with Extension Manager downloads - please make sure that SevenZipCmd is valid.
+													<span class="help-option-title">Extension Manager requires 7-Zip to unpack downloaded extensions.
+														If you are having issues with installing extensions - please make sure that SevenZipCmd is valid.
 													</span>
 												</p>
 

--- a/webui/index.html
+++ b/webui/index.html
@@ -722,7 +722,8 @@
 													<br>
 													<span class="label label-warning">NOTE:</span>
 													<span class="help-option-title">Extension Manager requires 7-Zip to unpack downloaded extensions.
-														If you are having issues with installing extensions - please make sure that SevenZipCmd is valid.
+														If you are having issues with Extension Manager downloads - please check 
+														<a href="#" onclick="Config.scrollToOption(event, this)">SevenZipCmd</a>.
 													</span>
 												</p>
 


### PR DESCRIPTION
-added Zip exit codes decoder according to 7-Zip [doc](https://documentation.help/7-Zip/exit_codes.htm);
-added warning text that SevenZipCmd may not be valid, in case of problems with installing extensions;