### PR TITLE
Fix: new stable/testing release notifications

### DIFF
--- a/nzbget.conf
+++ b/nzbget.conf
@@ -439,10 +439,11 @@ AuthorizedIP=
 # NOTE: For more details visit https://nzbget.com/documentation/certificate-verification/.
 CertCheck=no
 
-# Automatically check for new releases (none, stable).
+# Automatically check for new releases (none, stable, testing).
 #
 #  None    - do not show notifcations;
 #  Stable  - show notifications about new stable releases;
+#  Testing - show notifications about new testing releases;
 UpdateCheck=stable
 
 # User name for daemon-mode, POSIX only.

--- a/webui/config.js
+++ b/webui/config.js
@@ -2980,7 +2980,6 @@ var UpdateDialog = (new function($)
 
 
 		var installedVer = installedVersion;
-		var installedTesting = installedVersion.indexOf('testing') > -1;
 
 		var canInstallStable = UpdateInfo['stable-version'] &&
 			(installedVer < UpdateInfo['stable-version']);
@@ -3009,11 +3008,9 @@ var UpdateDialog = (new function($)
 		Util.show('#UpdateDialog_CheckFailed', hasUpdateSource && !hasUpdateInfo);
 		Util.show('#UpdateDialog_DownloadRow,#UpdateDialog_DownloadAvail', canDownload && !canUpdate);
 		$('#UpdateDialog_AvailRow').toggleClass('hide', !hasUpdateInfo);
-
-		if (!foreground &&
-			(((canInstallStable || canDownloadStable) && notificationAllowed('stable')) ||
-			 (Options.option('UpdateCheck') === 'testing' && installedRev > 0 &&
-			  (canInstallTesting || canDownloadTesting) && notificationAllowed('testing'))))
+		var canUpdateStable = Options.option('UpdateCheck') === 'stable' && (canInstallStable || canDownloadStable) && notificationAllowed('stable');
+		var canUpdateTesting = Options.option('UpdateCheck') === 'testing' && (canInstallTesting || canDownloadTesting) && notificationAllowed('testing');
+		if (canUpdateStable || canUpdateTesting)
 		{
 			$UpdateDialog.modal({backdrop: 'static'});
 		}

--- a/webui/package-info.json
+++ b/webui/package-info.json
@@ -1,4 +1,0 @@
-{
-	"update-info-link": "https://nzbget.com/info/nzbget-version-windows.json",
-	"install-script": "install-update.bat"
-}

--- a/webui/package-info.json
+++ b/webui/package-info.json
@@ -1,0 +1,4 @@
+{
+	"update-info-link": "https://nzbget.com/info/nzbget-version-windows.json",
+	"install-script": "install-update.bat"
+}


### PR DESCRIPTION
## Description

- added automatic checking for new testing releases;
- fixed notifications about the new stable/testing release;
- fixed "Uncaught ReferenceError: installedRev" error;

## Testing

Windows 11, macOS Ventura, Linux Debian 12