### PR TITLE
Be able to skip chown'ing /downloads folder

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -36,7 +36,6 @@ services:
       - TZ=Europe/London
       - NZBGET_USER=nzbget        #optional
       - NZBGET_PASS=tegbzn6789    #optional
-      - NZBGET_CHOWN_DOWNLOADS=0  #optional
     volumes:
       - /path/to/config:/config
       - /path/to/downloads:/downloads #optional
@@ -54,7 +53,6 @@ docker run -d \
   -e TZ=Europe/London \
   -e NZBGET_USER=nzbget `#optional` \
   -e NZBGET_PASS=tegbzn6789 `#optional` \
-  -e NZBGET_CHOWN_DOWNLOADS=0  `optional` \
   -p 6789:6789 \
   -v /path/to/config:/config \
   -v /path/to/downloads:/downloads `#optional` \
@@ -66,14 +64,13 @@ docker run -d \
 
 NZBGet container can be configured by passing environment variables to it. This can be done in docker-compose mode by specifying `environment:` and in cli mode by using -e switch.
 
-| Parameter	             | Description
-|:-----------------------|-
-| PUID                   | UserID (see below)
-| PGID                   | GroupID (see below)
-| TZ                     | Timezone
-| NZBGET_USER            | User name for web auth
-| NZBGET_PASS            | Password for web auth
-| NZBGET_CHOWN_DOWNLOADS | On start-up, the container will `chown` the files in the `/downloads` folder. To skip this, set `NZB_CHMOD_DOWNLOADS` to `0` (Default value is `1`)
+| Parameter	   | Description
+|:-------------|-
+| PUID         | UserID (see below)
+| PGID         | GroupID (see below)
+| TZ           | Timezone
+| NZBGET_USER  | User name for web auth
+| NZBGET_PASS  | Password for web auth
 
 # User / Group Identifiers
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,8 +34,8 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/London
-      - NZBGET_USER=nzbget        #optional
-      - NZBGET_PASS=tegbzn6789    #optional
+      - NZBGET_USER=nzbget     #optional
+      - NZBGET_PASS=tegbzn6789 #optional
     volumes:
       - /path/to/config:/config
       - /path/to/downloads:/downloads #optional
@@ -64,13 +64,13 @@ docker run -d \
 
 NZBGet container can be configured by passing environment variables to it. This can be done in docker-compose mode by specifying `environment:` and in cli mode by using -e switch.
 
-| Parameter	   | Description
-|:-------------|-
-| PUID         | UserID (see below)
-| PGID         | GroupID (see below)
-| TZ           | Timezone
-| NZBGET_USER  | User name for web auth
-| NZBGET_PASS  | Password for web auth
+| Parameter	  | Description
+|:------------|-
+| PUID        | UserID (see below)
+| PGID        | GroupID (see below)
+| TZ          | Timezone
+| NZBGET_USER | User name for web auth
+| NZBGET_PASS | Password for web auth
 
 # User / Group Identifiers
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -36,7 +36,7 @@ services:
       - TZ=Europe/London
       - NZBGET_USER=nzbget        #optional
       - NZBGET_PASS=tegbzn6789    #optional
-      - NZBGET_CHMOD_DOWNLOADS=0  #optional
+      - NZBGET_CHOWN_DOWNLOADS=0  #optional
     volumes:
       - /path/to/config:/config
       - /path/to/downloads:/downloads #optional
@@ -54,7 +54,7 @@ docker run -d \
   -e TZ=Europe/London \
   -e NZBGET_USER=nzbget `#optional` \
   -e NZBGET_PASS=tegbzn6789 `#optional` \
-  -e NZBGET_CHMOD_DOWNLOADS=0  `optional` \
+  -e NZBGET_CHOWN_DOWNLOADS=0  `optional` \
   -p 6789:6789 \
   -v /path/to/config:/config \
   -v /path/to/downloads:/downloads `#optional` \
@@ -73,7 +73,7 @@ NZBGet container can be configured by passing environment variables to it. This 
 | TZ                     | Timezone
 | NZBGET_USER            | User name for web auth
 | NZBGET_PASS            | Password for web auth
-| NZBGET_CHMOD_DOWNLOADS | On start-up, the container will `chown` the files in the `/downloads` folder. To skip this, set `NZB_CHMOD_DOWNLOADS` to `0` (Default value is `1`)
+| NZBGET_CHOWN_DOWNLOADS | On start-up, the container will `chown` the files in the `/downloads` folder. To skip this, set `NZB_CHMOD_DOWNLOADS` to `0` (Default value is `1`)
 
 # User / Group Identifiers
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,8 +34,9 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/London
-      - NZBGET_USER=nzbget     #optional
-      - NZBGET_PASS=tegbzn6789 #optional
+      - NZBGET_USER=nzbget        #optional
+      - NZBGET_PASS=tegbzn6789    #optional
+      - NZBGET_CHMOD_DOWNLOADS=0  #optional
     volumes:
       - /path/to/config:/config
       - /path/to/downloads:/downloads #optional
@@ -53,6 +54,7 @@ docker run -d \
   -e TZ=Europe/London \
   -e NZBGET_USER=nzbget `#optional` \
   -e NZBGET_PASS=tegbzn6789 `#optional` \
+  -e NZBGET_CHMOD_DOWNLOADS=0  `optional` \
   -p 6789:6789 \
   -v /path/to/config:/config \
   -v /path/to/downloads:/downloads `#optional` \
@@ -64,13 +66,14 @@ docker run -d \
 
 NZBGet container can be configured by passing environment variables to it. This can be done in docker-compose mode by specifying `environment:` and in cli mode by using -e switch.
 
-| Parameter	  | Description
-|:------------|-
-| PUID        | UserID (see below)
-| PGID        | GroupID (see below)
-| TZ          | Timezone
-| NZBGET_USER | User name for web auth
-| NZBGET_PASS | Password for web auth
+| Parameter	             | Description
+|:-----------------------|-
+| PUID                   | UserID (see below)
+| PGID                   | GroupID (see below)
+| TZ                     | Timezone
+| NZBGET_USER            | User name for web auth
+| NZBGET_PASS            | Password for web auth
+| NZBGET_CHMOD_DOWNLOADS | On start-up, the container will `chown` the files in the `/downloads` folder. To skip this, set `NZB_CHMOD_DOWNLOADS` to `0` (Default value is `1`)
 
 # User / Group Identifiers
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # default values
-: "${NZBGET_CHMOD_DOWNLOADS:=1}"
+: "${NZBGET_CHOWN_DOWNLOADS:=1}"
 
 # create downloads if not exist
 if [ ! -d /downloads ]; then
@@ -38,7 +38,7 @@ groupmod -o -g "$PGID" users
 usermod -o -u "$PUID" user
 
 chown -R user:users /config
-if [[ "${NZBGET_CHMOD_DOWNLOADS}" == "1" ]]; then
+if [[ "${NZBGET_CHOWN_DOWNLOADS}" == "1" ]]; then
   chown -R user:users /downloads
 fi
 su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env sh
 set -e
 
-# default values
-: "${NZBGET_CHOWN_DOWNLOADS:=1}"
-
 # create downloads if not exist
 if [ ! -d /downloads ]; then
     mkdir -p /downloads
@@ -38,7 +35,5 @@ groupmod -o -g "$PGID" users
 usermod -o -u "$PUID" user
 
 chown -R user:users /config
-if [[ "${NZBGET_CHOWN_DOWNLOADS}" == "1" ]]; then
-  chown -R user:users /downloads
-fi
+find /downloads -maxdepth 0 \( ! -group users -o ! -user user \) -exec chown user:users {} + || printf "*** Could not set permissions on /downloads ; this container may not work as expected ***"
 su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 set -e
 
+# default values
+: "${NZBGET_CHMOD_DOWNLOADS:=1}"
+
 # create downloads if not exist
 if [ ! -d /downloads ]; then
     mkdir -p /downloads
@@ -35,5 +38,7 @@ groupmod -o -g "$PGID" users
 usermod -o -u "$PUID" user
 
 chown -R user:users /config
-chown -R user:users /downloads
+if [[ "${NZBGET_CHMOD_DOWNLOADS}" == "1" ]]; then
+  chown -R user:users /downloads
+fi
 su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"


### PR DESCRIPTION
I'd like to be able to skip `chown`'ing the `/downloads` folder in the Docker container. As my downloads folder is actually on my NAS and the `/downloads` folder is exposed through NFS with limited permissions, chown'ing is not allowed. But I also know that it's not necessary, as I've set `$PUID` and `$GUID` to the correct values.
