### PR TITLE
Docker: fix startup chown

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -34,6 +34,14 @@ PGID=${PGID:-1000}
 groupmod -o -g "$PGID" users
 usermod -o -u "$PUID" user
 
-chown -R user:users /config
-chown -R user:users /downloads
+chown -R user:users /config || CONFIG_CHOWN_STATUS=$?
+if [ ! -z $CONFIG_CHOWN_STATUS ]; then
+  echo "*** Could not set permissions on /config ; this container may not work as expected ***"
+fi
+
+chown -R user:users /downloads || DOWNLOADS_CHOWN_STATUS=$?
+if [ ! -z $DOWNLOADS_CHOWN_STATUS ]; then
+  echo "*** Could not set permissions on /downloads ; this container may not work as expected ***"
+fi
+
 su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"


### PR DESCRIPTION
## Description

- added chown checks at startup, now the container does not fails, but issues warnings
- inspired by @bartlaarhoven (#185)

## Testing

by @phnzb Ubuntu 22.04.3 LTS x86_64 Docker 24.0.7