### PR TITLE
Fix: compiler and cppcheck warnings

### DIFF
--- a/daemon/extension/Extension.cpp
+++ b/daemon/extension/Extension.cpp
@@ -416,21 +416,18 @@ namespace Extension
 		return result;
 	}
 
-	namespace
+	void AddNewNode(xmlNodePtr rootNode, const char* name, const char* type, const char* value)
 	{
-		void AddNewNode(xmlNodePtr rootNode, const char* name, const char* type, const char* value)
-		{
-			xmlNodePtr memberNode = xmlNewNode(NULL, BAD_CAST "member");
-			xmlNodePtr valueNode = xmlNewNode(NULL, BAD_CAST "value");
-			xmlNewChild(memberNode, NULL, BAD_CAST "name", BAD_CAST name);
-			xmlNewChild(valueNode, NULL, BAD_CAST type, BAD_CAST value);
-			xmlAddChild(memberNode, valueNode);
-			xmlAddChild(rootNode, memberNode);
-		}
+		xmlNodePtr memberNode = xmlNewNode(NULL, BAD_CAST "member");
+		xmlNodePtr valueNode = xmlNewNode(NULL, BAD_CAST "value");
+		xmlNewChild(memberNode, NULL, BAD_CAST "name", BAD_CAST name);
+		xmlNewChild(valueNode, NULL, BAD_CAST type, BAD_CAST value);
+		xmlAddChild(memberNode, valueNode);
+		xmlAddChild(rootNode, memberNode);
+	}
 
-		const char* BoolToStr(bool value)
-		{
-			return value ? "true" : "false";
-		}
+	const char* BoolToStr(bool value)
+	{
+		return value ? "true" : "false";
 	}
 }

--- a/daemon/extension/Extension.h
+++ b/daemon/extension/Extension.h
@@ -107,11 +107,8 @@ namespace Extension
 	std::string ToJsonStr(const Script& script);
 	std::string ToXmlStr(const Script& script);
 
-	namespace
-	{
-		void AddNewNode(xmlNodePtr rootNode, const char* name, const char* type, const char* value);
-		const char* BoolToStr(bool value);
-	}
+	static void AddNewNode(xmlNodePtr rootNode, const char* name, const char* type, const char* value);
+	static const char* BoolToStr(bool value);
 }
 
 #endif

--- a/daemon/extension/ExtensionLoader.cpp
+++ b/daemon/extension/ExtensionLoader.cpp
@@ -347,7 +347,7 @@ namespace ExtensionLoader
 
 			for (size_t i = 0; i < str.size(); ++i)
 			{
-				if (i == str.size() - 1)
+				if (i == (str.size() - 1))
 				{
 					word += str[i];
 					elements.push_back(std::move(word));

--- a/daemon/extension/ExtensionLoader.cpp
+++ b/daemon/extension/ExtensionLoader.cpp
@@ -181,243 +181,241 @@ namespace ExtensionLoader
 
 			return true;
 		}
-		namespace
+
+		void RemoveTailAndTrim(std::string& str, const char* tail)
 		{
-			void RemoveTailAndTrim(std::string& str, const char* tail)
+			size_t tailIdx = str.find(tail);
+			if (tailIdx != std::string::npos)
 			{
-				size_t tailIdx = str.find(tail);
-				if (tailIdx != std::string::npos)
+				str.erase(tailIdx);
+			}
+			Util::TrimRight(str);
+		}
+
+		void BuildDisplayName(Extension::Script& script)
+		{
+			BString<1024> shortName = script.GetName();
+			if (char* ext = strrchr(shortName, '.')) *ext = '\0'; // strip file extension
+
+			const char* displayName = FileSystem::BaseFileName(shortName);
+
+			script.SetDisplayName(displayName);
+		}
+
+		void ParseOptionsAndCommands(
+			std::ifstream& file,
+			std::vector<ManifestFile::Option>& options,
+			std::vector<ManifestFile::Command>& commands)
+		{
+			std::vector<ManifestFile::SelectOption> selectOpts;
+			std::vector<std::string> description;
+
+			std::string line;
+			while (std::getline(file, line))
+			{
+				if (strstr(line.c_str(), END_SCRIPT_SIGNATURE))
 				{
-					str.erase(tailIdx);
+					break;
 				}
-				Util::TrimRight(str);
-			}
 
-			void BuildDisplayName(Extension::Script& script)
-			{
-				BString<1024> shortName = script.GetName();
-				if (char* ext = strrchr(shortName, '.')) *ext = '\0'; // strip file extension
-
-				const char* displayName = FileSystem::BaseFileName(shortName);
-
-				script.SetDisplayName(displayName);
-			}
-
-			void ParseOptionsAndCommands(
-				std::ifstream& file,
-				std::vector<ManifestFile::Option>& options,
-				std::vector<ManifestFile::Command>& commands)
-			{
-				std::vector<ManifestFile::SelectOption> selectOpts;
-				std::vector<std::string> description;
-
-				std::string line;
-				while (std::getline(file, line))
+				if (line.empty())
 				{
-					if (strstr(line.c_str(), END_SCRIPT_SIGNATURE))
-					{
-						break;
-					}
+					continue;
+				}
 
-					if (line.empty())
-					{
-						continue;
-					}
+				size_t selectStartIdx = line.rfind("(");
+				size_t selectEndIdx = line.rfind(")");
+				bool hasSelectOptions = description.empty()
+					&& !strncmp(line.c_str(), "# ", 2)
+					&& selectStartIdx != std::string::npos
+					&& selectEndIdx != std::string::npos
+					&& selectEndIdx == line.length() - 2;
 
-					size_t selectStartIdx = line.rfind("(");
-					size_t selectEndIdx = line.rfind(")");
-					bool hasSelectOptions = description.empty()
-						&& !strncmp(line.c_str(), "# ", 2)
-						&& selectStartIdx != std::string::npos
-						&& selectEndIdx != std::string::npos
-						&& selectEndIdx == line.length() - 2;
+				// e.g. # Description (Always, OnFailure) or # Description (1-65535) or # Description (1, 2-5, 10).
+				if (hasSelectOptions)
+				{
+					std::string selectOptionsStr = line.substr(selectStartIdx + 1, selectEndIdx - selectStartIdx - 1);
+					auto result = ExtractElements(selectOptionsStr);
+					auto& selectOptions = result.first;
+					auto& delimiter = result.second;
+					bool canBeNum = delimiter == "-";
 
-					// e.g. # Description (Always, OnFailure) or # Description (1-65535) or # Description (1, 2-5, 10).
-					if (hasSelectOptions)
-					{
-						std::string selectOptionsStr = line.substr(selectStartIdx + 1, selectEndIdx - selectStartIdx - 1);
-						auto result = ExtractElements(selectOptionsStr);
-						auto& selectOptions = result.first;
-						auto& delimiter = result.second;
-						bool canBeNum = delimiter == "-";
-						
-						if (delimiter.empty()) // doesn't have
-						{
-							description.push_back(line.substr(2));
-							continue;
-						}
-
-						if (canBeNum)
-						{
-							description.push_back(line.substr(2));
-						}
-						else
-						{
-							description.push_back(line.substr(2, selectStartIdx - 3) + ".");
-						}
-
-						selectOpts = GetSelectOptions(selectOptions, canBeNum);
-						continue;
-					}
-
-					if (!strncmp(line.c_str(), "# ", 2))
+					if (delimiter.empty()) // doesn't have
 					{
 						description.push_back(line.substr(2));
 						continue;
 					}
 
-					if (strncmp(line.c_str(), "# ", 2))
+					if (canBeNum)
 					{
-						// if option, e.g. #ConnectionTest=Send
-						size_t eqPos = line.find("=");
-						// if command, e.g. #ConnectionTest@Send Test E-Mail
-						size_t atPos = line.find("@");
+						description.push_back(line.substr(2));
+					}
+					else
+					{
+						description.push_back(line.substr(2, selectStartIdx - 3) + ".");
+					}
 
-						if (atPos != std::string::npos && eqPos == std::string::npos)
-						{
-							ManifestFile::Command command;
-							std::string name = line.substr(1, atPos - 1);
-							std::string action = line.substr(atPos + 1);
-							Util::Trim(action);
-							Util::Trim(name);
-							command.action = std::move(action);
-							command.name = std::move(name);
-							command.description = std::move(description);
-							command.displayName = command.name;
-							commands.push_back(std::move(command));
-							description.clear();
-							selectOpts.clear();
-							continue;
-						}
+					selectOpts = GetSelectOptions(selectOptions, canBeNum);
+					continue;
+				}
 
-						if (eqPos != std::string::npos)
-						{
-							ManifestFile::Option option;
-							std::string name = line.substr(1, eqPos - 1);
-							std::string value = line.substr(eqPos + 1);
-							Util::Trim(value);
-							Util::Trim(name);
-							bool canBeNum = !selectOpts.empty() && boost::variant2::get_if<double>(&selectOpts[0]);
-							option.value = std::move(GetSelectOpt(value, canBeNum));
-							option.name = std::move(name);
-							option.description = std::move(description);
-							option.select = std::move(selectOpts);
-							option.displayName = option.name;
-							options.push_back(std::move(option));
-							description.clear();
-							selectOpts.clear();
-							continue;
-						}
+				if (!strncmp(line.c_str(), "# ", 2))
+				{
+					description.push_back(line.substr(2));
+					continue;
+				}
+
+				if (strncmp(line.c_str(), "# ", 2))
+				{
+					// if option, e.g. #ConnectionTest=Send
+					size_t eqPos = line.find("=");
+					// if command, e.g. #ConnectionTest@Send Test E-Mail
+					size_t atPos = line.find("@");
+
+					if (atPos != std::string::npos && eqPos == std::string::npos)
+					{
+						ManifestFile::Command command;
+						std::string name = line.substr(1, atPos - 1);
+						std::string action = line.substr(atPos + 1);
+						Util::Trim(action);
+						Util::Trim(name);
+						command.action = std::move(action);
+						command.name = std::move(name);
+						command.description = std::move(description);
+						command.displayName = command.name;
+						commands.push_back(std::move(command));
+						description.clear();
+						selectOpts.clear();
+						continue;
+					}
+
+					if (eqPos != std::string::npos)
+					{
+						ManifestFile::Option option;
+						std::string name = line.substr(1, eqPos - 1);
+						std::string value = line.substr(eqPos + 1);
+						Util::Trim(value);
+						Util::Trim(name);
+						bool canBeNum = !selectOpts.empty() && boost::variant2::get_if<double>(&selectOpts[0]);
+						option.value = std::move(GetSelectOpt(value, canBeNum));
+						option.name = std::move(name);
+						option.description = std::move(description);
+						option.select = std::move(selectOpts);
+						option.displayName = option.name;
+						options.push_back(std::move(option));
+						description.clear();
+						selectOpts.clear();
+						continue;
 					}
 				}
 			}
+		}
 
-			std::vector<ManifestFile::SelectOption> 
-			GetSelectOptions(const std::vector<std::string>& opts, bool canBeNum)
+		std::vector<ManifestFile::SelectOption>
+		GetSelectOptions(const std::vector<std::string>& opts, bool canBeNum)
+		{
+			std::vector<ManifestFile::SelectOption> selectOpts;
+
+			for (const auto& option : opts)
 			{
-				std::vector<ManifestFile::SelectOption> selectOpts;
-
-				for (const auto& option : opts)
-				{
-					selectOpts.push_back(GetSelectOpt(option, canBeNum));
-				}
-				return selectOpts;
+				selectOpts.push_back(GetSelectOpt(option, canBeNum));
 			}
+			return selectOpts;
+		}
 
-			ManifestFile::SelectOption GetSelectOpt(const std::string& val, bool canBeNum)
+		ManifestFile::SelectOption GetSelectOpt(const std::string& val, bool canBeNum)
+		{
+			if (!canBeNum)
 			{
-				if (!canBeNum)
-				{
-					return ManifestFile::SelectOption(val);
-				}
-
-				auto result = Util::StrToNum(val);
-				if (result.has_value())
-				{
-					return ManifestFile::SelectOption(result.get());
-				}
-
 				return ManifestFile::SelectOption(val);
 			}
 
-			std::pair<std::vector<std::string>, std::string>
-			ExtractElements(const std::string& str)
+			auto result = Util::StrToNum(val);
+			if (result.has_value())
 			{
-				std::vector<std::string> elements;
-				std::string word;
-	
-				for (size_t i = 0; i < str.size(); ++i)
+				return ManifestFile::SelectOption(result.get());
+			}
+
+			return ManifestFile::SelectOption(val);
+		}
+
+		std::pair<std::vector<std::string>, std::string>
+		ExtractElements(const std::string& str)
+		{
+			std::vector<std::string> elements;
+			std::string word;
+
+			for (size_t i = 0; i < str.size(); ++i)
+			{
+				if (i == str.size() - 1)
 				{
-					if (i == str.size() - 1)
-				    {
-				        word += str[i];
-				        elements.push_back(std::move(word));
-				        break;
-				    }
-
-					if (str[i] == ',')
-					{
-						elements.push_back(std::move(word));
-						word.clear();
-						continue;
-					}
-
-					if (str[i] == ' ' && word.empty())
-					{
-						continue;
-					}
-
-					if (str[i] == ' ' && !word.empty())
-					{
-						elements.clear();
-						elements.push_back(str);
-						return std::make_pair(std::move(elements), "");
-					}
-
-					if (str[i] == '-' && elements.empty())
-					{
-						std::string restWord;
-						for (size_t j = i + 1; j < str.size(); ++j)
-						{
-							if (j >= str.size() - 1)
-							{
-								restWord += str[j];
-								elements.push_back(std::move(word));
-								elements.push_back(std::move(restWord));
-								return std::make_pair(std::move(elements), "-");
-							}
-
-							if (str[j] == ' ')
-							{
-								elements.push_back(str);
-								return std::make_pair(std::move(elements), "");
-							}
-
-							if (str[j] == ',')
-							{
-								word += '-' + restWord;
-								elements.push_back(std::move(word));
-								word.clear();
-								i = j;
-								break;
-							}
-
-							restWord += str[j];
-						}
-
-						continue;
-					}
-
 					word += str[i];
+					elements.push_back(std::move(word));
+					break;
 				}
 
-				if (elements.size() == 1)
+				if (str[i] == ',')
 				{
+					elements.push_back(std::move(word));
+					word.clear();
+					continue;
+				}
+
+				if (str[i] == ' ' && word.empty())
+				{
+					continue;
+				}
+
+				if (str[i] == ' ' && !word.empty())
+				{
+					elements.clear();
+					elements.push_back(str);
 					return std::make_pair(std::move(elements), "");
 				}
 
-				return std::make_pair(std::move(elements), ",");
+				if (str[i] == '-' && elements.empty())
+				{
+					std::string restWord;
+					for (size_t j = i + 1; j < str.size(); ++j)
+					{
+						if (j >= str.size() - 1)
+						{
+							restWord += str[j];
+							elements.push_back(std::move(word));
+							elements.push_back(std::move(restWord));
+							return std::make_pair(std::move(elements), "-");
+						}
+
+						if (str[j] == ' ')
+						{
+							elements.push_back(str);
+							return std::make_pair(std::move(elements), "");
+						}
+
+						if (str[j] == ',')
+						{
+							word += '-' + restWord;
+							elements.push_back(std::move(word));
+							word.clear();
+							i = j;
+							break;
+						}
+
+						restWord += str[j];
+					}
+
+					continue;
+				}
+
+				word += str[i];
 			}
+
+			if (elements.size() == 1)
+			{
+				return std::make_pair(std::move(elements), "");
+			}
+
+			return std::make_pair(std::move(elements), ",");
 		}
 	}
 
@@ -448,17 +446,14 @@ namespace ExtensionLoader
 		return true;
 	}
 
-	namespace
+	Extension::Kind GetScriptKind(const std::string& line)
 	{
-		Extension::Kind GetScriptKind(const std::string& line)
-		{
-			Extension::Kind kind;
-			kind.post = strstr(line.c_str(), POST_SCRIPT_SIGNATURE) != nullptr;
-			kind.scan = strstr(line.c_str(), SCAN_SCRIPT_SIGNATURE) != nullptr;
-			kind.queue = strstr(line.c_str(), QUEUE_SCRIPT_SIGNATURE) != nullptr;
-			kind.scheduler = strstr(line.c_str(), SCHEDULER_SCRIPT_SIGNATURE) != nullptr;
-			kind.feed = strstr(line.c_str(), FEED_SCRIPT_SIGNATURE) != nullptr;
-			return kind;
-		}
+		Extension::Kind kind;
+		kind.post = strstr(line.c_str(), POST_SCRIPT_SIGNATURE) != nullptr;
+		kind.scan = strstr(line.c_str(), SCAN_SCRIPT_SIGNATURE) != nullptr;
+		kind.queue = strstr(line.c_str(), QUEUE_SCRIPT_SIGNATURE) != nullptr;
+		kind.scheduler = strstr(line.c_str(), SCHEDULER_SCRIPT_SIGNATURE) != nullptr;
+		kind.feed = strstr(line.c_str(), FEED_SCRIPT_SIGNATURE) != nullptr;
+		return kind;
 	}
 }

--- a/daemon/extension/ExtensionLoader.h
+++ b/daemon/extension/ExtensionLoader.h
@@ -47,21 +47,19 @@ namespace ExtensionLoader
 	namespace V1
 	{
 		bool Load(Extension::Script& script, const char* location, const char* rootDir);
-		namespace
-		{
-			void ParseOptionsAndCommands(
-				std::ifstream& file,
-				std::vector<ManifestFile::Option>& options,
-				std::vector<ManifestFile::Command>& commands
-			);
-			std::vector<ManifestFile::SelectOption> 
-			GetSelectOptions(const std::vector<std::string>& opts, bool isDashDelim);
-			ManifestFile::SelectOption GetSelectOpt(const std::string& val, bool canBeNum);
-			void RemoveTailAndTrim(std::string& str, const char* tail);
-			void BuildDisplayName(Extension::Script& script);
-			std::pair<std::vector<std::string>, std::string> 
-			ExtractElements(const std::string& str);
-		}
+
+		static void ParseOptionsAndCommands(
+			std::ifstream& file,
+			std::vector<ManifestFile::Option>& options,
+			std::vector<ManifestFile::Command>& commands
+		);
+		static std::vector<ManifestFile::SelectOption>
+		GetSelectOptions(const std::vector<std::string>& opts, bool isDashDelim);
+		static ManifestFile::SelectOption GetSelectOpt(const std::string& val, bool canBeNum);
+		static void RemoveTailAndTrim(std::string& str, const char* tail);
+		static void BuildDisplayName(Extension::Script& script);
+		static std::pair<std::vector<std::string>, std::string>
+		ExtractElements(const std::string& str);
 	}
 
 	namespace V2
@@ -69,10 +67,7 @@ namespace ExtensionLoader
 		bool Load(Extension::Script& script, const char* location, const char* rootDir);
 	}
 
-	namespace
-	{
-		Extension::Kind GetScriptKind(const std::string& line);
-	}
+	static Extension::Kind GetScriptKind(const std::string& line);
 }
 
 #endif

--- a/daemon/extension/ExtensionManager.cpp
+++ b/daemon/extension/ExtensionManager.cpp
@@ -29,7 +29,7 @@
 
 namespace ExtensionManager
 {
-	const Extensions& Manager::GetExtensions() const
+	const Extensions& Manager::GetExtensions() const &
 	{
 		std::shared_lock<std::shared_timed_mutex> lock{m_mutex};
 		return m_extensions;

--- a/daemon/extension/ExtensionManager.cpp
+++ b/daemon/extension/ExtensionManager.cpp
@@ -38,20 +38,21 @@ namespace ExtensionManager
 	std::pair<WebDownloader::EStatus, std::string>
 	Manager::DownloadExtension(const std::string& url, const std::string& extName)
 	{
-		BString<1024> tmpFileName;
-		tmpFileName.Format("%s%cextension-%s.tmp.zip", g_Options->GetTempDir(), PATH_SEPARATOR, extName.c_str());
+		std::string tmpFileName = std::string(g_Options->GetTempDir()) 
+			+ PATH_SEPARATOR 
+			+ "extension-" + extName + ".tmp.zip";
 
 		std::unique_ptr<WebDownloader> downloader = std::make_unique<WebDownloader>();
 		downloader->SetUrl(url.c_str());
 		downloader->SetForce(true);
 		downloader->SetRetry(false);
-		downloader->SetOutputFilename(tmpFileName);
+		downloader->SetOutputFilename(tmpFileName.c_str());
 		downloader->SetInfoName(extName.c_str());
 
 		WebDownloader::EStatus status = downloader->DownloadWithRedirects(5);
 		downloader.reset();
 
-		return std::make_pair(status, tmpFileName.Str());
+		return std::make_pair(status, std::move(tmpFileName));
 	}
 
 	boost::optional<std::string>

--- a/daemon/extension/ExtensionManager.h
+++ b/daemon/extension/ExtensionManager.h
@@ -60,7 +60,7 @@ namespace ExtensionManager
 		std::pair<WebDownloader::EStatus, std::string>
 		DownloadExtension(const std::string& url, const std::string& info);
 		
-		const Extensions& GetExtensions() const;
+		const Extensions& GetExtensions() const &;
 
 	private:
 		void LoadExtensionDir(const char* directory, bool isSubDir, const char* rootDir);

--- a/daemon/extension/ManifestFile.cpp
+++ b/daemon/extension/ManifestFile.cpp
@@ -48,185 +48,182 @@ namespace ManifestFile
 		return true;
 	}
 
-	namespace
+	bool ValidateAndSet(const Json::JsonObject& json, Manifest& manifest)
 	{
-		bool ValidateAndSet(const Json::JsonObject& json, Manifest& manifest)
+		if (!CheckKeyAndSet(json, "author", manifest.author))
+			return false;
+
+		if (!CheckKeyAndSet(json, "main", manifest.main))
+			return false;
+
+		if (!CheckKeyAndSet(json, "homepage", manifest.homepage))
+			return false;
+
+		if (!CheckKeyAndSet(json, "about", manifest.about))
+			return false;
+
+		if (!CheckKeyAndSet(json, "version", manifest.version))
+			return false;
+
+		if (!CheckKeyAndSet(json, "name", manifest.name))
+			return false;
+
+		if (!CheckKeyAndSet(json, "displayName", manifest.displayName))
+			return false;
+
+		if (!CheckKeyAndSet(json, "kind", manifest.kind))
+			return false;
+
+		if (!CheckKeyAndSet(json, "license", manifest.license))
+			return false;
+
+		if (!CheckKeyAndSet(json, "taskTime", manifest.taskTime))
+			return false;
+
+		if (!CheckKeyAndSet(json, "queueEvents", manifest.queueEvents))
+			return false;
+
+		if (!ValidateOptionsAndSet(json, manifest.options))
+			return false;
+
+		if (!ValidateCommandsAndSet(json, manifest.commands))
+			return false;
+
+		if (!ValidateTxtAndSet(json, manifest.description, "description"))
+			return false;
+
+		if (!ValidateTxtAndSet(json, manifest.requirements, "requirements"))
+			return false;
+
+		return true;
+	}
+
+	bool ValidateCommandsAndSet(const Json::JsonObject& json, std::vector<Command>& commands)
+	{
+		auto rawCommands = json.if_contains("commands");
+		if (!rawCommands || !rawCommands->is_array())
+			return false;
+
+		for (auto& value : rawCommands->as_array())
 		{
-			if (!CheckKeyAndSet(json, "author", manifest.author))
-				return false;
+			Json::JsonObject cmdJson = value.as_object();
+			Command command;
 
-			if (!CheckKeyAndSet(json, "main", manifest.main))
-				return false;
+			if (!CheckKeyAndSet(cmdJson, "name", command.name))
+				continue;
 
-			if (!CheckKeyAndSet(json, "homepage", manifest.homepage))
-				return false;
+			if (!CheckKeyAndSet(cmdJson, "displayName", command.displayName))
+				continue;
 
-			if (!CheckKeyAndSet(json, "about", manifest.about))
-				return false;
+			if (!ValidateTxtAndSet(cmdJson, command.description, "description"))
+				continue;
 
-			if (!CheckKeyAndSet(json, "version", manifest.version))
-				return false;
+			if (!CheckKeyAndSet(cmdJson, "action", command.action))
+				continue;
 
-			if (!CheckKeyAndSet(json, "name", manifest.name))
-				return false;
-
-			if (!CheckKeyAndSet(json, "displayName", manifest.displayName))
-				return false;
-
-			if (!CheckKeyAndSet(json, "kind", manifest.kind))
-				return false;
-
-			if (!CheckKeyAndSet(json, "license", manifest.license))
-				return false;
-
-			if (!CheckKeyAndSet(json, "taskTime", manifest.taskTime))
-				return false;
-
-			if (!CheckKeyAndSet(json, "queueEvents", manifest.queueEvents))
-				return false;
-
-			if (!ValidateOptionsAndSet(json, manifest.options))
-				return false;
-
-			if (!ValidateCommandsAndSet(json, manifest.commands))
-				return false;
-
-			if (!ValidateTxtAndSet(json, manifest.description, "description"))
-				return false;
-
-			if (!ValidateTxtAndSet(json, manifest.requirements, "requirements"))
-				return false;
-
-			return true;
+			commands.emplace_back(std::move(command));
 		}
 
-		bool ValidateCommandsAndSet(const Json::JsonObject& json, std::vector<Command>& commands)
+		commands.shrink_to_fit();
+
+		return true;
+	}
+
+	bool ValidateOptionsAndSet(const Json::JsonObject& json, std::vector<Option>& options)
+	{
+		auto rawOptions = json.if_contains("options");
+		if (!rawOptions || !rawOptions->is_array())
+			return false;
+
+		for (auto& optionVal : rawOptions->as_array())
 		{
-			auto rawCommands = json.if_contains("commands");
-			if (!rawCommands || !rawCommands->is_array())
-				return false;
+			Json::JsonObject optionJson = optionVal.as_object();
+			auto selectJson = optionJson.if_contains("select");
+			if (!selectJson || !selectJson->is_array())
+				continue;
 
-			for (auto& value : rawCommands->as_array())
+			Option option;
+			if (!CheckKeyAndSet(optionJson, "name", option.name))
+				continue;
+
+			if (!CheckKeyAndSet(optionJson, "displayName", option.displayName))
+				continue;
+
+			if (!CheckKeyAndSet(optionJson, "value", option.value))
+				continue;
+
+			if (!ValidateTxtAndSet(optionJson, option.description, "description"))
+				continue;
+
+			for (auto& selectVal : selectJson->as_array())
 			{
-				Json::JsonObject cmdJson = value.as_object();
-				Command command;
-
-				if (!CheckKeyAndSet(cmdJson, "name", command.name))
-					continue;
-
-				if (!CheckKeyAndSet(cmdJson, "displayName", command.displayName))
-					continue;
-
-				if (!ValidateTxtAndSet(cmdJson, command.description, "description"))
-					continue;
-
-				if (!CheckKeyAndSet(cmdJson, "action", command.action))
-					continue;
-
-				commands.emplace_back(std::move(command));
-			}
-
-			commands.shrink_to_fit();
-
-			return true;
-		}
-
-		bool ValidateOptionsAndSet(const Json::JsonObject& json, std::vector<Option>& options)
-		{
-			auto rawOptions = json.if_contains("options");
-			if (!rawOptions || !rawOptions->is_array())
-				return false;
-
-			for (auto& optionVal : rawOptions->as_array())
-			{
-				Json::JsonObject optionJson = optionVal.as_object();
-				auto selectJson = optionJson.if_contains("select");
-				if (!selectJson || !selectJson->is_array())
-					continue;
-
-				Option option;
-				if (!CheckKeyAndSet(optionJson, "name", option.name))
-					continue;
-
-				if (!CheckKeyAndSet(optionJson, "displayName", option.displayName))
-					continue;
-
-				if (!CheckKeyAndSet(optionJson, "value", option.value))
-					continue;
-
-				if (!ValidateTxtAndSet(optionJson, option.description, "description"))
-					continue;
-
-				for (auto& selectVal : selectJson->as_array())
+				if (selectVal.is_string())
 				{
-					if (selectVal.is_string())
-					{
-						option.select.emplace_back(selectVal.get_string().c_str());
-						continue;
-					}
-					if (selectVal.is_number())
-					{
-						option.select.emplace_back(selectVal.to_number<double>());
-						continue;
-					}
+					option.select.emplace_back(selectVal.get_string().c_str());
+					continue;
 				}
-
-				options.emplace_back(std::move(option));
-			}
-
-			options.shrink_to_fit();
-
-			return true;
-		}
-
-		bool ValidateTxtAndSet(const Json::JsonObject& json, std::vector<std::string>& property, const char* propName)
-		{
-			auto rawProp = json.if_contains(propName);
-			if (!rawProp || !rawProp->is_array())
-				return false;
-
-			for (auto& value : rawProp->as_array())
-			{
-				if (value.is_string())
+				if (selectVal.is_number())
 				{
-					property.emplace_back(value.get_string().c_str());
+					option.select.emplace_back(selectVal.to_number<double>());
+					continue;
 				}
 			}
 
-			property.shrink_to_fit();
-
-			return true;
+			options.emplace_back(std::move(option));
 		}
 
-		bool CheckKeyAndSet(const Json::JsonObject& json, const char* key, std::string& property)
-		{
-			const auto& rawProperty = json.if_contains(key);
-			if (!rawProperty || !rawProperty->is_string())
-				return false;
+		options.shrink_to_fit();
 
+		return true;
+	}
+
+	bool ValidateTxtAndSet(const Json::JsonObject& json, std::vector<std::string>& property, const char* propName)
+	{
+		auto rawProp = json.if_contains(propName);
+		if (!rawProp || !rawProp->is_array())
+			return false;
+
+		for (auto& value : rawProp->as_array())
+		{
+			if (value.is_string())
+			{
+				property.emplace_back(value.get_string().c_str());
+			}
+		}
+
+		property.shrink_to_fit();
+
+		return true;
+	}
+
+	bool CheckKeyAndSet(const Json::JsonObject& json, const char* key, std::string& property)
+	{
+		const auto& rawProperty = json.if_contains(key);
+		if (!rawProperty || !rawProperty->is_string())
+			return false;
+
+		property = rawProperty->get_string().c_str();
+		return true;
+	}
+
+	bool CheckKeyAndSet(const Json::JsonObject& json, const char* key, SelectOption& property)
+	{
+		const auto& rawProperty = json.if_contains(key);
+		if (!rawProperty)
+			return false;
+
+		if (rawProperty->is_string())
+		{
 			property = rawProperty->get_string().c_str();
 			return true;
 		}
 
-		bool CheckKeyAndSet(const Json::JsonObject& json, const char* key, SelectOption& property)
+		if (rawProperty->is_number())
 		{
-			const auto& rawProperty = json.if_contains(key);
-			if (!rawProperty)
-				return false;
-
-			if (rawProperty->is_string())
-			{
-				property = rawProperty->get_string().c_str();
-				return true;
-			}
-
-			if (rawProperty->is_number())
-			{
-				property = rawProperty->to_number<double>();
-				return true;
-			}
-
-			return false;
+			property = rawProperty->to_number<double>();
+			return true;
 		}
+
+		return false;
 	}
 }

--- a/daemon/extension/ManifestFile.h
+++ b/daemon/extension/ManifestFile.h
@@ -68,15 +68,13 @@ namespace ManifestFile
 	};
 
 	bool Load(Manifest& manifest, const char* directory);
-	namespace
-	{
-		bool ValidateAndSet(const Json::JsonObject& json, Manifest& manifest);
-		bool ValidateCommandsAndSet(const Json::JsonObject& json, std::vector<Command>& commands);
-		bool ValidateOptionsAndSet(const Json::JsonObject& json, std::vector<Option>& options);
-		bool ValidateTxtAndSet(const Json::JsonObject& json, std::vector<std::string>& property, const char* propName);
-		bool CheckKeyAndSet(const Json::JsonObject& json, const char* key, std::string& property);
-		bool CheckKeyAndSet(const Json::JsonObject& json, const char* key, SelectOption& property);
-	}
+
+	static bool ValidateAndSet(const Json::JsonObject& json, Manifest& manifest);
+	static bool ValidateCommandsAndSet(const Json::JsonObject& json, std::vector<Command>& commands);
+	static bool ValidateOptionsAndSet(const Json::JsonObject& json, std::vector<Option>& options);
+	static bool ValidateTxtAndSet(const Json::JsonObject& json, std::vector<std::string>& property, const char* propName);
+	static bool CheckKeyAndSet(const Json::JsonObject& json, const char* key, std::string& property);
+	static bool CheckKeyAndSet(const Json::JsonObject& json, const char* key, SelectOption& property);
 };
 
 #endif


### PR DESCRIPTION
## Description

- removed unnecessary empty namespaces;
- use std::string instead of custom BString due to potential memory corruption;
- added the recommended & qualifier to GetExtensions method;

## Testing

By @dnzbk on:
- Windows 11;
- Debian 12;