### PR TITLE
Fix buffer overflow in CString::AppendFmtV

### DIFF
--- a/daemon/util/NString.cpp
+++ b/daemon/util/NString.cpp
@@ -164,7 +164,7 @@ void CString::AppendFmtV(const char* format, va_list ap)
 
 	m_data = newData;
 
-	vsnprintf(m_data + curLen, newLen + 1, format, ap2);
+	vsnprintf(m_data + curLen, addLen + 1, format, ap2);
 
 	va_end(ap2);
 }


### PR DESCRIPTION
## Description

Fix a (potential) buffer overflow in `CString::AppendFmtV`.

Compiling nzbget with GCC13 and `_FORTIFY_SOURCE` can currently lead to the program being terminated:
```
*** buffer overflow detected ***: terminated
```

<details>
  <summary>Example backtrace</summary>
  
  ```
#0  0x00007fc501ac607c in __pthread_kill_implementation () from /nix/store/1rm6sr6ixxzipv5358x0cmaw8rs84g2j-glibc-2.38-44/lib/libc.so.6
#1  0x00007fc501a76e06 in raise () from /nix/store/1rm6sr6ixxzipv5358x0cmaw8rs84g2j-glibc-2.38-44/lib/libc.so.6
#2  0x00007fc501a5f8f5 in abort () from /nix/store/1rm6sr6ixxzipv5358x0cmaw8rs84g2j-glibc-2.38-44/lib/libc.so.6
#3  0x00007fc501a607a1 in __libc_message.cold () from /nix/store/1rm6sr6ixxzipv5358x0cmaw8rs84g2j-glibc-2.38-44/lib/libc.so.6
#4  0x00007fc501b551d9 in __fortify_fail () from /nix/store/1rm6sr6ixxzipv5358x0cmaw8rs84g2j-glibc-2.38-44/lib/libc.so.6
#5  0x00007fc501b54b94 in __chk_fail () from /nix/store/1rm6sr6ixxzipv5358x0cmaw8rs84g2j-glibc-2.38-44/lib/libc.so.6
#6  0x00007fc501b56929 in __vsnprintf_chk () from /nix/store/1rm6sr6ixxzipv5358x0cmaw8rs84g2j-glibc-2.38-44/lib/libc.so.6
#7  0x00000000004e1e3d in CString::AppendFmtV(char const*, __va_list_tag*) ()
#8  0x00000000004e1ef4 in CString::AppendFmt(char const*, ...) ()
#9  0x00000000004a2296 in NzbInfo::BuildFinalDirName() ()
#10 0x000000000048a578 in UnpackController::CreateUnpackDir() ()
#11 0x000000000048cccf in UnpackController::Run() ()
#12 0x00000000004e6092 in Thread::thread_handler() ()
#13 0x00007fc501e13683 in execute_native_thread_routine () from /nix/store/agp6lqznayysqvqkx4k1ggr8n1rsyi8c-gcc-13.2.0-lib/lib/libstdc++.so.6
#14 0x00007fc501ac4383 in start_thread () from /nix/store/1rm6sr6ixxzipv5358x0cmaw8rs84g2j-glibc-2.38-44/lib/libc.so.6
#15 0x00007fc501b4700c in clone3 () from /nix/store/1rm6sr6ixxzipv5358x0cmaw8rs84g2j-glibc-2.38-44/lib/libc.so.6
  ```
</details>

It should not actually be possible that a buffer overflow occurs, since the allocated length is checked correctly. But fortify source still detects the wrong length.

## Testing

Running with this patch for a few days now and no more crashes so far.