### PR TITLE
fix: removed changing ownership at the beginning of container start

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,9 +39,4 @@ if [ ! -z $CONFIG_CHOWN_STATUS ]; then
   echo "*** Could not set permissions on /config ; this container may not work as expected ***"
 fi
 
-chown -R user:users /downloads || DOWNLOADS_CHOWN_STATUS=$?
-if [ ! -z $DOWNLOADS_CHOWN_STATUS ]; then
-  echo "*** Could not set permissions on /downloads ; this container may not work as expected ***"
-fi
-
 su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -34,9 +34,14 @@ PGID=${PGID:-1000}
 groupmod -o -g "$PGID" users >/dev/null
 usermod -o -u "$PUID" user >/dev/null
 
-chown -R user:users /config || CONFIG_CHOWN_STATUS=$?
+chown user:users /config || CONFIG_CHOWN_STATUS=$?
 if [ ! -z $CONFIG_CHOWN_STATUS ]; then
   echo "*** Could not set permissions on /config ; this container may not work as expected ***"
+fi
+
+chown user:users /downloads || DOWNLOADS_CHOWN_STATUS=$?
+if [ ! -z $DOWNLOADS_CHOWN_STATUS ]; then
+  echo "*** Could not set permissions on /downloads ; this container may not work as expected ***"
 fi
 
 su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"


### PR DESCRIPTION
## Description

A `chown` of a download directory might lead to unwanted effects, as there are users who already have a working environment and want to switch to NZBGet. The `chown` is unnecessary, as the check if the necessary folders are existing and/or are writable happens somewhere else.

Here the issue to this PR: https://github.com/nzbgetcom/nzbget/issues/217

## Testing

Built the container in my environment and was able to run it successfully.