### PR TITLE
Fix: dark theme on Linux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -352,6 +352,8 @@ webui_FILES = \
 	webui/messages.js \
 	webui/status.js \
 	webui/style.css \
+	webui/light-theme.css \
+	webui/dark-theme.css \
 	webui/upload.js \
 	webui/util.js \
 	webui/config.js \


### PR DESCRIPTION
## Description

- fixed dark theme. The `dark-theme.css` and `light-theme.css` files were not used in the Linux build.

## Testing

- @dnzbk Linux Debian 12
- @phnzb Ubuntu 22.04.4 LTS