### PR TITLE
Fix file/directory permissions after unpacking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,9 @@ project(
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
-		set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g0 -pthread -g -Weverything -Wno-c++98-compat" CACHE STRING "" FORCE)
+		set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g0 -pthread -g -DDEBUG -Weverything -Wno-c++98-compat" CACHE STRING "" FORCE)
 	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-		set(CMAKE_CXX_FLAGS "-O0 -g0 -pthread -g -Wall -Wextra" CACHE STRING "" FORCE)
+		set(CMAKE_CXX_FLAGS "-O0 -g0 -pthread -g -DDEBUG -Wall -Wextra" CACHE STRING "" FORCE)
 	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 		set(CMAKE_CXX_FLAGS "/Od /Zi /MTd /MP /W4 /EHs /DDEBUG /D_DEBUG /DWIN32 /wd4800 /wd4267" CACHE STRING "" FORCE)
 		set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} winmm.lib Dbghelp.lib libcpmtd.lib" CACHE STRING "" FORCE)

--- a/daemon/postprocess/Unpack.cpp
+++ b/daemon/postprocess/Unpack.cpp
@@ -2,7 +2,8 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2013-2018 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *
+ *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ * 
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -722,6 +723,10 @@ bool UnpackController::Cleanup()
 
 			// silently overwrite existing files
 			FileSystem::DeleteFile(dstFile);
+
+#ifndef WIN32
+			FileSystem::SetFilePermissionsWithUmask(dstFile.Str(), g_Options->GetUMask());
+#endif
 
 			bool hiddenFile = filename[0] == '.';
 

--- a/daemon/postprocess/Unpack.cpp
+++ b/daemon/postprocess/Unpack.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2013-2018 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  * 
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -724,10 +724,6 @@ bool UnpackController::Cleanup()
 			// silently overwrite existing files
 			FileSystem::DeleteFile(dstFile);
 
-#ifndef WIN32
-			FileSystem::SetFilePermissionsWithUmask(dstFile.Str(), g_Options->GetUMask());
-#endif
-
 			bool hiddenFile = filename[0] == '.';
 
 			if (!FileSystem::MoveFile(srcFile, dstFile) && !hiddenFile)
@@ -736,6 +732,10 @@ bool UnpackController::Cleanup()
 					*FileSystem::GetLastErrorMessage());
 				ok = false;
 			}
+
+#ifndef WIN32
+			FileSystem::SetFilePermissionsWithUmask(dstFile.Str(), g_Options->GetUMask());
+#endif
 
 			extractedFiles.push_back(filename);
 		}

--- a/daemon/postprocess/Unpack.cpp
+++ b/daemon/postprocess/Unpack.cpp
@@ -734,14 +734,16 @@ bool UnpackController::Cleanup()
 			}
 
 #ifndef WIN32
-			FileSystem::SetFilePermissionsWithUmask(dstFile.Str(), g_Options->GetUMask());
+			// Fixing file or directory permissions overridden by the unpacker
+			FileSystem::SetFileOrDirPermissionsWithUMask(dstFile.Str(), g_Options->GetUMask());
 #endif
 
 			extractedFiles.push_back(filename);
 		}
 
 #ifndef WIN32
-			FileSystem::SetFilePermissionsWithUmask(destDir, g_Options->GetUMask());
+		// Fixing directory permissions overridden by the unpacker
+		FileSystem::SetDirPermissionsWithUMask(destDir, g_Options->GetUMask());
 #endif
 
 	}

--- a/daemon/postprocess/Unpack.cpp
+++ b/daemon/postprocess/Unpack.cpp
@@ -741,7 +741,7 @@ bool UnpackController::Cleanup()
 		}
 
 #ifndef WIN32
-			FileSystem::SetFilePermissionsWithUmask(destDir.Str(), g_Options->GetUMask());
+			FileSystem::SetFilePermissionsWithUmask(destDir, g_Options->GetUMask());
 #endif
 
 	}

--- a/daemon/postprocess/Unpack.cpp
+++ b/daemon/postprocess/Unpack.cpp
@@ -715,11 +715,11 @@ bool UnpackController::Cleanup()
 	{
 		// moving files back
 		DirBrowser dir(m_unpackDir);
+		const char* destDir = !m_finalDir.Empty() ? *m_finalDir : *m_destDir;
 		while (const char* filename = dir.Next())
 		{
 			BString<1024> srcFile("%s%c%s", *m_unpackDir, PATH_SEPARATOR, filename);
-			BString<1024> dstFile("%s%c%s", !m_finalDir.Empty() ? *m_finalDir : *m_destDir,
-				PATH_SEPARATOR, *FileSystem::MakeValidFilename(filename));
+			BString<1024> dstFile("%s%c%s", destDir, PATH_SEPARATOR, *FileSystem::MakeValidFilename(filename));
 
 			// silently overwrite existing files
 			FileSystem::DeleteFile(dstFile);
@@ -739,6 +739,11 @@ bool UnpackController::Cleanup()
 
 			extractedFiles.push_back(filename);
 		}
+
+#ifndef WIN32
+			FileSystem::SetFilePermissionsWithUmask(destDir.Str(), g_Options->GetUMask());
+#endif
+
 	}
 
 	CString errmsg;

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -958,7 +958,7 @@ void FileSystem::FixExecPermission(const char* filename)
 	}
 }
 
-void SetFilePermissionsWithUmask(const char* filename, mode_t umask)
+void FileSystem::SetFilePermissionsWithUmask(const char* filename, mode_t umask)
 {
 	struct stat buffer;
 	if (!stat(filename, &buffer))

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -961,7 +961,7 @@ void FileSystem::FixExecPermission(const char* filename)
 void SetFilePermissionsWithUmask(const char* filename, mode_t umask)
 {
 	struct stat buffer;
-	if (!stat(filename, &buf))
+	if (!stat(filename, &buffer))
 	{
 		mode_t permissions = buffer.st_mode & ~umask;
 		chmod(filename, permissions);

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -954,6 +955,16 @@ void FileSystem::FixExecPermission(const char* filename)
 	{
 		buffer.st_mode = buffer.st_mode | S_IXUSR | S_IXGRP | S_IXOTH;
 		chmod(filename, buffer.st_mode);
+	}
+}
+
+void SetFilePermissionsWithUmask(const char* filename, mode_t umask)
+{
+	struct stat buffer;
+	if (!stat(filename, &buf))
+	{
+		mode_t permissions = buffer.st_mode & ~umask;
+		chmod(filename, permissions);
 	}
 }
 #endif

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -22,6 +22,7 @@
 #include "nzbget.h"
 #include "FileSystem.h"
 #include "Util.h"
+#include "Log.h"
 
 const char* RESERVED_DEVICE_NAMES[] = { "CON", "PRN", "AUX", "NUL",
 	"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
@@ -960,11 +961,15 @@ void FileSystem::FixExecPermission(const char* filename)
 
 void FileSystem::SetFilePermissionsWithUmask(const char* filename, mode_t umask)
 {
-	struct stat buffer;
-	if (!stat(filename, &buffer))
+	mode_t permissions = buffer.st_mode & ~umask;
+	info("%s %o %s %s", "Setting permissons ", permissions, "on", filename);
+	if (!chmod(filename, permissions))
 	{
-		mode_t permissions = buffer.st_mode & ~umask;
-		chmod(filename, permissions);
+		info("%s", "Success");
+	}
+	else
+	{
+		error("%s", "Failure");
 	}
 }
 #endif

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -961,15 +961,19 @@ void FileSystem::FixExecPermission(const char* filename)
 
 void FileSystem::SetFilePermissionsWithUmask(const char* filename, mode_t umask)
 {
-	mode_t permissions = buffer.st_mode & ~umask;
-	info("%s %o %s %s", "Setting permissons ", permissions, "on", filename);
-	if (!chmod(filename, permissions))
+	struct stat buffer;
+	if (!stat(filename, &buffer))
 	{
-		info("%s", "Success");
-	}
-	else
-	{
-		error("%s", "Failure");
+		mode_t permissions = buffer.st_mode & ~umask;
+		info("%s %o %s %s", "Setting permissons ", permissions, "on", filename);
+		if (!chmod(filename, permissions))
+		{
+			info("%s", "Success");
+		}
+		else
+		{
+			error("%s", "Failure");
+		}
 	}
 }
 #endif

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -61,6 +62,7 @@ public:
 #ifndef WIN32
 	static CString ExpandHomePath(const char* filename);
 	static void FixExecPermission(const char* filename);
+	static void SetFilePermissionsWithUmask(const char* filename, mode_t umask);
 #endif
 	static CString ExpandFileName(const char* filename);
 	static CString GetExeFileName(const char* argv0);

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -62,7 +62,7 @@ public:
 #ifndef WIN32
 	static CString ExpandHomePath(const char* filename);
 	static void FixExecPermission(const char* filename);
-	static void SetFilePermissionsWithUmask(const char* filename, mode_t umask);
+	static void SetFilePermissionsWithUmask(const char* filename, int umask);
 #endif
 	static CString ExpandFileName(const char* filename);
 	static CString GetExeFileName(const char* argv0);

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -62,7 +62,10 @@ public:
 #ifndef WIN32
 	static CString ExpandHomePath(const char* filename);
 	static void FixExecPermission(const char* filename);
-	static void SetFilePermissionsWithUmask(const char* filename, int umask);
+	static bool SetFileOrDirPermissionsWithUMask(const char* filename, int umask);
+	static bool SetFilePermissionsWithUMask(const char* filename, int umask);
+	static bool SetDirPermissionsWithUMask(const char* filename, int umask);
+	static bool SetPermissionsWithUMask(const char* filename, mode_t mode, int umask);
 #endif
 	static CString ExpandFileName(const char* filename);
 	static CString GetExeFileName(const char* argv0);


### PR DESCRIPTION
## Description

- fixed file/directory permissions overriden by the unpacker;
- added the DEBUG definition for debug builds on POSIX systems.

## Testing

@dnzbk Linux Debian 12 with NZBGet v23.1
@phnzb Ubuntu 22.04.4 LTS x86_64