### PR TITLE
NewsServer Add UI - Default encryption and ports

### DIFF
--- a/nzbget.conf
+++ b/nzbget.conf
@@ -199,8 +199,14 @@ Server1.Group=0
 # Host name of news server.
 Server1.Host=my.newsserver.com
 
-# Port to connect to (1-65535).
-Server1.Port=119
+# Encrypted server connection (TLS/SSL) (yes, no).
+#
+# NOTE: By changing this option you should also change the option <ServerX.Port>
+# accordingly because unsecure and encrypted connections use different ports.
+Server1.Encryption=yes
+
+# News Server port, usually 563 for secure connections, 119 for unsecure connections, rare - 80 or 443 (1-65535).
+Server1.Port=563
 
 # User name to use for authentication.
 Server1.Username=user
@@ -210,12 +216,6 @@ Server1.Password=pass
 
 # Server requires "Join Group"-command (yes, no).
 Server1.JoinGroup=no
-
-# Encrypted server connection (TLS/SSL) (yes, no).
-#
-# NOTE: By changing this option you should also change the option <ServerX.Port>
-# accordingly because unsecure and encrypted connections use different ports.
-Server1.Encryption=no
 
 # Cipher to use for encrypted server connection.
 #

--- a/webui/config.js
+++ b/webui/config.js
@@ -2,6 +2,7 @@
  * This file is part of nzbget. See <https://nzbget.com>.
  *
  * Copyright (C) 2012-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ * Copyright (C) 2024 Denis <denis@nzbget.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1323,6 +1324,26 @@ var Config = (new function($)
 		{
 			var optFormId = $(control).parent().attr('id');
 			var option = findOptionById(optFormId);
+
+			var suffixStartIdx = optFormId.indexOf('_Encryption');
+			if (suffixStartIdx !== -1)
+			{
+				
+				var prefix = optFormId.substring(0, suffixStartIdx);
+				var portOption = findOptionById(prefix + '_Port');
+				var prevVal = getOptionValue(option);
+				var newValue = getOptionValue(portOption);
+				var input = $('#' + prefix + '_Port')[0];
+				if (prevVal === 'no' && newValue === '563')
+				{
+					input.value = '119';
+				}
+				else if (prevVal === 'yes' && newValue === '119')
+				{
+					input.value = '563';
+				}
+			}
+			
 			if (option.onchange)
 			{
 				option.onchange(option);

--- a/webui/config.js
+++ b/webui/config.js
@@ -1324,30 +1324,66 @@ var Config = (new function($)
 		{
 			var optFormId = $(control).parent().attr('id');
 			var option = findOptionById(optFormId);
-
-			var suffixStartIdx = optFormId.indexOf('_Encryption');
-			if (suffixStartIdx !== -1)
-			{
-				
-				var prefix = optFormId.substring(0, suffixStartIdx);
-				var portOption = findOptionById(prefix + '_Port');
-				var prevVal = getOptionValue(option);
-				var newValue = getOptionValue(portOption);
-				var input = $('#' + prefix + '_Port')[0];
-				if (prevVal === 'no' && newValue === '563')
-				{
-					input.value = '119';
-				}
-				else if (prevVal === 'yes' && newValue === '119')
-				{
-					input.value = '563';
-				}
-			}
 			
 			if (option.onchange)
 			{
 				option.onchange(option);
 			}
+
+			tlsSwitchHelper(option)
+		}
+	}
+
+	function tlsSwitchHelper(option)
+	{
+		var defaultPort = '119';
+		var defaultTlsPort = '563';
+
+		var defaultPort2 = '80';
+		var defaultTlsPort2 = '443';
+		
+		var suffixStartIdx = option.formId.indexOf('_Encryption');
+		if (suffixStartIdx < 0)
+		{
+			return;
+		}
+
+		var portOptionId = option.formId.substring(0, suffixStartIdx) + '_Port';
+		var portOption = findOptionById(portOptionId);
+		var useTls = getOptionValue(option) === 'yes';
+		var currentPort = getOptionValue(portOption);
+		var inputField = $('#' + portOptionId)[0];
+
+		if (useTls)
+		{
+			if (currentPort === defaultPort)
+			{
+				inputField.value = defaultTlsPort;
+				return;
+			}
+
+			if (currentPort === defaultPort2)
+			{
+				inputField.value = defaultTlsPort2;
+			}
+
+			return;
+		}
+
+		if (!useTls)
+		{
+			if (currentPort === defaultTlsPort)
+			{
+				inputField.value = defaultPort;
+				return;
+			}
+
+			if (currentPort === defaultTlsPort2)
+			{
+				inputField.value = defaultPort2;
+			}
+
+			return;
 		}
 	}
 


### PR DESCRIPTION
## Description

- moved `Server.Encryption` between `Server.Host` and `Server.Port`;
- made `Server.Encryption` to `ON` by default;
- made port depend on `Server.Encryption value unless user has put something up:
  - 563/443 for secure;
  - 119/80 for unsecure.

## Testing

- Windows 11 - Chrome;
- macOS Ventura - Safari.