### PR TITLE
Add support for the"nzbgetMinVersion" property in "manifest.json"

### DIFF
--- a/daemon/extension/Extension.cpp
+++ b/daemon/extension/Extension.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -79,9 +79,19 @@ namespace Extension
 		m_version = std::move(version);
 	}
 
+	void Script::SetNzbgetMinVersion(std::string version)
+	{
+		m_nzbgetMinVersion = std::move(version);
+	}
+
 	const char* Script::GetVersion() const
 	{
 		return m_version.c_str();
+	}
+
+	const char* Script::GetNzbgetMinVersion() const
+	{
+		return m_nzbgetMinVersion.c_str();
 	}
 
 	void Script::SetLicense(std::string license)
@@ -230,6 +240,7 @@ namespace Extension
 		json["Homepage"] = script.GetHomepage();
 		json["License"] = script.GetLicense();
 		json["Version"] = script.GetVersion();
+		json["NZBGetMinVersion"] = script.GetNzbgetMinVersion();
 		json["PostScript"] = script.GetPostScript();
 		json["ScanScript"] = script.GetScanScript();
 		json["QueueScript"] = script.GetQueueScript();
@@ -335,6 +346,7 @@ namespace Extension
 		AddNewNode(structNode, "Homepage", "string", script.GetHomepage());
 		AddNewNode(structNode, "License", "string", script.GetLicense());
 		AddNewNode(structNode, "Version", "string", script.GetVersion());
+		AddNewNode(structNode, "NZBGetMinVersion", "string", script.GetNzbgetMinVersion());
 
 		AddNewNode(structNode, "PostScript", "boolean", BoolToStr(script.GetPostScript()));
 		AddNewNode(structNode, "ScanScript", "boolean", BoolToStr(script.GetScanScript()));

--- a/daemon/extension/Extension.h
+++ b/daemon/extension/Extension.h
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ namespace Extension
 		bool feed = false;
 	};
 
-	class Script
+	class Script final
 	{
 	public:
 		Script() = default;
@@ -54,7 +54,9 @@ namespace Extension
 		void SetAuthor(std::string author);
 		const char* GetAuthor() const;
 		void SetVersion(std::string version);
+		void SetNzbgetMinVersion(std::string version);
 		const char* GetVersion() const;
+		const char* GetNzbgetMinVersion() const;
 		void SetLicense(std::string license);
 		const char* GetLicense() const;
 		void SetHomepage(std::string homepage);
@@ -91,6 +93,7 @@ namespace Extension
 		std::string m_rootDir;
 		std::string m_author;
 		std::string m_version;
+		std::string m_nzbgetMinVersion;
 		std::string m_homepage;
 		std::string m_license;
 		std::string m_name;

--- a/daemon/extension/ExtensionLoader.cpp
+++ b/daemon/extension/ExtensionLoader.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -438,6 +438,7 @@ namespace ExtensionLoader
 		script.SetHomepage(std::move(manifest.homepage));
 		script.SetLicense(std::move(manifest.license));
 		script.SetVersion(std::move(manifest.version));
+		script.SetNzbgetMinVersion(std::move(manifest.nzbgetMinVersion));
 		script.SetDisplayName(std::move(manifest.displayName));
 		script.SetName(std::move(manifest.name));
 		script.SetAbout(std::move(manifest.about));

--- a/daemon/extension/ExtensionManager.h
+++ b/daemon/extension/ExtensionManager.h
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ namespace ExtensionManager
 {
 	using Extensions = std::vector<std::shared_ptr<const Extension::Script>>;
 
-	class Manager
+	class Manager final
 	{
 	public:
 		Manager() = default;

--- a/daemon/extension/ManifestFile.cpp
+++ b/daemon/extension/ManifestFile.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -45,6 +45,8 @@ namespace ManifestFile
 
 		if (!ValidateAndSet(json, manifest))
 			return false;
+
+		CheckKeyAndSet(json, "nzbgetMinVersion", manifest.nzbgetMinVersion);
 
 		return true;
 	}

--- a/daemon/extension/ManifestFile.h
+++ b/daemon/extension/ManifestFile.h
@@ -68,6 +68,7 @@ namespace ManifestFile
 		std::string homepage;
 		std::string displayName;
 		std::string version;
+		std::string nzbgetMinVersion;
 		std::string license;
 		std::string about;
 		std::string queueEvents;

--- a/docs/extensions/EXTENSIONS.md
+++ b/docs/extensions/EXTENSIONS.md
@@ -41,6 +41,7 @@ and the `executable` file, like `main.py`.
   "kind": "POST-PROCESSING",
   "displayName": "My EMail Extension",
   "version": "2.0.0",
+  "nzbgetMinVersion": "23",
   "author": "John Doe",
   "license": "GNU",
   "about": "Sends E-Mail notification.",
@@ -149,6 +150,10 @@ The name that will be displayed in the web interface.
 ### `"version"`
 
 Extension version.
+
+### `"nzbgetMinVersion" (optional)`
+
+NZBGet minimum required version.
 
 ### `"author"`
 

--- a/tests/extension/ExtensionTest.cpp
+++ b/tests/extension/ExtensionTest.cpp
@@ -45,6 +45,7 @@ Extension::Script GetExtension()
 	script.SetQueueEvents("QueueEvents");
 	script.SetTaskTime("TaskTime");
 	script.SetVersion("Version");
+	script.SetNzbgetMinVersion("23.1");
 
 	option.description = { "description" };
 	option.displayName = "displayName";
@@ -86,6 +87,7 @@ BOOST_AUTO_TEST_CASE(ToJsonStrTest)
 \"Homepage\":\"Homepage\",\
 \"License\":\"License\",\
 \"Version\":\"Version\",\
+\"NZBGetMinVersion\":\"23.1\",\
 \"PostScript\":true,\
 \"ScanScript\":false,\
 \"QueueScript\":false,\
@@ -118,6 +120,7 @@ BOOST_AUTO_TEST_CASE(ToXmlStrTest)
 <member><name>Homepage</name><value><string>Homepage</string></value></member>\
 <member><name>License</name><value><string>License</string></value></member>\
 <member><name>Version</name><value><string>Version</string></value></member>\
+<member><name>NZBGetMinVersion</name><value><string>23.1</string></value></member>\
 <member><name>PostScript</name><value><boolean>true</boolean></value></member>\
 <member><name>ScanScript</name><value><boolean>false</boolean></value></member>\
 <member><name>QueueScript</name><value><boolean>false</boolean></value></member>\

--- a/tests/extension/ManifestFileTest.cpp
+++ b/tests/extension/ManifestFileTest.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -47,6 +47,7 @@ BOOST_AUTO_TEST_CASE(ManifestFileTest)
 	BOOST_CHECK(manifestFile.kind == "POST-PROCESSING");
 	BOOST_CHECK(manifestFile.displayName == "Email");
 	BOOST_CHECK(manifestFile.version == "1.0.0");
+	BOOST_CHECK(manifestFile.nzbgetMinVersion == "23.1");
 	BOOST_CHECK(manifestFile.author == "Author's name");
 	BOOST_CHECK(manifestFile.homepage == "https://github");
 	BOOST_CHECK(manifestFile.license == "GNU");

--- a/tests/testdata/extension/manifest/valid/manifest.json
+++ b/tests/testdata/extension/manifest/valid/manifest.json
@@ -4,6 +4,7 @@
 	"kind": "POST-PROCESSING",
 	"displayName": "Email",
 	"version": "1.0.0",
+	"nzbgetMinVersion": "23.1",
 	"author": "Author's name",
 	"homepage": "https://github",
 	"license": "GNU",

--- a/webui/config.js
+++ b/webui/config.js
@@ -3472,7 +3472,7 @@ var ExtensionManager = (new function($)
 		var remote = [];
 		for (var i = 0; i < remoteExtensions.length; i++) {
 			var extension = remoteExtensions[i];
-			if (!checkMinRequiredVersion(extension.nzbgetMinVersion))
+			if (!checkNzbgetMinRequiredVersion(extension.nzbgetMinVersion))
 			{
 				continue;
 			}
@@ -3498,7 +3498,7 @@ var ExtensionManager = (new function($)
 		return v1.localeCompare(v2, undefined, { numeric: true, sensitivity: 'base' }) < 0;
 	}
 
-	function checkMinRequiredVersion(extVersion)
+	function checkNzbgetMinRequiredVersion(extVersion)
 	{
 		var nzbgetVersion = Options.option('Version');
 		return isOutdated(extVersion, nzbgetVersion);

--- a/webui/config.js
+++ b/webui/config.js
@@ -3349,6 +3349,7 @@ function Extension()
 	this.about = '';
 	this.url = '';
 	this.testError = '';
+	this.nzbgetMinVersion = '';
 	this.isActive = false;
 	this.installed = false;
 	this.outdated = false;
@@ -3361,7 +3362,8 @@ var ExtensionManager = (new function($)
 	this.id = 'extension-manager';
 	this.table = 'ExtensionManagerTable';
 	this.tbody = 'ExtensionManagerTBody';
-	this.extensionsUrl = 'https://raw.githubusercontent.com/nzbgetcom/nzbget-extensions/main/extensions.json';
+	//this.extensionsUrl = 'https://raw.githubusercontent.com/nzbgetcom/nzbget-extensions/main/extensions.json';
+	this.extensionsUrl = 'https://raw.githubusercontent.com/nzbgetcom/nzbget-extensions/feature/SpeedControl/extensions.json';
 
 	var scriptOrderId = 'ScriptOrder';
 	var extensionsId = 'Extensions';
@@ -3391,6 +3393,7 @@ var ExtensionManager = (new function($)
 			extension.homepage = ext.Homepage;
 			extension.about = ext.About;
 			extension.name = ext.Name;
+			extension.nzbgetMinVersion = ext.NZBGetMinVersion;
 			extension.installed = true;
 			extension.isActive = activeExtensions.indexOf(ext.Name) != -1;
 			return extension;
@@ -3412,6 +3415,7 @@ var ExtensionManager = (new function($)
 					extension.id = ext.Name + '_' + defaultSectionName;
 					extension.displayName = ext.displayName;
 					extension.version = ext.version;
+					extension.nzbgetMinVersion = ext['nzbgetMinVersion'] || '';
 					extension.author = ext.author;
 					extension.homepage = ext.homepage;
 					extension.about = ext.about;
@@ -3469,6 +3473,11 @@ var ExtensionManager = (new function($)
 		var remote = [];
 		for (var i = 0; i < remoteExtensions.length; i++) {
 			var extension = remoteExtensions[i];
+			if (!checkMinRequiredVersion(extension.nzbgetMinVersion))
+			{
+				continue;
+			}
+
 			var idx = installedExtensions.map(function(ext) { return ext.name; }).indexOf(extension.name);
 			if (idx == -1)
 			{
@@ -3477,15 +3486,23 @@ var ExtensionManager = (new function($)
 			else
 			{
 				var installedExt = installedExtensions[idx];
-				if (installedExt.version.localeCompare(extension.version, undefined, { numeric: true, sensitivity: 'base' }) < 0)
-				{
-					installedExt.outdated = true;
-				}
+				installedExt.outdated = isOutdated(installedExt.version, extension.version);
 				installedExt.url = extension.url;
 			}
 		}
 
 		return remote.concat(installedExtensions);
+	}
+
+	function isOutdated(v1, v2)
+	{
+		return v1.localeCompare(v2, undefined, { numeric: true, sensitivity: 'base' }) < 0;
+	}
+
+	function checkMinRequiredVersion(extVersion)
+	{
+		var nzbgetVersion = Options.option('Version');
+		return isOutdated(extVersion, nzbgetVersion);
 	}
 
 	function downloadExtension(ext)

--- a/webui/config.js
+++ b/webui/config.js
@@ -3472,6 +3472,7 @@ var ExtensionManager = (new function($)
 		var remote = [];
 		for (var i = 0; i < remoteExtensions.length; i++) {
 			var extension = remoteExtensions[i];
+
 			if (!checkNzbgetMinRequiredVersion(extension.nzbgetMinVersion))
 			{
 				continue;

--- a/webui/config.js
+++ b/webui/config.js
@@ -3362,8 +3362,7 @@ var ExtensionManager = (new function($)
 	this.id = 'extension-manager';
 	this.table = 'ExtensionManagerTable';
 	this.tbody = 'ExtensionManagerTBody';
-	//this.extensionsUrl = 'https://raw.githubusercontent.com/nzbgetcom/nzbget-extensions/main/extensions.json';
-	this.extensionsUrl = 'https://raw.githubusercontent.com/nzbgetcom/nzbget-extensions/feature/SpeedControl/extensions.json';
+	this.extensionsUrl = 'https://raw.githubusercontent.com/nzbgetcom/nzbget-extensions/main/extensions.json';
 
 	var scriptOrderId = 'ScriptOrder';
 	var extensionsId = 'Extensions';


### PR DESCRIPTION
## Description

- added a new "nzbgetMinVersion" property to `manifest.json` to be able to specify the minimum version of NZBGet that the extension is compatible with;
- added a filter for remote extensions that are incompatible with the current version of NZBGet;
- updated EXTENSIONS.md;

## Testing

- Windows 11;
- macOS Ventura.