### PR TITLE
Fix files/dirs permissions overridden by the unpacker

### DIFF
--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -277,6 +277,12 @@ void NZBGet::Init()
 	{
 		/* set newly created file permissions */
 		umask(uMask);
+		FileSystem::SetUMask(uMask);
+	}
+	else
+	{
+		mode_t currUMask = umask(umask(022));
+		FileSystem::SetUMask(currUMask);
 	}
 #endif
 

--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -281,7 +281,7 @@ void NZBGet::Init()
 	}
 	else
 	{
-		FileSystem::uMask = umask(022);
+		FileSystem::uMask = umask(0);
 		umask(FileSystem::uMask);
 	}
 

--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -276,13 +276,13 @@ void NZBGet::Init()
 	if (uMask > 0 && uMask < 1000)
 	{
 		/* set newly created file permissions */
-		umask(uMask);
-		FileSystem::SetUMask(uMask);
+		FileSystem::uMask = uMask;
+		umask(FileSystem::uMask);
 	}
 	else
 	{
-		mode_t currUMask = umask(umask(022));
-		FileSystem::SetUMask(currUMask);
+		FileSystem::uMask = umask(022);
+		umask(FileSystem::uMask);
 	}
 #endif
 

--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -272,8 +272,8 @@ void NZBGet::Init()
 	BootConfig();
 
 #ifndef WIN32
-	int uMask = m_options->GetUMask();
-	if (uMask > 0 && uMask < 1000)
+	mode_t uMask = static_cast<mode_t>(m_options->GetUMask());
+	if (uMask > 0 && uMask < 01000)
 	{
 		/* set newly created file permissions */
 		FileSystem::uMask = uMask;
@@ -284,6 +284,11 @@ void NZBGet::Init()
 		FileSystem::uMask = umask(022);
 		umask(FileSystem::uMask);
 	}
+
+#ifdef DEBUG
+	debug("Using %o umask", FileSystem::uMask);
+#endif
+
 #endif
 
 	m_scanner->InitOptions();

--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -272,10 +272,11 @@ void NZBGet::Init()
 	BootConfig();
 
 #ifndef WIN32
-	if (m_options->GetUMask() < 01000)
+	int umask = m_options->GetUMask();
+	if (umask > 0 && umask < 1000)
 	{
 		/* set newly created file permissions */
-		umask(m_options->GetUMask());
+		umask(umask);
 	}
 #endif
 

--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -272,11 +272,11 @@ void NZBGet::Init()
 	BootConfig();
 
 #ifndef WIN32
-	int umask = m_options->GetUMask();
-	if (umask > 0 && umask < 1000)
+	int uMask = m_options->GetUMask();
+	if (uMask > 0 && uMask < 1000)
 	{
 		/* set newly created file permissions */
-		umask(umask);
+		umask(uMask);
 	}
 #endif
 

--- a/daemon/postprocess/Unpack.cpp
+++ b/daemon/postprocess/Unpack.cpp
@@ -735,7 +735,7 @@ bool UnpackController::Cleanup()
 
 #ifndef WIN32
 			// Fixing file or directory permissions overridden by the unpacker
-			FileSystem::SetFileOrDirPermissionsWithUMask(dstFile.Str(), g_Options->GetUMask());
+			FileSystem::RestoreFileOrDirPermissions(dstFile.Str());
 #endif
 
 			extractedFiles.push_back(filename);
@@ -743,7 +743,7 @@ bool UnpackController::Cleanup()
 
 #ifndef WIN32
 		// Fixing directory permissions overridden by the unpacker
-		FileSystem::SetDirPermissionsWithUMask(destDir, g_Options->GetUMask());
+		FileSystem::RestoreDirPermissions(destDir);
 #endif
 
 	}

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -959,7 +959,7 @@ void FileSystem::FixExecPermission(const char* filename)
 	}
 }
 
-bool FileSystem::SetFileOrDirPermissionsWithUMask(const char* filename, mode_t umask) 
+bool FileSystem::SetFileOrDirPermissionsWithUMask(const char* filename, int umask) 
 {
 	struct stat buffer;
 	int ec = stat(filename, &buffer);
@@ -981,22 +981,26 @@ bool FileSystem::SetFileOrDirPermissionsWithUMask(const char* filename, mode_t u
 	return SetFilePermissionsWithUMask(filename, umask);
 }
 
-bool FileSystem::SetFilePermissionsWithUMask(const char* filepath, mode_t umask)
+bool FileSystem::SetFilePermissionsWithUMask(const char* filepath, int umask)
 {
 	mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH; // 0666
 	return SetPermissionsWithUMask(filepath, mode, umask);
 }
 
-bool FileSystem::SetDirPermissionsWithUMask(const char* filename, mode_t umask)
+bool FileSystem::SetDirPermissionsWithUMask(const char* filename, int umask)
 {
 	mode_t mode = S_IRWXU | S_IRWXG | S_IRWXO; // 0777
 	return SetPermissionsWithUMask(filename, mode, umask);
 }
 
-bool FileSystem::SetPermissionsWithUMask(const char* filename, mode_t mode, mode_t umask) 
+bool FileSystem::SetPermissionsWithUMask(const char* filename, mode_t mode, int umask) 
 {
-	if (umask < 0001 || umask >= 1000)
+	if (umask == 0 || (umask == 01000)
 	{
+
+#ifdef DEBUG
+		debug("umask is equal to  %o. Setting umask from a user system...");
+#endif
 		umask = GetCurrentUMask();
 	}
 
@@ -1022,7 +1026,7 @@ bool FileSystem::SetPermissionsWithUMask(const char* filename, mode_t mode, mode
 mode_t FileSystem::GetCurrentUMask()
 {
 	mode_t currUMask = umask(0);
-    umask(currUMask); // Restore the original umask value
+	umask(currUMask); // Restore the original umask value
 	return currUMask;
 }
 #endif

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -995,7 +995,7 @@ bool FileSystem::SetDirPermissionsWithUMask(const char* filename, mode_t umask)
 
 bool FileSystem::SetPermissionsWithUMask(const char* filename, mode_t mode, mode_t umask) 
 {
-	if (umask >= 01000)
+	if (umask == 0000 || umask >= 01000)
 	{
 		umask = GetCurrentUMask();
 	}

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -1016,9 +1016,9 @@ bool FileSystem::RestorePermissions(const char* filename, mode_t mode)
 
 mode_t FileSystem::GetSysUMask()
 {
-	mode_t sysUmask = umask(0);
-	umask(sysUmask); // Restore the original umask value
-	return sysUmask;
+	mode_t currUmask = umask(0);
+	umask(currUmask); // Restore the original umask value
+	return currUmask;
 }
 #endif
 

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -1024,7 +1024,7 @@ void FileSystem::SetUMask(mode_t uMask)
 
 }
 
-mode_t FileSystem::GetUMask() const
+mode_t FileSystem::GetUMask()
 {
 	return m_umask;
 }

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -948,6 +948,9 @@ bool FileSystem::FlushDirBuffers(const char* filename, CString& errmsg)
 }
 
 #ifndef WIN32
+
+mode_t FileSystem::uMask
+
 void FileSystem::FixExecPermission(const char* filename)
 {
 	struct stat buffer;
@@ -995,7 +998,7 @@ bool FileSystem::RestoreDirPermissions(const char* filename)
 
 bool FileSystem::RestorePermissions(const char* filename, mode_t mode) 
 {
-	mode_t permissions = mode & ~uMask;
+	mode_t permissions = mode & ~FileSystem::uMask;
 	int ec = chmod(filename, permissions);
 	if (ec == 0)
 	{

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -949,7 +949,7 @@ bool FileSystem::FlushDirBuffers(const char* filename, CString& errmsg)
 
 #ifndef WIN32
 
-mode_t FileSystem::uMask
+mode_t FileSystem::uMask;
 
 void FileSystem::FixExecPermission(const char* filename)
 {

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -978,19 +978,19 @@ bool FileSystem::RestoreFileOrDirPermissions(const char* filename)
 		return RestoreDirPermissions(filename);
 	} 
 
-	return RestoreFilePermissionsk(filename);
+	return RestoreFilePermissions(filename);
 }
 
 bool FileSystem::RestoreFilePermissions(const char* filepath)
 {
 	mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH; // 0666
-	return RestorePermissions(filepath, mode, umask);
+	return RestorePermissions(filepath, mode);
 }
 
 bool FileSystem::RestoreDirPermissions(const char* filename)
 {
 	mode_t mode = S_IRWXU | S_IRWXG | S_IRWXO; // 0777
-	return RestorePermissions(filename, mode, umask);
+	return RestorePermissions(filename, mode);
 }
 
 bool FileSystem::RestorePermissions(const char* filename, mode_t mode) 

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -1014,21 +1014,6 @@ bool FileSystem::RestorePermissions(const char* filename, mode_t mode)
 	return false;
 }
 
-void FileSystem::SetUMask(mode_t uMask)
-{
-	m_umask = uMask;
-
-#ifdef DEBUG
-	debug("umask %o was set", uMask);
-#endif
-
-}
-
-mode_t FileSystem::GetUMask()
-{
-	return m_umask;
-}
-
 #endif
 
 #ifdef WIN32

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -995,7 +995,7 @@ bool FileSystem::SetDirPermissionsWithUMask(const char* filename, int umask)
 
 bool FileSystem::SetPermissionsWithUMask(const char* filename, mode_t mode, int umask) 
 {
-	if (umask == 0 || (umask == 01000)
+	if (umask < 0 || umask >= 1000)
 	{
 
 #ifdef DEBUG

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -995,7 +995,7 @@ bool FileSystem::SetDirPermissionsWithUMask(const char* filename, int umask)
 
 bool FileSystem::SetPermissionsWithUMask(const char* filename, mode_t mode, int umask) 
 {
-	if (umask < 0 || umask >= 1000)
+	if (umask <= 0 || umask >= 1000)
 	{
 
 #ifdef DEBUG

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -995,7 +995,7 @@ bool FileSystem::RestoreDirPermissions(const char* filename)
 
 bool FileSystem::RestorePermissions(const char* filename, mode_t mode) 
 {
-	mode_t permissions = mode & ~m_umask;
+	mode_t permissions = mode & ~uMask;
 	int ec = chmod(filename, permissions);
 	if (ec == 0)
 	{

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -995,7 +995,7 @@ bool FileSystem::RestoreDirPermissions(const char* filename)
 
 bool FileSystem::RestorePermissions(const char* filename, mode_t mode) 
 {
-	mode_t permissions = mode & ~GetSysUMask();
+	mode_t permissions = mode & ~m_umask;
 	int ec = chmod(filename, permissions);
 	if (ec == 0)
 	{
@@ -1014,12 +1014,21 @@ bool FileSystem::RestorePermissions(const char* filename, mode_t mode)
 	return false;
 }
 
-mode_t FileSystem::GetSysUMask()
+void FileSystem::SetUMask(mode_t uMask)
 {
-	mode_t currUmask = umask(0);
-	umask(currUmask); // Restore the original umask value
-	return currUmask;
+	m_umask = uMask;
+
+#ifdef DEBUG
+	debug("umask %o was set", uMask);
+#endif
+
 }
+
+mode_t FileSystem::GetUMask() const
+{
+	return m_umask;
+}
+
 #endif
 
 #ifdef WIN32

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -995,7 +995,7 @@ bool FileSystem::SetDirPermissionsWithUMask(const char* filename, mode_t umask)
 
 bool FileSystem::SetPermissionsWithUMask(const char* filename, mode_t mode, mode_t umask) 
 {
-	if (umask == 0000 || umask >= 01000)
+	if (umask < 0001 || umask >= 1000)
 	{
 		umask = GetCurrentUMask();
 	}

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -62,11 +62,11 @@ public:
 #ifndef WIN32
 	static CString ExpandHomePath(const char* filename);
 	static void FixExecPermission(const char* filename);
-	static bool SetFileOrDirPermissionsWithUMask(const char* filename, int umask);
-	static bool SetFilePermissionsWithUMask(const char* filename, int umask);
-	static bool SetDirPermissionsWithUMask(const char* filename, int umask);
-	static bool SetPermissionsWithUMask(const char* filename, mode_t mode, int umask);
-	static mode_t GetCurrentUMask();
+	static bool RestoreFileOrDirPermissions(const char* filename);
+	static bool RestoreFilePermissions(const char* filename);
+	static bool RestoreDirPermissions(const char* filename);
+	static bool RestorePermissions(const char* filename, mode_t mode);
+	static mode_t GetSysUMask();
 #endif
 	static CString ExpandFileName(const char* filename);
 	static CString GetExeFileName(const char* argv0);

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -66,7 +66,10 @@ public:
 	static bool RestoreFilePermissions(const char* filename);
 	static bool RestoreDirPermissions(const char* filename);
 	static bool RestorePermissions(const char* filename, mode_t mode);
-	static mode_t GetSysUMask();
+	static void SetUMask(mode_t uMask);
+	static mode_t GetUMask() const;
+private:
+	mode_t m_umask = 022;
 #endif
 	static CString ExpandFileName(const char* filename);
 	static CString GetExeFileName(const char* argv0);

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -62,10 +62,10 @@ public:
 #ifndef WIN32
 	static CString ExpandHomePath(const char* filename);
 	static void FixExecPermission(const char* filename);
-	static bool SetFileOrDirPermissionsWithUMask(const char* filename, mode_t umask);
-	static bool SetFilePermissionsWithUMask(const char* filename, mode_t umask);
-	static bool SetDirPermissionsWithUMask(const char* filename, mode_t umask);
-	static bool SetPermissionsWithUMask(const char* filename, mode_t mode, mode_t umask);
+	static bool SetFileOrDirPermissionsWithUMask(const char* filename, int umask);
+	static bool SetFilePermissionsWithUMask(const char* filename, int umask);
+	static bool SetDirPermissionsWithUMask(const char* filename, int umask);
+	static bool SetPermissionsWithUMask(const char* filename, mode_t mode, int umask);
 	static mode_t GetCurrentUMask();
 #endif
 	static CString ExpandFileName(const char* filename);

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -62,10 +62,11 @@ public:
 #ifndef WIN32
 	static CString ExpandHomePath(const char* filename);
 	static void FixExecPermission(const char* filename);
-	static bool SetFileOrDirPermissionsWithUMask(const char* filename, int umask);
-	static bool SetFilePermissionsWithUMask(const char* filename, int umask);
-	static bool SetDirPermissionsWithUMask(const char* filename, int umask);
-	static bool SetPermissionsWithUMask(const char* filename, mode_t mode, int umask);
+	static bool SetFileOrDirPermissionsWithUMask(const char* filename, mode_t umask);
+	static bool SetFilePermissionsWithUMask(const char* filename, mode_t umask);
+	static bool SetDirPermissionsWithUMask(const char* filename, mode_t umask);
+	static bool SetPermissionsWithUMask(const char* filename, mode_t mode, mode_t umask);
+	static mode_t GetCurrentUMask();
 #endif
 	static CString ExpandFileName(const char* filename);
 	static CString GetExeFileName(const char* argv0);

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -66,10 +66,7 @@ public:
 	static bool RestoreFilePermissions(const char* filename);
 	static bool RestoreDirPermissions(const char* filename);
 	static bool RestorePermissions(const char* filename, mode_t mode);
-	static void SetUMask(mode_t uMask);
-	static mode_t GetUMask();
-private:
-	mode_t m_umask = 022;
+	static mode_t uMask = 022;
 #endif
 	static CString ExpandFileName(const char* filename);
 	static CString GetExeFileName(const char* argv0);

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -67,7 +67,7 @@ public:
 	static bool RestoreDirPermissions(const char* filename);
 	static bool RestorePermissions(const char* filename, mode_t mode);
 	static void SetUMask(mode_t uMask);
-	static mode_t GetUMask() const;
+	static mode_t GetUMask();
 private:
 	mode_t m_umask = 022;
 #endif

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -66,7 +66,7 @@ public:
 	static bool RestoreFilePermissions(const char* filename);
 	static bool RestoreDirPermissions(const char* filename);
 	static bool RestorePermissions(const char* filename, mode_t mode);
-	static mode_t uMask = 022;
+	static mode_t uMask;
 #endif
 	static CString ExpandFileName(const char* filename);
 	static CString GetExeFileName(const char* argv0);


### PR DESCRIPTION
## Description

- fixed files/dirs permissions overridden by the unpacker.

## Testing

- Debian 12;