### PR TITLE
Better config locations

### DIFF
--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -182,12 +182,9 @@ const int BoolCount = 12;
 #ifndef WIN32
 const char* PossibleConfigLocations[] =
 	{
-		"~/.nzbget",
+		"~/.nzbget", // backwards compatibility
+		"~/.config/nzbget.conf",
 		"/etc/nzbget.conf",
-		"/usr/etc/nzbget.conf",
-		"/usr/local/etc/nzbget.conf",
-		"/opt/etc/nzbget.conf",
-		"~/usr/etc/nzbget.conf",
 		nullptr
 	};
 #endif

--- a/docs/HOW_TO_USE.md
+++ b/docs/HOW_TO_USE.md
@@ -23,12 +23,8 @@ locations (in this order):
 On POSIX systems:
 ```
 <EXE-DIR>/nzbget.conf
-~/.nzbget
+~/.config/nzbget.conf
 /etc/nzbget.conf
-/usr/etc/nzbget.conf
-/usr/local/etc/nzbget.conf
-/opt/etc/nzbget.conf
-~/usr/etc/nzbget.conf
 ```
 
 On Windows:


### PR DESCRIPTION
I dislike dotfiles in my home dir so this allows the config to be read from `~/.config/nzbget.conf`. Should probably do it via `$XDG_CONFIG_HOME` but oh well.

This also gets rid of the dumb paths that nobody should be using anyway (sorry to the 3 people that do use them!). I know that breaking configs is bad but I think we have the luxury to do so since this is a fork :wink: