### PR TITLE
Fix style when hosting in a subdir

### DIFF
--- a/webui/style.css
+++ b/webui/style.css
@@ -26,7 +26,7 @@ html {
 	font-style: normal;
 	font-weight: 100 700;
 	src: local('material-icons'),
-		 url(/lib/material-icons.woff2) format('woff2'),
+		 url(lib/material-icons.woff2) format('woff2'),
 }
 
 .material-icon {


### PR DESCRIPTION
## Description

Fixes the material icons not loading when nzbget is hosted under a subdirectory (e.g. when using a reverse proxy).

## Testing

Loaded and viewed my local instance