### PR TITLE
Docker: v24 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ QNAP packages are available as native / buildroot packages or via [sherpa](https
 
 ## Brief introduction on how to use NZBGet
  - [How to use](docs/HOW_TO_USE.md)
+ - [Performance tips](docs/PERFORMANCE.md)
 
 ## Contribution
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN \
   if [ "${UNRAR_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/amd64" ]; \
     then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=x86-64-v2|" makefile; fi && \
   if [ "${UNRAR_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/arm64" ]; \
-    then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=armv8-a|" makefile; fi && \
+    then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=armv8-a+crypto+crc|" makefile; fi && \
   if [ "${UNRAR_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/arm/v7" ]; \
     then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=armv7-a|" makefile; fi && \
   make -j ${MAKE_JOBS} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ FROM alpine:3.19.1 AS build
 # args
 ARG NZBGET_RELEASE=develop
 ARG UNRAR_VERSION=7.0.7
+ARG UNRAR6_VERSION=6.2.12
 ARG UNRAR_NATIVE=false
 ARG MAKE_JOBS=1
 ARG TARGETPLATFORM
@@ -46,7 +47,7 @@ RUN \
   curl -o /app/nzbget/cacert.pem -L "https://curl.se/ca/cacert.pem" && \
   echo "**** install unrar from source ****" && \
   mkdir /tmp/unrar && \
-  curl -o /tmp/unrar.tar.gz -L "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \  
+  curl -o /tmp/unrar.tar.gz -L "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \
   tar xf /tmp/unrar.tar.gz -C /tmp/unrar --strip-components=1 && \
   cd /tmp/unrar && \
   if [ "${UNRAR_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/amd64" ]; \
@@ -56,7 +57,14 @@ RUN \
   if [ "${UNRAR_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/arm/v7" ]; \
     then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=armv7-a|" makefile; fi && \
   make -j ${MAKE_JOBS} && \
-  install -v -m755 unrar /usr/bin
+  install -v -m755 unrar /usr/bin && \
+  echo "**** install unrar6 from source ****" && \
+  mkdir /tmp/unrar6 && \
+  curl -o /tmp/unrar6.tar.gz -L "https://www.rarlab.com/rar/unrarsrc-${UNRAR6_VERSION}.tar.gz" && \
+  tar xf /tmp/unrar6.tar.gz -C /tmp/unrar6 --strip-components=1 && \
+  cd /tmp/unrar6 && \
+  make -j ${MAKE_JOBS} && \
+  install -v -m755 unrar /usr/bin/unrar6
 
 # runtime stage
 FROM alpine:3.19.1
@@ -75,6 +83,7 @@ RUN \
   echo "**** cleanup ****" && \
   rm -rf /root/.cache /root/.cargo /tmp/*
 COPY --from=build /usr/bin/unrar /usr/bin/unrar
+COPY --from=build /usr/bin/unrar6 /usr/bin/unrar6
 COPY --from=build /app/nzbget/ /app/nzbget/
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,9 +3,9 @@ FROM alpine:3.19.1 AS build
 
 # args
 ARG NZBGET_RELEASE=develop
-ARG UNRAR_VERSION=7.0.7
 ARG UNRAR6_VERSION=6.2.12
-ARG UNRAR_NATIVE=false
+ARG UNRAR7_VERSION=7.0.7
+ARG UNRAR7_NATIVE=false
 ARG MAKE_JOBS=1
 ARG TARGETPLATFORM
 
@@ -45,26 +45,26 @@ RUN \
   ln -s /usr/bin/unrar /app/nzbget/unrar && \
   cp /nzbget/pubkey.pem /app/nzbget/pubkey.pem && \
   curl -o /app/nzbget/cacert.pem -L "https://curl.se/ca/cacert.pem" && \
-  echo "**** install unrar from source ****" && \
-  mkdir /tmp/unrar && \
-  curl -o /tmp/unrar.tar.gz -L "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \
-  tar xf /tmp/unrar.tar.gz -C /tmp/unrar --strip-components=1 && \
-  cd /tmp/unrar && \
-  if [ "${UNRAR_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/amd64" ]; \
+  echo "**** install unrar7 from source ****" && \
+  mkdir /tmp/unrar7 && \
+  curl -o /tmp/unrar7.tar.gz -L "https://www.rarlab.com/rar/unrarsrc-${UNRAR7_VERSION}.tar.gz" && \
+  tar xf /tmp/unrar7.tar.gz -C /tmp/unrar7 --strip-components=1 && \
+  cd /tmp/unrar7 && \
+  if [ "${UNRAR7_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/amd64" ]; \
     then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=x86-64-v2|" makefile; fi && \
-  if [ "${UNRAR_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/arm64" ]; \
+  if [ "${UNRAR7_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/arm64" ]; \
     then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=armv8-a+crypto+crc|" makefile; fi && \
-  if [ "${UNRAR_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/arm/v7" ]; \
+  if [ "${UNRAR7_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/arm/v7" ]; \
     then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=armv7-a|" makefile; fi && \
   make -j ${MAKE_JOBS} && \
-  install -v -m755 unrar /usr/bin && \
+  install -v -m755 unrar /usr/bin/unrar7 && \
   echo "**** install unrar6 from source ****" && \
   mkdir /tmp/unrar6 && \
   curl -o /tmp/unrar6.tar.gz -L "https://www.rarlab.com/rar/unrarsrc-${UNRAR6_VERSION}.tar.gz" && \
   tar xf /tmp/unrar6.tar.gz -C /tmp/unrar6 --strip-components=1 && \
   cd /tmp/unrar6 && \
   make -j ${MAKE_JOBS} && \
-  install -v -m755 unrar /usr/bin/unrar6
+  install -v -m755 unrar /usr/bin/
 
 # runtime stage
 FROM alpine:3.19.1
@@ -83,7 +83,7 @@ RUN \
   echo "**** cleanup ****" && \
   rm -rf /root/.cache /root/.cargo /tmp/*
 COPY --from=build /usr/bin/unrar /usr/bin/unrar
-COPY --from=build /usr/bin/unrar6 /usr/bin/unrar6
+COPY --from=build /usr/bin/unrar7 /usr/bin/unrar7
 COPY --from=build /app/nzbget/ /app/nzbget/
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -128,6 +128,8 @@ Unrar 7 built with next march parameters:
 - arm64:  armv8-a+crypto+crc
 - armhf:  armv7-a
 
+More information about unrar performance: [Performance tips](https://github.com/nzbgetcom/nzbget/blob/develop/docs/PERFORMANCE.md#unrar)
+
 # Native unrar 7 build support
 
 To build image on hardware which support crypto acceleration with native-optimized unrar can be used docker-compose like this (also needed entrypoint.sh and Dockerfile from [official repository](https://github.com/nzbgetcom/nzbget/tree/develop/docker)):

--- a/docker/README.md
+++ b/docker/README.md
@@ -99,8 +99,9 @@ Dockerfile supports next build arguments:
 | Argument	      | Description
 |:----------------|-
 | NZBGET_RELEASE  | Branch name or tag to build from
-| UNRAR_VERSION   | Unrar version
-| UNRAR_NATIVE    | Build native unrar (see below)
+| UNRAR6_VERSION  | Unrar 6 version
+| UNRAR7_VERSION  | Unrar 7 version
+| UNRAR7_NATIVE   | Build native unrar (see below)
 | MAKE_JOBS       | Number of make jobs for speed up build
 
 # ghcr.io
@@ -118,14 +119,16 @@ In case a linux image or docker image is slower than expected, here are some tip
 1. Increase number of server connections (NEWS-SERVERS -> Connections) - default is 8, and 16 and 32 are worth trying
 2. For slower machines/hosts - increase article read chunk size from 4 to 64 (CONNECTION -> ArticleReadChunkSize). This is new setting available in v23.
 
-# Native unrar build support
+# Unrar 7 support
 
-Unrar from version 7.0 supports hardware crypto acceleration for unpacking encrypted archives.
-For compatibility with most hardware nzbgetcom image unrar built with next march parameters:
+The NZBGet docker image contains the optimized unrar7 binary. To use unrar7, change in settings UNPACK - UnrarCmd to `unrar7`.
+Unrar 7 built with next march parameters:
 
 - x86_64: x86-64-v2
-- arm64:  armv8-a
+- arm64:  armv8-a+crypto+crc
 - armhf:  armv7-a
+
+# Native unrar 7 build support
 
 To build image on hardware which support crypto acceleration with native-optimized unrar can be used docker-compose like this (also needed entrypoint.sh and Dockerfile from [official repository](https://github.com/nzbgetcom/nzbget/tree/develop/docker)):
 
@@ -142,7 +145,7 @@ services:
         # make jobs == host cpu cores
         MAKE_JOBS: 4
         # build native unrar
-        UNRAR_NATIVE: "true"
+        UNRAR7_NATIVE: "true"
     environment:
       - PUID=1000
       - PGID=1000
@@ -156,7 +159,3 @@ services:
       - 6789:6789
     restart: unless-stopped
 ```
-
-# Unrar 6 support
-
-The NZBGet docker image contains the unrar6 binary for systems that do not support unrar7. To use unrar6, change in settings UNPACK - UnrarCmd to `unrar6`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -156,3 +156,7 @@ services:
       - 6789:6789
     restart: unless-stopped
 ```
+
+# Unrar 6 support
+
+The NZBGet docker image contains the unrar6 binary for systems that do not support unrar7. To use unrar6, change in settings UNPACK - UnrarCmd to `unrar6`.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         NZBGET_RELEASE: develop
         MAKE_JOBS: 4
-        UNRAR_NATIVE: true
+        UNRAR7_NATIVE: true
     environment:
       - PUID=1000
       - PGID=1000

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,29 +23,23 @@ if [ ! -f /config/nzbget.conf ]; then
     chown user:users /config/nzbget.conf
 fi
 
-# create scripts dir
-if [ ! -d /downloads/scripts ]; then
-    mkdir -p /downloads/scripts
-    chown user:users /downloads/scripts
-fi
-
 # parse env vars to options
 OPTIONS=""
 if [ ! -z "${NZBGET_USER}" ]; then
-  OPTIONS="${OPTIONS}-o ControlUsername=${NZBGET_USER} "
+    OPTIONS="${OPTIONS}-o ControlUsername=${NZBGET_USER} "
 fi
 if [ ! -z "${NZBGET_PASS}" ]; then
-  OPTIONS="${OPTIONS}-o ControlPassword=${NZBGET_PASS} "
+    OPTIONS="${OPTIONS}-o ControlPassword=${NZBGET_PASS} "
 fi
 
 chown user:users /config || CONFIG_CHOWN_STATUS=$?
 if [ ! -z $CONFIG_CHOWN_STATUS ]; then
-  echo "*** Could not set permissions on /config ; this container may not work as expected ***"
+    echo "*** Could not set permissions on /config ; this container may not work as expected ***"
 fi
 
 chown user:users /downloads || DOWNLOADS_CHOWN_STATUS=$?
 if [ ! -z $DOWNLOADS_CHOWN_STATUS ]; then
-  echo "*** Could not set permissions on /downloads ; this container may not work as expected ***"
+    echo "*** Could not set permissions on /downloads ; this container may not work as expected ***"
 fi
 
 su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -33,7 +33,7 @@ Several tests (`time unrar -p<password> x <archive>`, archive size ~1.6Gb):
     user    0m 12.08s
     sys     0m 1.27s
     ```
-  - unrar7 (march=x86-64-v2)
+  - unrar 7.0 march=x86-64-v2
     ```
     real    0m 6.13s
     user    0m 5.34s

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,44 @@
+# NZBGet performance tips (WIP)
+
+## Unrar
+
+Unrar from version 7 provides improved performance when extracting encrypted archives, especially when built with optimized march.
+
+Several tests (`time unrar -p<password> x <archive>`, archive size ~1.6Gb):
+
+- arm64 (Mac mini M2)
+  - unrar 6.24
+    ```
+    real    0m 27.71s
+    user    0m 25.00s
+    sys     0m 1.41s
+    ```
+  - unrar 7.0 march=armv8-a
+    ```
+    real    0m 11.04s
+    user    0m 9.28s
+    sys     0m 1.19s
+    ```
+  - unrar 7.0 march=armv8-a+crypto+crc
+    ```
+    real    0m 6.04s
+    user    0m 3.59s
+    sys     0m 1.48s
+    ```
+
+- x86_64 (Intel Xeon E3-1265L V2)
+  - unrar 6.24
+    ```
+    real    0m 13.51s
+    user    0m 12.08s
+    sys     0m 1.27s
+    ```
+  - unrar7 (march=x86-64-v2)
+    ```
+    real    0m 6.13s
+    user    0m 5.34s
+    sys     0m 1.90s
+    ```
+
+Extraction speed is increased by ~2x and ~4.5x when using the optimized binary.
+The NZBGet docker container includes unrar6 (used by default, for most compatibility), and an optimized unrar7 (can be enabled in the settings). More information can be found in [Docker readme](../docker/README.md#unrar-7-support)


### PR DESCRIPTION
## Description

- added back unrar6 to docker container, unrar6 is default now
- replaced build flags for arm64 unrar7 (inspired by #216), unrar7 is now optional
- updated docker readme, added PERFORMANCE.md and unrar 6/7 information
- removed create `scripts` directory on startup (it is created by nzbget daemon on demand)
- fixes #255
- fixes #248

## Testing

tested by @phnzb on
- Ubuntu 22.04.4 LTS / Docker 26.0.0
- macOS Sonoma 14.4.1 / Docker 26.0.0