### PR TITLE
Check if `nzbget` proc is already running before starting on QNAP

### DIFF
--- a/qnap/package/shared/nzbget.sh
+++ b/qnap/package/shared/nzbget.sh
@@ -12,6 +12,12 @@ case "$1" in
         echo "$QPKG_NAME is disabled."
         exit 1
     fi
+
+    if /bin/pidof nzbget &>/dev/null; then
+        echo "$QPKG_NAME is already running."
+        exit 0
+    fi
+
     cd $QPKG_ROOT/nzbget
     $QPKG_ROOT/nzbget/nzbget -c $QPKG_ROOT/nzbget/nzbget.conf -D
     ;;


### PR DESCRIPTION
- Minor observation: it's currently possible to launch another instance if this is tried twice. First time, doesn't work. Run a second time and now there's a new instance with no listening port.
- This change should prevent multiple instances being launched.
