### PR TITLE
Fix: parcheck dependency checking is always enabled even if parcheck is disabled

### DIFF
--- a/cmake/posix.cmake
+++ b/cmake/posix.cmake
@@ -148,12 +148,12 @@ if(NOT DISABLE_CURSES)
 	set(HAVE_NCURSES_H 1)
 endif()
 
-if(NOT DISABLED_PARCHECK)
+if(NOT DISABLE_PARCHECK)
 	check_type_size(size_t SIZE_T)
 	check_symbol_exists(fseeko "stdio.h" HAVE_FSEEKO)
 	check_function_exists(getopt HAVE_GETOPT)
 else() 
-  set(DISABLED_PARCHECK 1)
+  set(DISABLE_PARCHECK 1)
 endif()
 
 # check ctime_r


### PR DESCRIPTION
## Description

- fixed a typo in CMake that caused parcheck dependencies to always be checked even if parcheck was disabled.

## Testing

- Linux Debian 12;
- macOS Ventura;
- FreeBSD 13.