### PR TITLE
Fix: fseeko not found on some systems

### DIFF
--- a/cmake/posix.cmake
+++ b/cmake/posix.cmake
@@ -150,7 +150,7 @@ endif()
 
 if(NOT DISABLE_PARCHECK)
 	check_type_size(size_t SIZE_T)
-	check_symbol_exists(fseeko "stdio.h" HAVE_FSEEKO)
+	check_function_exists(fseeko HAVE_FSEEKO)
 	check_function_exists(getopt HAVE_GETOPT)
 else() 
   set(DISABLE_PARCHECK 1)


### PR DESCRIPTION
## Description

- it's needed to use a more appropriate CMake command (check_function_exists rather than check_symbol_exists) 
to look for the fseeko function as on some systems it may have been falsely not found.


## Testing

- Linux Debian 12;
- FreeBSD 13;
- macOS Ventura.