### PR TITLE
fix: fixed icons in old browsers

### DIFF
--- a/webui/style.css
+++ b/webui/style.css
@@ -24,9 +24,8 @@ html {
 @font-face {
 	font-family: 'Material Icons';
 	font-style: normal;
-	font-weight: 100 700;
-	src: local('material-icons'),
-		 url(lib/material-icons.woff2) format('woff2'),
+	font-weight: normal;
+    src: url(lib/material-icons.woff2) format('woff2');
 }
 
 .material-icon {


### PR DESCRIPTION
## Description

- fixed new icons in old browsers.

## Testing

- Google Chrome 68/115/116;
- Safari 14/15/17;
- Firefox 115. 