### PR TITLE
added v24 versions into issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -14,11 +14,17 @@ body:
     label: NZBGet Version
     description: Which version of NZBGet has this bug?
     options:
+    - v24.1-stable
+    - v24.1-testing
+    - v24-stable
+    - v24-testing
     - v23-stable
     - v23-testing
     - v22-stable (nzbgetcom takeover)
     - v22-testing (nzbgetcom takeover)
     - v21 or earlier (orignal nzbget)
+    - latest-stable (if not listed here)
+    - latest-testing (if not listed here)
   validations:
     required: true
 - type: dropdown

--- a/.github/ISSUE_TEMPLATE/03_build.yml
+++ b/.github/ISSUE_TEMPLATE/03_build.yml
@@ -7,11 +7,17 @@ body:
     label: NZBGet Version
     description: Version of NZBGet for the scope of this issue
     options:
+    - v24.1-stable
+    - v24.1-testing
+    - v24-stable
+    - v24-testing
     - v23-stable
     - v23-testing
     - v22-stable (nzbgetcom takeover)
     - v22-testing (nzbgetcom takeover)
     - v21 or earlier (orignal nzbget)
+    - latest-stable (if not listed here)
+    - latest-testing (if not listed here)
   validations:
     required: true
 - type: dropdown


### PR DESCRIPTION
## Description

Issue templates are missing latest nzbget versions.

## Lib changes

None

## Testing

None, hoping it's difficult to mess up.