### PR TITLE
feature/local dockerfile build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,8 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v5
       with:
-        context: docker
+        context: .
+        file: docker/Dockerfile
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         provenance: false
         push: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,42 +9,13 @@ ARG UNRAR7_NATIVE=false
 ARG MAKE_JOBS=1
 ARG TARGETPLATFORM
 
+#install build packages
 RUN \
   echo "**** install build packages ****" && \
-  apk add g++ gcc git libxml2-dev libxslt-dev make ncurses-dev openssl-dev boost-dev curl cmake && \
-  echo "**** build nzbget ****" && \
-  mkdir -p /app/nzbget && \
-  git clone https://github.com/nzbgetcom/nzbget.git nzbget && \
-  cd nzbget/ && \
-  git checkout ${NZBGET_RELEASE} && \
-  mkdir -p build && \
-  cd build && \
-  cmake .. -DCMAKE_INSTALL_PREFIX=/app/nzbget && \
-  cmake --build . -j ${MAKE_JOBS} && \
-  cmake --install . && \
-  mv /app/nzbget/bin/nzbget /app/nzbget/ && \
-  rm -rf /app/nzbget/bin/ && \
-  rm -rf /app/nzbget/etc/ && \
-  sed -i \
-    -e "s|^MainDir=.*|MainDir=/downloads|g" \
-    -e "s|^ScriptDir=.*|ScriptDir=$\{MainDir\}/scripts|g" \
-    -e "s|^WebDir=.*|WebDir=$\{AppDir\}/webui|g" \
-    -e "s|^ConfigTemplate=.*|ConfigTemplate=$\{AppDir\}/webui/nzbget.conf.template|g" \
-    -e "s|^UnrarCmd=.*|UnrarCmd=unrar|g" \
-    -e "s|^SevenZipCmd=.*|SevenZipCmd=7z|g" \
-    -e "s|^CertStore=.*|CertStore=$\{AppDir\}/cacert.pem|g" \
-    -e "s|^CertCheck=.*|CertCheck=yes|g" \
-    -e "s|^DestDir=.*|DestDir=$\{MainDir\}/completed|g" \
-    -e "s|^InterDir=.*|InterDir=$\{MainDir\}/intermediate|g" \
-    -e "s|^LogFile=.*|LogFile=$\{MainDir\}/nzbget.log|g" \
-    -e "s|^AuthorizedIP=.*|AuthorizedIP=127.0.0.1|g" \
-  /app/nzbget/share/nzbget/nzbget.conf && \
-  mv /app/nzbget/share/nzbget/webui /app/nzbget/ && \
-  cp /app/nzbget/share/nzbget/nzbget.conf /app/nzbget/webui/nzbget.conf.template && \
-  ln -s /usr/bin/7z /app/nzbget/7za && \
-  ln -s /usr/bin/unrar /app/nzbget/unrar && \
-  cp /nzbget/pubkey.pem /app/nzbget/pubkey.pem && \
-  curl -o /app/nzbget/cacert.pem -L "https://curl.se/ca/cacert.pem" && \
+  apk add g++ gcc git libxml2-dev libxslt-dev make ncurses-dev openssl-dev boost-dev curl cmake
+
+#install archive packages
+RUN \
   echo "**** install unrar7 from source ****" && \
   mkdir /tmp/unrar7 && \
   curl -o /tmp/unrar7.tar.gz -L "https://www.rarlab.com/rar/unrarsrc-${UNRAR7_VERSION}.tar.gz" && \
@@ -66,6 +37,41 @@ RUN \
   make -j ${MAKE_JOBS} && \
   install -v -m755 unrar /usr/bin/
 
+#build nzbget
+ADD ./ nzbget
+RUN \
+  echo "**** build nzbget ****" && \
+  mkdir -p /app/nzbget && \
+  mkdir -p /nzbget/build && \
+  cd /nzbget/build && \
+  cmake .. -DCMAKE_INSTALL_PREFIX=/app/nzbget && \
+  cmake --build . -j ${MAKE_JOBS} && \
+  cmake --install . && \
+  mv /app/nzbget/bin/nzbget /app/nzbget/ && \
+  rm -rf /app/nzbget/bin/ && \
+  rm -rf /app/nzbget/etc/ && \
+  mv /app/nzbget/share/nzbget/webui /app/nzbget/ && \
+  cp /app/nzbget/share/nzbget/nzbget.conf /app/nzbget/webui/nzbget.conf.template && \ 
+  cp /nzbget/pubkey.pem /app/nzbget/pubkey.pem && \
+  curl -o /app/nzbget/cacert.pem -L "https://curl.se/ca/cacert.pem"
+
+#change default configvalues
+RUN \
+  sed -i \
+    -e "s|^MainDir=.*|MainDir=/downloads|g" \
+    -e "s|^ScriptDir=.*|ScriptDir=$\{MainDir\}/scripts|g" \
+    -e "s|^WebDir=.*|WebDir=$\{AppDir\}/webui|g" \
+    -e "s|^ConfigTemplate=.*|ConfigTemplate=$\{AppDir\}/webui/nzbget.conf.template|g" \
+    -e "s|^UnrarCmd=.*|UnrarCmd=unrar|g" \
+    -e "s|^SevenZipCmd=.*|SevenZipCmd=7z|g" \
+    -e "s|^CertStore=.*|CertStore=$\{AppDir\}/cacert.pem|g" \
+    -e "s|^CertCheck=.*|CertCheck=yes|g" \
+    -e "s|^DestDir=.*|DestDir=$\{MainDir\}/completed|g" \
+    -e "s|^InterDir=.*|InterDir=$\{MainDir\}/intermediate|g" \
+    -e "s|^LogFile=.*|LogFile=$\{MainDir\}/nzbget.log|g" \
+    -e "s|^AuthorizedIP=.*|AuthorizedIP=127.0.0.1|g" \
+  /app/nzbget/share/nzbget/nzbget.conf
+
 # runtime stage
 FROM alpine:3.19.1
 ARG NZBGET_RELEASE=develop
@@ -85,7 +91,7 @@ RUN \
 COPY --from=build /usr/bin/unrar /usr/bin/unrar
 COPY --from=build /usr/bin/unrar7 /usr/bin/unrar7
 COPY --from=build /app/nzbget/ /app/nzbget/
-ADD entrypoint.sh /entrypoint.sh
+ADD docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && \
   echo "**** create non-root user ****" && \
   adduser -G users -D -u 1000 -h /config -s /bin/sh user && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -84,7 +84,7 @@ uid=1000(user) gid=1000(users) groups=1000(users)
 
 # Building locally
 
-For development purposes the Docker Image can be build using the localy cloned repository (`docker` folder): 
+For development purposes the Docker Image can be build using the locally cloned repository (`docker` folder): 
 
 ```
 git clone https://github.com/nzbgetcom/nzbget.git

--- a/docker/README.md
+++ b/docker/README.md
@@ -84,13 +84,13 @@ uid=1000(user) gid=1000(users) groups=1000(users)
 
 # Building locally
 
-For development purposes can be used Dockerfile or docker-compose file from official repository (`docker` folder): 
+For development purposes the Docker Image can be build using the localy cloned repository (`docker` folder): 
 
 ```
 git clone https://github.com/nzbgetcom/nzbget.git
-cd docker
-docker compose up
+docker compose -f docker/docker-compose.yml up --build
 -or-
+cd docker
 docker build . -t nzbget-local
 ```
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,8 @@
 services:
   nzbget:
     build:
-      context: .
+      context: ../
+      dockerfile: docker/Dockerfile
       args:
         NZBGET_RELEASE: develop
         MAKE_JOBS: 4


### PR DESCRIPTION
switch docker instructions to build the image using the localy cloned repository. Split the Dockerfile run instruction make the local docker-filesystem layers cachable. ~50% build speedup on 4 core vm.