### PR TITLE
 Remove the use of Boost.Variant and Boost.Optional

### DIFF
--- a/daemon/extension/Extension.cpp
+++ b/daemon/extension/Extension.cpp
@@ -271,11 +271,11 @@ namespace Extension
 			optionJson["Multi"] = option.section.multi;
 			optionJson["Prefix"] = option.section.prefix;
 
-			if (const std::string* val = boost::variant2::get_if<std::string>(&option.value))
+			if (const std::string* val = std::get_if<std::string>(&option.value))
 			{
 				optionJson["Value"] = *val;
 			}
-			else if (const double* val = boost::variant2::get_if<double>(&option.value))
+			else if (const double* val = std::get_if<double>(&option.value))
 			{
 				optionJson["Value"] = *val;
 			}
@@ -287,11 +287,11 @@ namespace Extension
 
 			for (const auto& value : option.select)
 			{
-				if (const std::string* val = boost::variant2::get_if<std::string>(&value))
+				if (const std::string* val = std::get_if<std::string>(&value))
 				{
 					selectJson.push_back(Json::JsonValue(*val));
 				}
-				else if (const double* val = boost::variant2::get_if<double>(&value))
+				else if (const double* val = std::get_if<double>(&value))
 				{
 					selectJson.push_back(Json::JsonValue(*val));
 				}
@@ -396,11 +396,11 @@ namespace Extension
 			AddNewNode(optionsNode, "Section", "string", option.section.name.c_str());
 			AddNewNode(optionsNode, "Prefix", "string", option.section.prefix.c_str());
 
-			if (const std::string* val = boost::variant2::get_if<std::string>(&option.value))
+			if (const std::string* val = std::get_if<std::string>(&option.value))
 			{
 				AddNewNode(optionsNode, "Value", "string", val->c_str());
 			}
-			else if (const double* val = boost::variant2::get_if<double>(&option.value))
+			else if (const double* val = std::get_if<double>(&option.value))
 			{
 				AddNewNode(optionsNode, "Value", "number", std::to_string(*val).c_str());
 			}
@@ -408,11 +408,11 @@ namespace Extension
 			xmlNodePtr selectNode = xmlNewNode(NULL, BAD_CAST "Select");
 			for (const auto& selectOption : option.select)
 			{
-				if (const std::string* val = boost::variant2::get_if<std::string>(&selectOption))
+				if (const std::string* val = std::get_if<std::string>(&selectOption))
 				{
 					AddNewNode(selectNode, "Value", "string", val->c_str());
 				}
-				else if (const double* val = boost::variant2::get_if<double>(&selectOption))
+				else if (const double* val = std::get_if<double>(&selectOption))
 				{
 					AddNewNode(selectNode, "Value", "number", std::to_string(*val).c_str());
 				}

--- a/daemon/extension/ExtensionLoader.cpp
+++ b/daemon/extension/ExtensionLoader.cpp
@@ -301,7 +301,7 @@ namespace ExtensionLoader
 					{
 						ManifestFile::Option option{};
 						ParseSectionAndSet<ManifestFile::Option>(option, currSectionName, line, eqPos);
-						bool canBeNum = !selectOpts.empty() && boost::variant2::get_if<double>(&selectOpts[0]);
+						bool canBeNum = !selectOpts.empty() && std::get_if<double>(&selectOpts[0]);
 						std::string value = line.substr(eqPos + 1);
 						Util::Trim(value);
 						option.value = GetSelectOpt(value, canBeNum);
@@ -338,7 +338,7 @@ namespace ExtensionLoader
 			auto result = Util::StrToNum(val);
 			if (result.has_value())
 			{
-				return ManifestFile::SelectOption(result.get());
+				return ManifestFile::SelectOption(result.value());
 			}
 
 			return ManifestFile::SelectOption(val);

--- a/daemon/extension/ExtensionManager.cpp
+++ b/daemon/extension/ExtensionManager.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -55,7 +55,7 @@ namespace ExtensionManager
 		return std::make_pair(status, std::move(tmpFileName));
 	}
 
-	boost::optional<std::string>
+	std::optional<std::string>
 	Manager::UpdateExtension(const std::string& filename, const std::string& extName)
 	{
 		std::unique_lock<std::shared_mutex> lock{m_mutex};
@@ -89,10 +89,10 @@ namespace ExtensionManager
 		}
 
 		m_extensions.erase(extensionIt);
-		return boost::none;
+		return std::nullopt;
 	}
 
-	boost::optional<std::string> 
+	std::optional<std::string> 
 	Manager::InstallExtension(const std::string& filename, const std::string& dest)
 	{
 		if (Util::EmptyStr(g_Options->GetSevenZipCmd()))
@@ -129,10 +129,10 @@ namespace ExtensionManager
 			return "Failed to delete temp file: " + filename;
 		}
 
-		return boost::none;
+		return std::nullopt;
 	}
 
-	boost::optional<std::string>
+	std::optional<std::string>
 	Manager::DeleteExtension(const std::string& name)
 	{
 		std::unique_lock<std::shared_mutex> lock{m_mutex};
@@ -155,10 +155,10 @@ namespace ExtensionManager
 		}
 
 		m_extensions.erase(extensionIt);
-		return boost::none;
+		return std::nullopt;
 	}
 
-	boost::optional<std::string>
+	std::optional<std::string>
 	Manager::LoadExtensions()
 	{
 		const char* scriptDir = g_Options->GetScriptDir();
@@ -181,10 +181,10 @@ namespace ExtensionManager
 		CreateTasks();
 		m_extensions.shrink_to_fit();
 
-		return boost::none;
+		return std::nullopt;
 	}
 
-	boost::optional<std::string>
+	std::optional<std::string>
 	Manager::DeleteExtension(const Extension::Script& ext)
 	{
 		const char* location = ext.GetLocation();
@@ -208,14 +208,14 @@ namespace ExtensionManager
 			CString err;
 			if (!FileSystem::DeleteDirectoryWithContent(location, err))
 			{
-				return boost::optional<std::string>(err.Str());
+				return std::optional<std::string>(err.Str());
 			}
 
-			return boost::none;
+			return std::nullopt;
 		}
 		else if (FileSystem::FileExists(location) && FileSystem::DeleteFile(location))
 		{
-			return boost::none;
+			return std::nullopt;
 		}
 
 		return std::string("Failed to delete ") + location;

--- a/daemon/extension/ExtensionManager.h
+++ b/daemon/extension/ExtensionManager.h
@@ -24,7 +24,7 @@
 #include <utility>
 #include <memory>
 #include <shared_mutex>
-#include <boost/optional.hpp>
+#include <optional>
 #include "WebDownloader.h"
 #include "Options.h"
 #include "Extension.h"
@@ -45,16 +45,16 @@ namespace ExtensionManager
 		Manager(Manager&&) = delete;
 		Manager& operator=(Manager&&) = delete;
 
-		boost::optional<std::string> 
+		std::optional<std::string> 
 		InstallExtension(const std::string& filename, const std::string& dest);
 
-		boost::optional<std::string> 
+		std::optional<std::string> 
 		UpdateExtension(const std::string& filename, const std::string& extName);
 
-		boost::optional<std::string>
+		std::optional<std::string>
 		DeleteExtension(const std::string& name);
 
-		boost::optional<std::string>
+		std::optional<std::string>
 		LoadExtensions();
 
 		std::pair<WebDownloader::EStatus, std::string>
@@ -69,7 +69,7 @@ namespace ExtensionManager
 		bool Exists(const std::string& name) const;
 		void Sort(const char* order);
 		std::string GetExtensionName(const std::string& fileName) const;
-		boost::optional<std::string>
+		std::optional<std::string>
 		DeleteExtension(const Extension::Script& ext);
 
 		Extensions m_extensions;

--- a/daemon/extension/ManifestFile.h
+++ b/daemon/extension/ManifestFile.h
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -22,13 +22,13 @@
 
 #include <string>
 #include <vector>
-#include <boost/variant2.hpp>
+#include <variant>
 #include "Json.h"
 #include "Util.h"
 
 namespace ManifestFile
 {
-	using SelectOption = boost::variant2::variant<double, std::string>;
+	using SelectOption = std::variant<double, std::string>;
 
 	extern const char* MANIFEST_FILE;
 	extern const char* DEFAULT_SECTION_NAME;

--- a/daemon/main/nzbget.h
+++ b/daemon/main/nzbget.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -210,6 +211,8 @@ compiled */
 #include <shared_mutex>
 #include <condition_variable>
 #include <chrono>
+#include <optional>
+#include <variant>
 
 #include <libxml/parser.h>
 #include <libxml/xmlreader.h>

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -2731,7 +2732,7 @@ void LoadExtensionsXmlCommand::Execute()
 		const auto& error = g_ExtensionManager->LoadExtensions();
 		if (error)
 		{
-			BuildErrorResponse(3, error.get().c_str());
+			BuildErrorResponse(3, error.value().c_str());
 			return;
 		}	
 	}
@@ -2797,7 +2798,7 @@ void DownloadExtensionXmlCommand::Execute()
 	const auto error = g_ExtensionManager->InstallExtension(filename, scriptDir);
 	if (error)
 	{
-		BuildErrorResponse(3, error.get().c_str());
+		BuildErrorResponse(3, error.value().c_str());
 		return;
 	}
 
@@ -2834,7 +2835,7 @@ void UpdateExtensionXmlCommand::Execute()
 	const auto error = g_ExtensionManager->UpdateExtension(filename, extName);
 	if (error)
 	{
-		BuildErrorResponse(3, error.get().c_str());
+		BuildErrorResponse(3, error.value().c_str());
 		return;
 	}
 
@@ -2854,7 +2855,7 @@ void DeleteExtensionXmlCommand::Execute()
 	const auto error = g_ExtensionManager->DeleteExtension(extName);
 	if (error)
 	{
-		BuildErrorResponse(2, error.get().c_str());
+		BuildErrorResponse(2, error.value().c_str());
 		return;
 	}
 

--- a/daemon/util/ScriptController.cpp
+++ b/daemon/util/ScriptController.cpp
@@ -315,8 +315,8 @@ void ScriptController::PrepareArgs()
 		}
 		else
 		{
-			strncpy(m_cmdLine, found.get().c_str(), sizeof(m_cmdLine) - 1);
-			m_cmdArgs.emplace_back(found.get().c_str());
+			strncpy(m_cmdLine, found.value().c_str(), sizeof(m_cmdLine) - 1);
+			m_cmdArgs.emplace_back(found.value().c_str());
 		}
 	}
 	else

--- a/daemon/util/Util.cpp
+++ b/daemon/util/Util.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -114,7 +114,7 @@ void Util::Init()
 	CurrentTicks();
 }
 
-boost::optional<std::string> 
+std::optional<std::string> 
 Util::FindExecutorProgram(const std::string& filename, const std::string& customPath)
 {
 	size_t idx = filename.find_last_of(".");
@@ -164,7 +164,7 @@ Util::FindExecutorProgram(const std::string& filename, const std::string& custom
 		{
 			return std::string("py");
 		}
-		return boost::none;
+		return std::nullopt;
 	}
 
 	if (fileExt == ".sh")
@@ -179,7 +179,7 @@ Util::FindExecutorProgram(const std::string& filename, const std::string& custom
 		{
 			return std::string("sh");
 		}
-		return boost::none;
+		return std::nullopt;
 	}
 
 	if (fileExt == ".js")
@@ -189,7 +189,7 @@ Util::FindExecutorProgram(const std::string& filename, const std::string& custom
 		{
 			return std::string("node");
 		}
-		return boost::none;
+		return std::nullopt;
 	}
 
 	if (fileExt == ".cmd" || fileExt == ".bat")
@@ -199,7 +199,7 @@ Util::FindExecutorProgram(const std::string& filename, const std::string& custom
 		{
 			return filename;
 		}
-		return boost::none;
+		return std::nullopt;
 	}
 
 	if (fileExt == ".exe")
@@ -221,7 +221,7 @@ void Util::SplitInt64(int64 Int64, uint32* Hi, uint32* Lo)
 	*Lo = (uint32)(Int64 & 0xFFFFFFFF);
 }
 
-boost::optional<double> 
+std::optional<double> 
 Util::StrToNum(const std::string& str)
 {
 	std::istringstream ss(str);
@@ -231,13 +231,13 @@ Util::StrToNum(const std::string& str)
 	{
 		if (!ss.eof()) 
 		{
-			return boost::none;
+			return std::nullopt;
 		}
 
-		return boost::optional<double>{ num };
+		return { num };
 	}
 
-	return boost::none;
+	return std::nullopt;
 }
 
 /* Base64 decryption is taken from

--- a/daemon/util/Util.h
+++ b/daemon/util/Util.h
@@ -22,7 +22,7 @@
 #ifndef UTIL_H
 #define UTIL_H
 
-#include <boost/optional.hpp>
+#include <optional>
 #include "NString.h"
 
 #ifdef WIN32
@@ -35,7 +35,7 @@ class Util
 {
 public:
 	static bool MatchFileExt(const char* filename, const char* extensionList, const char* listSeparator);
-	static boost::optional<std::string> 
+	static std::optional<std::string> 
 	FindExecutorProgram(const std::string& filename, const std::string& customPath);
 
 	/*
@@ -47,7 +47,7 @@ public:
 
 	static int64 JoinInt64(uint32 Hi, uint32 Lo);
 	static void SplitInt64(int64 Int64, uint32* Hi, uint32* Lo);
-	static boost::optional<double> StrToNum(const std::string& str);
+	static std::optional<double> StrToNum(const std::string& str);
 
 	static void TrimRight(char* str);
 	static void TrimRight(std::string& str);

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -19,7 +19,6 @@ Also required are:
    - [Zlib](https://gnuwin32.sourceforge.net/packages/zlib.htm)
    - [libxml2](https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home)
    - [Boost.JSON](https://www.boost.org/doc/libs/1_84_0/libs/json/doc/html/index.html)
-   - [Boost.Optional](https://www.boost.org/doc/libs/1_84_0/libs/optional/doc/html/index.html)
 
 For tests:
    - [Boost.Test](https://www.boost.org/doc/libs/1_84_0/libs/test/doc/html/index.html)
@@ -40,7 +39,6 @@ vcpkg install openssl:x64-windows-static
 vcpkg install libxml2:x64-windows-static
 vcpkg install zlib:x64-windows-static
 vcpkg install boost-json:x64-windows-static
-vcpkg install boost-optional:x64-windows-static
 ```
   - For tests:
 ```

--- a/tests/extension/ExtensionLoaderTest.cpp
+++ b/tests/extension/ExtensionLoaderTest.cpp
@@ -104,25 +104,25 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"Append list of files to the message.",
 			"Add the list of downloaded files (the content of destination directory)."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option.value) == "yes");
-	BOOST_CHECK(boost::variant2::get<std::string>(option.select[0]) == "yes");
-	BOOST_CHECK(boost::variant2::get<std::string>(option.select[1]) == "no");
+	BOOST_CHECK(std::get<std::string>(option.value) == "yes");
+	BOOST_CHECK(std::get<std::string>(option.select[0]) == "yes");
+	BOOST_CHECK(std::get<std::string>(option.select[1]) == "no");
 
 	auto option2 = extension.GetOptions()[1];
 	BOOST_CHECK(option2.name == "Port");
 	BOOST_CHECK(option2.displayName == "Port");
 	BOOST_CHECK(option2.description == std::vector<std::string>({ "SMTP server port (1-65535)." }));
-	BOOST_CHECK(boost::variant2::get<double>(option2.value) == 25.);
-	BOOST_CHECK(boost::variant2::get<double>(option2.select[0]) == 1.);
-	BOOST_CHECK(boost::variant2::get<double>(option2.select[1]) == 65535.);
+	BOOST_CHECK(std::get<double>(option2.value) == 25.);
+	BOOST_CHECK(std::get<double>(option2.select[0]) == 1.);
+	BOOST_CHECK(std::get<double>(option2.select[1]) == 65535.);
 
 	auto option3 = extension.GetOptions()[2];
 	BOOST_CHECK(option3.name == "SendMail");
 	BOOST_CHECK(option3.displayName == "SendMail");
 	BOOST_CHECK(option3.description == std::vector<std::string>({ "When to send the message." }));
-	BOOST_CHECK(boost::variant2::get<std::string>(option3.value) == "Always");
-	BOOST_CHECK(boost::variant2::get<std::string>(option3.select[0]) == "Always");
-	BOOST_CHECK(boost::variant2::get<std::string>(option3.select[1]) == "OnFailure");
+	BOOST_CHECK(std::get<std::string>(option3.value) == "Always");
+	BOOST_CHECK(std::get<std::string>(option3.select[0]) == "Always");
+	BOOST_CHECK(std::get<std::string>(option3.select[1]) == "OnFailure");
 
 	auto option4 = extension.GetOptions()[3];
 	BOOST_CHECK(option4.name == "Encryption");
@@ -133,10 +133,10 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 			" yes   - switch to secure session using StartTLS command;",
 			" force - start secure session on encrypted socket."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option4.value) == "yes");
-	BOOST_CHECK(boost::variant2::get<std::string>(option4.select[0]) == "yes");
-	BOOST_CHECK(boost::variant2::get<std::string>(option4.select[1]) == "no");
-	BOOST_CHECK(boost::variant2::get<std::string>(option4.select[2]) == "force");
+	BOOST_CHECK(std::get<std::string>(option4.value) == "yes");
+	BOOST_CHECK(std::get<std::string>(option4.select[0]) == "yes");
+	BOOST_CHECK(std::get<std::string>(option4.select[1]) == "no");
+	BOOST_CHECK(std::get<std::string>(option4.select[2]) == "force");
 
 	auto option5 = extension.GetOptions()[4];
 	BOOST_CHECK(option5.name == "To");
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"Email address you want this email to be sent to.",
 			"Multiple addresses can be separated with comma."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option5.value) == "myaccount@gmail.com");
+	BOOST_CHECK(std::get<std::string>(option5.value) == "myaccount@gmail.com");
 	BOOST_CHECK(option5.select.empty());
 
 	auto option6 = extension.GetOptions()[5];
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"Banned extensions.",
 			"Extensions must be separated by a comma (eg: .wmv, .divx)."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option6.value) == "");
+	BOOST_CHECK(std::get<std::string>(option6.value) == "");
 	BOOST_CHECK(option6.select.empty());
 
 	auto option7 = extension.GetOptions()[6];
@@ -165,34 +165,34 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"Common specifiers (for movies, series and dated tv shows):",
 			"{TEXT}          - lowercase the text."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option7.value) == "%t (%y)");
+	BOOST_CHECK(std::get<std::string>(option7.value) == "%t (%y)");
 	BOOST_CHECK(option7.select.empty());
 
 	auto option8 = extension.GetOptions()[7];
 	BOOST_CHECK(option8.name == "outputVideoExtension");
 	BOOST_CHECK(option8.displayName == "outputVideoExtension");
 	BOOST_CHECK(option8.description == std::vector<std::string>({ "ffmpeg output settings." }));
-	BOOST_CHECK(boost::variant2::get<std::string>(option8.value) == ".mp4");
+	BOOST_CHECK(std::get<std::string>(option8.value) == ".mp4");
 	BOOST_CHECK(option8.select.empty());
 
 	auto option9 = extension.GetOptions()[8];
 	BOOST_CHECK(option9.name == "outputVideoCodec");
 	BOOST_CHECK(option9.displayName == "outputVideoCodec");
 	BOOST_CHECK(option9.description.empty());
-	BOOST_CHECK(boost::variant2::get<std::string>(option9.value) == "libx264");
+	BOOST_CHECK(std::get<std::string>(option9.value) == "libx264");
 	BOOST_CHECK(option9.select.empty());
 
 	auto option10 = extension.GetOptions()[9];
 	BOOST_CHECK(option10.name == "outputDefault");
 	BOOST_CHECK(option10.displayName == "outputDefault");
 	BOOST_CHECK(option10.description == std::vector<std::string>({ "Output Default.", "description" }));
-	BOOST_CHECK(boost::variant2::get<std::string>(option10.value) == "None");
-	BOOST_CHECK(boost::variant2::get<std::string>(option10.select[0]) == "None");
-	BOOST_CHECK(boost::variant2::get<std::string>(option10.select[1]) == "iPad");
-	BOOST_CHECK(boost::variant2::get<std::string>(option10.select[2]) == "iPad-1080p");
-	BOOST_CHECK(boost::variant2::get<std::string>(option10.select[3]) == "iPad-720p");
-	BOOST_CHECK(boost::variant2::get<std::string>(option10.select[4]) == "Apple-TV2");
-	BOOST_CHECK(boost::variant2::get<std::string>(option10.select[5]) == "iPod");
+	BOOST_CHECK(std::get<std::string>(option10.value) == "None");
+	BOOST_CHECK(std::get<std::string>(option10.select[0]) == "None");
+	BOOST_CHECK(std::get<std::string>(option10.select[1]) == "iPad");
+	BOOST_CHECK(std::get<std::string>(option10.select[2]) == "iPad-1080p");
+	BOOST_CHECK(std::get<std::string>(option10.select[3]) == "iPad-720p");
+	BOOST_CHECK(std::get<std::string>(option10.select[4]) == "Apple-TV2");
+	BOOST_CHECK(std::get<std::string>(option10.select[5]) == "iPod");
 
 	auto option11 = extension.GetOptions()[10];
 	BOOST_CHECK(option11.name == "auto_update");
@@ -201,9 +201,9 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"Auto Update nzbToMedia.",
 		"description"
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option11.value) == "0");
-	BOOST_CHECK(boost::variant2::get<std::string>(option11.select[0]) == "0");
-	BOOST_CHECK(boost::variant2::get<std::string>(option11.select[1]) == "1");
+	BOOST_CHECK(std::get<std::string>(option11.value) == "0");
+	BOOST_CHECK(std::get<std::string>(option11.select[0]) == "0");
+	BOOST_CHECK(std::get<std::string>(option11.select[1]) == "1");
 
 	auto option12 = extension.GetOptions()[11];
 	BOOST_CHECK(option12.name == "niceness");
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"Niceness for external extraction process.",
 		"Set the Niceness value for the nice command (Linux). These range from -20 (most favorable to the process) to 19 (least favorable to the process)."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option12.value) == "10");
+	BOOST_CHECK(std::get<std::string>(option12.value) == "10");
 	BOOST_CHECK(option12.select.empty());
 
 	auto option13 = extension.GetOptions()[12];
@@ -222,11 +222,11 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"ionice scheduling class.",
 		"Set the ionice scheduling class (Linux). 0 for none, 1 for real time, 2 for best-effort, 3 for idle."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option13.value) == "2");
-	BOOST_CHECK(boost::variant2::get<std::string>(option13.select[0]) == "0");
-	BOOST_CHECK(boost::variant2::get<std::string>(option13.select[1]) == "1");
-	BOOST_CHECK(boost::variant2::get<std::string>(option13.select[2]) == "2");
-	BOOST_CHECK(boost::variant2::get<std::string>(option13.select[3]) == "3");
+	BOOST_CHECK(std::get<std::string>(option13.value) == "2");
+	BOOST_CHECK(std::get<std::string>(option13.select[0]) == "0");
+	BOOST_CHECK(std::get<std::string>(option13.select[1]) == "1");
+	BOOST_CHECK(std::get<std::string>(option13.select[2]) == "2");
+	BOOST_CHECK(std::get<std::string>(option13.select[3]) == "3");
 
 	auto option14 = extension.GetOptions()[13];
 	BOOST_CHECK(option14.name == "ionice_class");
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"ionice scheduling class.",
 		"Set the ionice scheduling class (0, 1, 2, 3)."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option14.value) == "2");
+	BOOST_CHECK(std::get<std::string>(option14.value) == "2");
 	BOOST_CHECK(option14.select.empty());
 
 	auto option15 = extension.GetOptions()[14];
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"Custom Plex Section(s) you would like to update [Optional].",
 		"Section Number(s) corresponding to your Plex library (comma separated)."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option15.value) == "");
+	BOOST_CHECK(std::get<std::string>(option15.value) == "");
 	BOOST_CHECK(option15.select.empty());
 
 	auto option16 = extension.GetOptions()[15];
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 		"(Test2).",
 		"description."
 		}));
-	BOOST_CHECK(boost::variant2::get<std::string>(option16.value) == "");
+	BOOST_CHECK(std::get<std::string>(option16.value) == "");
 	BOOST_CHECK(option16.select.empty());
 
 	auto option17 = extension.GetOptions()[16];
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 	BOOST_CHECK(option17.name == "Name");
 	BOOST_CHECK(option17.displayName == "Name");
 	BOOST_CHECK(option17.description == std::vector<std::string>({ "Name of the category to monitor." }));
-	BOOST_CHECK(boost::variant2::get<std::string>(option17.value) == "");
+	BOOST_CHECK(std::get<std::string>(option17.value) == "");
 	BOOST_CHECK(option17.select.empty());
 
 	auto option18 = extension.GetOptions()[17];
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 	BOOST_CHECK(option18.name == "DownloadRate");
 	BOOST_CHECK(option18.displayName == "DownloadRate");
 	BOOST_CHECK(option18.description == std::vector<std::string>({ "Speed limit for that category (KB)." }));
-	BOOST_CHECK(boost::variant2::get<std::string>(option18.value) == "0");
+	BOOST_CHECK(std::get<std::string>(option18.value) == "0");
 	BOOST_CHECK(option18.select.empty());
 
 	auto option19 = extension.GetOptions()[18];
@@ -285,6 +285,6 @@ BOOST_AUTO_TEST_CASE(ExtensionV1LoaderTest)
 	BOOST_CHECK(option19.name == "Name");
 	BOOST_CHECK(option19.displayName == "Name");
 	BOOST_CHECK(option19.description == std::vector<std::string>({ "Feed." }));
-	BOOST_CHECK(boost::variant2::get<std::string>(option19.value) == "");
+	BOOST_CHECK(std::get<std::string>(option19.value) == "");
 	BOOST_CHECK(option19.select.empty());
 }

--- a/tests/extension/ExtensionManagerTest.cpp
+++ b/tests/extension/ExtensionManagerTest.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(LoadExtesionsTest)
 	std::vector<std::string> correctOrder = { "Extension2", "Extension1", "email" };
 	ExtensionManager::Manager manager;
 
-	BOOST_REQUIRE(manager.LoadExtensions() == boost::none);
+	BOOST_REQUIRE(manager.LoadExtensions() == std::nullopt);
 	BOOST_REQUIRE(manager.GetExtensions().size() == 4);
 
 	for (size_t i = 0; i < manager.GetExtensions().size(); ++i)
@@ -78,12 +78,12 @@ BOOST_AUTO_TEST_CASE(ShouldNotDeleteExtensionIfExtensionIsBusyTest)
 	g_Options = &options;
 	ExtensionManager::Manager manager;
 
-	BOOST_REQUIRE(manager.LoadExtensions() == boost::none);
+	BOOST_REQUIRE(manager.LoadExtensions() == std::nullopt);
 
 	const auto busyExt = manager.GetExtensions()[0];
 
 	auto error = manager.DeleteExtension(busyExt->GetName());
 
 	BOOST_CHECK(error.has_value() == true);
-	BOOST_CHECK(error.get() == "Failed to delete: " + std::string(busyExt->GetName()) + " is executing");
+	BOOST_CHECK(error.value() == "Failed to delete: " + std::string(busyExt->GetName()) + " is executing");
 }

--- a/tests/extension/ManifestFileTest.cpp
+++ b/tests/extension/ManifestFileTest.cpp
@@ -68,9 +68,9 @@ BOOST_AUTO_TEST_CASE(ManifestFileTest)
 	BOOST_CHECK(option.name == "sendMail");
 	BOOST_CHECK(option.displayName == "SendMail");
 	BOOST_CHECK(option.description == std::vector<std::string>({ "When to send the message." }));
-	BOOST_CHECK(boost::variant2::get<std::string>(option.value) == "Always");
-	BOOST_CHECK(boost::variant2::get<std::string>(option.select[0]) == "Always");
-	BOOST_CHECK(boost::variant2::get<std::string>(option.select[1]) == "OnFailure");
+	BOOST_CHECK(std::get<std::string>(option.value) == "Always");
+	BOOST_CHECK(std::get<std::string>(option.select[0]) == "Always");
+	BOOST_CHECK(std::get<std::string>(option.select[1]) == "OnFailure");
 
 	auto& option2 = manifestFile.options[1];
 	BOOST_CHECK(option2.section.multi == false);
@@ -79,9 +79,9 @@ BOOST_AUTO_TEST_CASE(ManifestFileTest)
 	BOOST_CHECK(option2.name == "port");
 	BOOST_CHECK(option2.displayName == "Port");
 	BOOST_CHECK(option2.description == std::vector<std::string>({ "SMTP server port (1-65535)" }));
-	BOOST_CHECK(boost::variant2::get<double>(option2.value) == 25.);
-	BOOST_CHECK(boost::variant2::get<double>(option2.select[0]) == 1.);
-	BOOST_CHECK(boost::variant2::get<double>(option2.select[1]) == 65535.);
+	BOOST_CHECK(std::get<double>(option2.value) == 25.);
+	BOOST_CHECK(std::get<double>(option2.select[0]) == 1.);
+	BOOST_CHECK(std::get<double>(option2.select[1]) == 65535.);
 
 	auto& option3 = manifestFile.options[2];
 	BOOST_CHECK(option3.section.multi == true);
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(ManifestFileTest)
 	BOOST_CHECK(option3.name == "Category");
 	BOOST_CHECK(option3.displayName == "Category");
 	BOOST_CHECK(option3.description == std::vector<std::string>({ "Categories section" }));
-	BOOST_CHECK(boost::variant2::get<double>(option2.value) == 25.);
+	BOOST_CHECK(std::get<double>(option2.value) == 25.);
 
 	BOOST_REQUIRE(manifestFile.commands.size() == 2);
 

--- a/tests/util/UtilTest.cpp
+++ b/tests/util/UtilTest.cpp
@@ -121,9 +121,9 @@ BOOST_AUTO_TEST_CASE(RegExTest)
 
 BOOST_AUTO_TEST_CASE(StrToNumTest)
 {
-	BOOST_CHECK(Util::StrToNum("3.14").get() == 3.14);
-	BOOST_CHECK(Util::StrToNum("3.").get() == 3.0);
-	BOOST_CHECK(Util::StrToNum("3").get() == 3);
+	BOOST_CHECK(Util::StrToNum("3.14").value() == 3.14);
+	BOOST_CHECK(Util::StrToNum("3.").value() == 3.0);
+	BOOST_CHECK(Util::StrToNum("3").value() == 3);
 	BOOST_CHECK(Util::StrToNum("3 not a number").has_value() == false);
 	BOOST_CHECK(Util::StrToNum("not a number").has_value() == false);
 }


### PR DESCRIPTION
## Description

Remove the use of Boost.Variant and Boost.Optional

## Lib changes

- removed the use of Boost.Variant and Boost.Optional since they are no longer relevant after moving to C++17 and GCC 9+.

## Testing

- Windows 10;
- Linux Debian 12;
- macOS Ventura.