### PR TITLE
docs/extensions: make JSON valid

### DIFF
--- a/docs/extensions/EXTENSIONS.md
+++ b/docs/extensions/EXTENSIONS.md
@@ -73,7 +73,7 @@ and the `executable` file, like `main.py`.
       "value": "Always",
       "description": ["When to send the message."],
       "select": ["Always", "OnFailure"]
-    },
+    }
   ],
   "commands": [
     {


### PR DESCRIPTION
Hi,
This just fixes the example JSON for an extension to make it valid.