### PR TITLE
Fix: wrong 'number' type for doubles in xml

### DIFF
--- a/daemon/extension/Extension.cpp
+++ b/daemon/extension/Extension.cpp
@@ -402,7 +402,7 @@ namespace Extension
 			}
 			else if (const double* val = std::get_if<double>(&option.value))
 			{
-				AddNewNode(optionsNode, "Value", "number", std::to_string(*val).c_str());
+				AddNewNode(optionsNode, "Value", "double", std::to_string(*val).c_str());
 			}
 
 			xmlNodePtr selectNode = xmlNewNode(NULL, BAD_CAST "Select");
@@ -414,7 +414,7 @@ namespace Extension
 				}
 				else if (const double* val = std::get_if<double>(&selectOption))
 				{
-					AddNewNode(selectNode, "Value", "number", std::to_string(*val).c_str());
+					AddNewNode(selectNode, "Value", "double", std::to_string(*val).c_str());
 				}
 			}
 

--- a/tests/extension/ExtensionTest.cpp
+++ b/tests/extension/ExtensionTest.cpp
@@ -151,13 +151,13 @@ BOOST_AUTO_TEST_CASE(ToXmlStrTest)
 <member><name>Multi</name><value><boolean>true</boolean></value></member>\
 <member><name>Section</name><value><string>Section</string></value></member>\
 <member><name>Prefix</name><value><string>Prefix</string></value></member>\
-<member><name>Value</name><value><number>5.000000</number></value></member>\
+<member><name>Value</name><value><double>5.000000</double></value></member>\
 <Description>\
 <member><name>Value</name><value><string>description</string></value></member>\
 </Description>\
 <Select>\
-<member><name>Value</name><value><number>0.000000</number></value></member>\
-<member><name>Value</name><value><number>10.000000</number></value></member>\
+<member><name>Value</name><value><double>0.000000</double></value></member>\
+<member><name>Value</name><value><double>10.000000</double></value></member>\
 </Select>\
 </Options>\
 </struct></value>";


### PR DESCRIPTION
## Description

- according to xml-rpc [doc](https://xmlrpc.com/spec.md) the 'double' type must be used for floating-point numbers.
