### PR TITLE
Fix: free/total disk size on x32 systems

### DIFF
--- a/daemon/main/DiskService.cpp
+++ b/daemon/main/DiskService.cpp
@@ -70,7 +70,7 @@ void DiskService::CheckDiskSpace()
 	if (res.has_value() && g_Options->GetDiskSpace() >= 0)
 	{
 		const auto& value = res.value();
-		if (value.available / 1024 / 1024 < static_cast<size_t>(g_Options->GetDiskSpace()))
+		if (value.available / 1024 / 1024 < g_Options->GetDiskSpace())
 		{
 			warn("Low disk space on %s. Pausing download", g_Options->GetDestDir());
 			g_WorkState->SetPauseDownload(true);
@@ -83,7 +83,7 @@ void DiskService::CheckDiskSpace()
 		if (res.has_value() && g_Options->GetDiskSpace() >= 0)
 		{
 			const auto& value = res.value();
-			if (value.available / 1024 / 1024 < static_cast<size_t>(g_Options->GetDiskSpace()))
+			if (value.available / 1024 / 1024 < g_Options->GetDiskSpace())
 			{
 				warn("Low disk space on %s. Pausing download", g_Options->GetInterDir());
 				g_WorkState->SetPauseDownload(true);

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -1448,8 +1448,8 @@ void StatusXmlCommand::Execute()
 	if (res.has_value())
 	{
 		const auto& value = res.value();
-		freeDiskSpace = Util::SafeIntCast<size_t, int64>(value.available);
-		totalDiskSpace = Util::SafeIntCast<size_t, int64>(value.total);
+		freeDiskSpace = value.available;
+		totalDiskSpace = value.total;
 	}
 	Util::SplitInt64(freeDiskSpace, &freeDiskSpaceHi, &freeDiskSpaceLo);
 	Util::SplitInt64(totalDiskSpace, &totalDiskSpaceHi, &totalDiskSpaceLo);

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -745,16 +745,16 @@ std::optional<FileSystem::DiskState> FileSystem::GetDiskState(const char* path)
 
 	if (GetDiskFreeSpaceEx(path, &freeBytesAvailable, &totalNumberOfBytes, nullptr))
 	{
-		size_t available = freeBytesAvailable.QuadPart;
-		size_t total = totalNumberOfBytes.QuadPart;
+		int64 available = Util::SafeIntCast<uint64, int64>(freeBytesAvailable.QuadPart);
+		int64 total = Util::SafeIntCast<uint64, int64>(totalNumberOfBytes.QuadPart);
 		return FileSystem::DiskState{ available, total };
 	}
 #else
 	struct statvfs diskdata;
 	if (!statvfs(path, &diskdata))
 	{
-		size_t available = diskdata.f_bavail * diskdata.f_frsize;
-		size_t total = diskdata.f_blocks * diskdata.f_frsize;
+		int64 available = Util::SafeIntCast<uint64, int64>(diskdata.f_bavail * diskdata.f_frsize);
+		int64 total = Util::SafeIntCast<uint64, int64>(diskdata.f_blocks * diskdata.f_frsize);
 		return FileSystem::DiskState{ available, total };
 	}
 #endif

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -31,8 +31,8 @@ class FileSystem
 {
 	struct DiskState
 	{
-		size_t available;
-		size_t total;
+		int64 available;
+		int64 total;
 	};
 
 public:


### PR DESCRIPTION
## Description
[#331](https://github.com/nzbgetcom/nzbget/issues/331)

- fixed free/total disk size on x32 systems with hard drives larger than 2 TB

## Testing

- Windows x86/x64
- macOS Ventura
- Linux Debian x64