### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/daemon/system/CPU.cpp
+++ b/daemon/system/CPU.cpp
@@ -204,9 +204,13 @@ namespace System
 #if __BSD__
 	void CPU::Init()
 	{
+		int mib[2];
 		size_t len = BUFFER_SIZE;
 		char model[BUFFER_SIZE];
-		if (sysctlbyname("hw.model", &model, &len, nullptr, 0) == 0)
+
+		mib[0] = CTL_HW;
+		mib[1] = HW_MODEL;
+		if (sysctl(mib, 2, model, &len, nullptr, 0) != -1)
 		{
 			m_model = model;
 			Util::Trim(m_model);

--- a/daemon/system/OS.cpp
+++ b/daemon/system/OS.cpp
@@ -259,9 +259,13 @@ namespace System
 #if __BSD__
 	void OS::Init()
 	{
+		int mib[2];
 		size_t len = BUFFER_SIZE;
 		char buffer[BUFFER_SIZE];
-		if (sysctlbyname("kern.ostype", &buffer, &len, nullptr, 0) == 0)
+
+		mib[0] = CTL_KERN;
+		mib[1] = KERN_OSTYPE;
+		if (sysctl(mib, 2, buffer, &len, nullptr, 0) != -1)
 		{
 			m_name = buffer;
 			Util::Trim(m_name);
@@ -273,7 +277,8 @@ namespace System
 
 		len = BUFFER_SIZE;
 
-		if (sysctlbyname("kern.osrelease", &buffer, &len, nullptr, 0) == 0)
+		mib[1] = KERN_OSRELEASE;
+		if (sysctl(mib, 2, buffer, &len, nullptr, 0) != -1)
 		{
 			m_version = buffer;
 			Util::Trim(m_version);


### PR DESCRIPTION
## Description
The commit c5dce75 causes the build to fail on OpenBSD due to the use of the `sysctlbyname` function, which is not available on OpenBSD. This issue can be resolved by replacing `sysctlbyname` with the `sysctl` function, which is supported across all BSD variants.

## Lib changes

No changes.

## Testing

Build- and run-tested on OpenBSD current. Build-tested on FreeBSD 14.0.