### PR TITLE
Fix building with LibreSSL

### DIFF
--- a/daemon/system/SystemInfo.cpp
+++ b/daemon/system/SystemInfo.cpp
@@ -64,7 +64,13 @@ namespace System
 #endif
 
 #ifdef HAVE_OPENSSL
+#ifdef LIBRESSL_VERSION_TEXT
+		std::string str = LIBRESSL_VERSION_TEXT;
+		m_libraries.push_back({ "LibreSSL",
+				str.substr(str.find(" ") + 1) });
+#else
 		m_libraries.push_back({ "OpenSSL", OPENSSL_FULL_VERSION_STR });
+#endif
 #endif
 
 #ifdef HAVE_LIBGNUTLS


### PR DESCRIPTION
## Description

The commit c5dce75 introduces a build failure on systems using LibreSSL. LibreSSL, a fork of OpenSSL, aims to modernize the codebase, enhance security, and follow best development practices. The build failure is due to the replacement of `OPENSSL_FULL_VERSION_STR` with `LIBRESSL_VERSION_TEXT`. The latter requires some string manipulation since it is defined as "LibreSSL major.minor.patch".

## Lib changes

No changes.

## Testing

Build- and run-tested on OpenBSD current. Build-tested on FreeBSD 14.0.