### PR TITLE
CMakeLists.txt - Fix omission in CMAKE_CXX_FLAGS_DEBUG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
-		set(CMAKE_CXX_FLAGS_DEBUG "-O0 -pthread -g -DDEBUG -Weverything -Wno-c++98-compat" CACHE STRING "" FORCE)
+		set(CMAKE_CXX_FLAGS "-O0 -pthread -g -DDEBUG -Weverything -Wno-c++98-compat" CACHE STRING "" FORCE)
 	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 		set(CMAKE_CXX_FLAGS "-O0 -pthread -g -DDEBUG -Wall -Wextra" CACHE STRING "" FORCE)
 	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")


### PR DESCRIPTION
## Description

When building with `-DCMAKE_BUILD_TYPE=Debug`, using clang, the wrong `CMAKE_C_FLAGS_DEBUG` are set, which causes a wrong debug build. This issue is caused by 0043452, which sets `CMAKE_CXX_FLAGS_DEBUG` to the correct flags, but later is set to `CMAKE_CXX_FLAGS`, which is empty.

Issue does not occur when building with a different compiler.

## Lib changes

No changes.

## Testing

Build debug release using clang on OpenBSD current.