### PR TITLE
Out-of-bound check

### DIFF
--- a/daemon/system/SystemInfo.cpp
+++ b/daemon/system/SystemInfo.cpp
@@ -66,8 +66,10 @@ namespace System
 #ifdef HAVE_OPENSSL
 #ifdef LIBRESSL_VERSION_TEXT
 		std::string str = LIBRESSL_VERSION_TEXT;
-		m_libraries.push_back({ "LibreSSL",
-				str.substr(str.find(" ") + 1) });
+		size_t pos = str.find(" ");
+
+		str = pos != std::string::npos ? str.substr(pos + 1) : "unknown";
+		m_libraries.push_back({ "LibreSSL", str });
 #else
 		m_libraries.push_back({ "OpenSSL", OPENSSL_FULL_VERSION_STR });
 #endif


### PR DESCRIPTION
## Description
## Description

bc9637c unbreaks the build for building against LibreSSL, but could result in an out-of-bound read. Address this by checking `str.find(" ") != std::string::npos`.

Based on feedback from @dnzbk
(https://github.com/nzbgetcom/nzbget/pull/337/files/a3c94e4faabfaf3967718f7a3a38a5ebc807115e#r1703551062)


## Lib changes

No change.

## Testing

Build- and run-tested on OpenBSD current.