### PR TITLE
Fixed: buffer overflow

### DIFF
--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -56,20 +56,21 @@ void FileSystem::NormalizePathSeparators(char* path)
 	}
 }
 
-std::optional<std::string> FileSystem::GetFileRealPath(const std::string& path)
+std::optional<std::string> FileSystem::GetFileRealPath(std::string_view path)
 {
-	char buffer[256];
-
 #ifdef WIN32
-	DWORD len = GetFullPathName(path.c_str(), 256, buffer, nullptr);
+	char buffer[MAX_PATH];
+	DWORD len = GetFullPathName(path.data(), MAX_PATH, buffer, nullptr);
 	if (len != 0)
 	{
-		return std::optional<std::string>{ buffer };
+		return std::optional{ buffer };
 	}
 #else
-	if (realpath(path.c_str(), buffer) != nullptr)
+	if (char* realPath = realpath(path.data(), nullptr))
 	{
-		return std::optional<std::string>{ buffer };
+		std::string res = realPath;
+		free(realPath);
+		return std::optional(std::move(res));
 	}
 #endif
 

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -40,7 +40,7 @@ public:
 	static char* BaseFileName(const char* filename);
 	static bool SameFilename(const char* filename1, const char* filename2);
 	static void NormalizePathSeparators(char* path);
-	static std::optional<std::string> GetFileRealPath(const std::string& path);
+	static std::optional<std::string> GetFileRealPath(std::string_view path);
 	static bool LoadFileIntoBuffer(const char* filename, CharBuffer& buffer, bool addTrailingNull);
 	static bool SaveBufferIntoFile(const char* filename, const char* buffer, int bufLen);
 	static bool AllocateFile(const char* filename, int64 size, bool sparse, CString& errmsg);


### PR DESCRIPTION
## Description

The bug was reproducible only in the Release build and only on Gentoo.

- use a safer approach of using `getrealpath` according to the [doc](https://man7.org/linux/man-pages/man3/realpath.3.html)
- using `std::string_view` instead of `std::string&` for better performance
- improved `SystemInfoTest` to make it more flexible 

## Testing

- Linux Debian 12
- Windows 10
- macOS Ventura
- Gentoo 2.15