### PR TITLE
Show InterDir disk info on the STATUS page

### DIFF
--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -1462,20 +1462,36 @@ void StatusXmlCommand::Execute()
 	int64 freeInterDiskSpace = 0;
 	int64 totalInterDiskSpace = 0;
 
-	auto destDirRes = FileSystem::GetDiskState(g_Options->GetDestDir());
-	if (destDirRes.has_value())
+	if (Util::EmptyStr(g_Options->GetDestDir()))
 	{
-		const auto& value = destDirRes.value();
-		freeDiskSpace = value.available;
-		totalDiskSpace = value.total;
+		freeDiskSpace = 0;
+		totalDiskSpace = 0;
+	}
+	else
+	{
+		auto res = FileSystem::GetDiskState(g_Options->GetDestDir());
+		if (res.has_value())
+		{
+			const auto& value = res.value();
+			freeDiskSpace = value.available;
+			totalDiskSpace = value.total;
+		}
 	}
 
-	auto interDirRes = FileSystem::GetDiskState(g_Options->GetInterDir());
-	if (interDirRes.has_value())
+	if (Util::EmptyStr(g_Options->GetInterDir()))
 	{
-		const auto& value = interDirRes.value();
-		freeInterDiskSpace = value.available;
-		totalInterDiskSpace = value.total;
+		freeInterDiskSpace = freeDiskSpace;
+		totalInterDiskSpace = totalDiskSpace;
+	}
+	else
+	{
+		auto res = FileSystem::GetDiskState(g_Options->GetInterDir());
+		if (res.has_value())
+		{
+			const auto& value = res.value();
+			freeInterDiskSpace = value.available;
+			totalInterDiskSpace = value.total;
+		}
 	}
 
 	Util::SplitInt64(freeDiskSpace, &freeDiskSpaceHi, &freeDiskSpaceLo);

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -1303,6 +1303,12 @@ void StatusXmlCommand::Execute()
 		"<member><name>TotalDiskSpaceLo</name><value><i4>%u</i4></value></member>\n"
 		"<member><name>TotalDiskSpaceHi</name><value><i4>%u</i4></value></member>\n"
 		"<member><name>TotalDiskSpaceMB</name><value><i4>%i</i4></value></member>\n"
+		"<member><name>FreeInterDiskSpaceLo</name><value><i4>%u</i4></value></member>\n"
+		"<member><name>FreeInterDiskSpaceHi</name><value><i4>%u</i4></value></member>\n"
+		"<member><name>FreeInterDiskSpaceMB</name><value><i4>%i</i4></value></member>\n"
+		"<member><name>TotalInterDiskSpaceLo</name><value><i4>%u</i4></value></member>\n"
+		"<member><name>TotalInterDiskSpaceHi</name><value><i4>%u</i4></value></member>\n"
+		"<member><name>TotalInterDiskSpaceMB</name><value><i4>%i</i4></value></member>\n"
 		"<member><name>ServerTime</name><value><i4>%i</i4></value></member>\n"
 		"<member><name>ResumeTime</name><value><i4>%i</i4></value></member>\n"
 		"<member><name>FeedActive</name><value><boolean>%s</boolean></value></member>\n"
@@ -1359,6 +1365,12 @@ void StatusXmlCommand::Execute()
 		"\"TotalDiskSpaceLo\" : %u,\n"
 		"\"TotalDiskSpaceHi\" : %u,\n"
 		"\"TotalDiskSpaceMB\" : %i,\n"
+		"\"FreeInterDiskSpaceLo\" : %u,\n"
+		"\"FreeInterDiskSpaceHi\" : %u,\n"
+		"\"FreeInterDiskSpaceMB\" : %i,\n"
+		"\"TotalInterDiskSpaceLo\" : %u,\n"
+		"\"TotalInterDiskSpaceHi\" : %u,\n"
+		"\"TotalInterDiskSpaceMB\" : %i,\n"
 		"\"ServerTime\" : %i,\n"
 		"\"ResumeTime\" : %i,\n"
 		"\"FeedActive\" : %s,\n"
@@ -1442,19 +1454,39 @@ void StatusXmlCommand::Execute()
 
 	uint32 freeDiskSpaceHi, freeDiskSpaceLo;
 	uint32 totalDiskSpaceHi, totalDiskSpaceLo;
+	uint32 freeInterDiskSpaceHi, freeInterDiskSpaceLo;
+	uint32 totalInterDiskSpaceHi, totalInterDiskSpaceLo;
+
 	int64 freeDiskSpace = 0;
 	int64 totalDiskSpace = 0;
-	auto res = FileSystem::GetDiskState(g_Options->GetDestDir());
-	if (res.has_value())
+	int64 freeInterDiskSpace = 0;
+	int64 totalInterDiskSpace = 0;
+
+	auto destDirRes = FileSystem::GetDiskState(g_Options->GetDestDir());
+	if (destDirRes.has_value())
 	{
-		const auto& value = res.value();
+		const auto& value = destDirRes.value();
 		freeDiskSpace = value.available;
 		totalDiskSpace = value.total;
 	}
+
+	auto interDirRes = FileSystem::GetDiskState(g_Options->GetInterDir());
+	if (interDirRes.has_value())
+	{
+		const auto& value = interDirRes.value();
+		freeInterDiskSpace = value.available;
+		totalInterDiskSpace = value.total;
+	}
+
 	Util::SplitInt64(freeDiskSpace, &freeDiskSpaceHi, &freeDiskSpaceLo);
 	Util::SplitInt64(totalDiskSpace, &totalDiskSpaceHi, &totalDiskSpaceLo);
+	Util::SplitInt64(freeInterDiskSpace, &freeInterDiskSpaceHi, &freeInterDiskSpaceLo);
+	Util::SplitInt64(totalInterDiskSpace, &totalInterDiskSpaceHi, &totalInterDiskSpaceLo);
+
 	int freeDiskSpaceMB = static_cast<int>(freeDiskSpace / 1024 / 1024);
 	int totalDiskSpaceMB = static_cast<int>(totalDiskSpace / 1024 / 1024);
+	int freeInterDiskSpaceMB = static_cast<int>(freeInterDiskSpace / 1024 / 1024);
+	int totalInterDiskSpaceMB = static_cast<int>(totalInterDiskSpace / 1024 / 1024);
 
 	int serverTime = (int)Util::CurrentTime();
 	int resumeTime = (int)g_WorkState->GetResumeTime();
@@ -1482,6 +1514,12 @@ void StatusXmlCommand::Execute()
 		totalDiskSpaceLo, 
 		totalDiskSpaceHi, 
 		totalDiskSpaceMB,
+		freeInterDiskSpaceLo, 
+		freeInterDiskSpaceHi, 
+		freeInterDiskSpaceMB, 
+		totalInterDiskSpaceLo, 
+		totalInterDiskSpaceHi, 
+		totalInterDiskSpaceMB,
 		serverTime, resumeTime, BoolToStr(feedActive), queuedScripts);
 
 	int index = 0;

--- a/docs/api/STATUS.md
+++ b/docs/api/STATUS.md
@@ -58,6 +58,12 @@ This method returns structure with following fields:
 - **TotalDiskSpaceLo** `(int)` - `v24.2` Total disk space on `DestDir`, in bytes. This field contains the low 32-bits of 64-bit value
 - **TotalDiskSpaceHi** `(int)` - `v24.2` Total disk space on `DestDir`, in bytes. This field contains the high 32-bits of 64-bit value
 - **TotalDiskSpaceMB** `(int)` - `v24.2` Total disk space on `DestDir`, in MiB.
+- **FreeInterDiskSpaceLo** `(int)` - `v24.3` Free disk space on `InterDir`, in bytes. This field contains the low 32-bits of 64-bit value
+- **FreeInterDiskSpaceHi** `(int)` - `v24.3` Free disk space on `InterDir`, in bytes. This field contains the high 32-bits of 64-bit value
+- **FreeInterDiskSpaceMB** `(int)` - `v24.3` Free disk space on `InterDir`, in MiB.
+- **TotalInterDiskSpaceLo** `(int)` - `v24.3` Total disk space on `InterDir`, in bytes. This field contains the low 32-bits of 64-bit value
+- **TotalInterDiskSpaceHi** `(int)` - `v24.3` Total disk space on `InterDir`, in bytes. This field contains the high 32-bits of 64-bit value
+- **TotalInterDiskSpaceMB** `(int)` - `v24.3` Total disk space on `InterDir`, in MiB.
 - **QueueScriptCount** `(int)` - Indicates number of queue-scripts queued for execution including the currently running.
 - **NewsServers** `(struct[])` - Status of news-servers, array of structures with following fields
   - **ID** `(int)` - Server number in the configuration file. For example `1` for server defined by options `Server1.Host`, `Server1.Port`, etc.

--- a/webui/index.html
+++ b/webui/index.html
@@ -729,21 +729,13 @@
 																<td width="50%">Arch</td>
 																<td id="SysInfo_Arch" width="50%"></td>
 															</tr>
-															<tr>
-																<td width="50%">Free disk space (DestDir)</td>
-																<td id="SysInfo_FreeDiskSpace" width="50%"></td>
+															<tr id="SysInfo_DestDiskSpaceContainer">
+																<td width="50%">Free / Total disk space (DestDir)</td>
+																<td id="SysInfo_DestDiskSpace" width="50%"></td>
 															</tr>
-															<tr>
-																<td width="50%">Total disk space (DestDir)</td>
-																<td id="SysInfo_TotalDiskSpace" width="50%"></td>
-															</tr>
-															<tr id="SysInfo_FreeInterDiskSpaceTr">
-																<td width="50%">Free disk space (InterDir)</td>
-																<td id="SysInfo_FreeInterDiskSpace" width="50%"></td>
-															</tr>
-															<tr id="SysInfo_TotalInterDiskSpaceTr">
-																<td width="50%">Total disk space (InterDir)</td>
-																<td id="SysInfo_TotalInterDiskSpace" width="50%"></td>
+															<tr id="SysInfo_InterDiskSpaceContainer">
+																<td width="50%">Free / Total disk space (InterDir)</td>
+																<td id="SysInfo_InterDiskSpace" width="50%"></td>
 															</tr>
 															<tr>
 																<td width="50%">Write buffer</td>

--- a/webui/index.html
+++ b/webui/index.html
@@ -730,12 +730,20 @@
 																<td id="SysInfo_Arch" width="50%"></td>
 															</tr>
 															<tr>
-																<td width="50%">Free disk space</td>
+																<td width="50%">Free disk space (DestDir)</td>
 																<td id="SysInfo_FreeDiskSpace" width="50%"></td>
 															</tr>
 															<tr>
-																<td width="50%">Total disk space</td>
+																<td width="50%">Total disk space (DestDir)</td>
 																<td id="SysInfo_TotalDiskSpace" width="50%"></td>
+															</tr>
+															<tr id="SysInfo_FreeInterDiskSpaceTr">
+																<td width="50%">Free disk space (InterDir)</td>
+																<td id="SysInfo_FreeInterDiskSpace" width="50%"></td>
+															</tr>
+															<tr id="SysInfo_TotalInterDiskSpaceTr">
+																<td width="50%">Total disk space (InterDir)</td>
+																<td id="SysInfo_TotalInterDiskSpace" width="50%"></td>
 															</tr>
 															<tr>
 																<td width="50%">Write buffer</td>

--- a/webui/system-info.js
+++ b/webui/system-info.js
@@ -76,7 +76,7 @@ var SystemInfo = (new function($)
 			if (destDirOpt && interDirOpt)
 			{
 				var destDirPath = destDirOpt.Value;
-				var interDistPath = interDirOpt.Value ? interDirOpt : destDirPath;
+				var interDistPath = interDirOpt.Value ? interDirOpt.Value : destDirPath;
 				renderDiskSpace(+status['FreeDiskSpaceMB'], +status['TotalDiskSpaceMB'], destDirPath);
 				renderInterDiskSpace(+status['FreeInterDiskSpaceMB'], +status['TotalInterDiskSpaceMB'], interDistPath);
 			}

--- a/webui/system-info.js
+++ b/webui/system-info.js
@@ -29,12 +29,10 @@ var SystemInfo = (new function($)
 	var $SysInfo_CPUModel;
 	var $SysInfo_Arch;
 	var $SysInfo_IP;
-	var $SysInfo_FreeDiskSpace;
-	var $SysInfo_TotalDiskSpace;
-	var $SysInfo_FreeInterDiskSpace;
-	var $SysInfo_TotalInterDiskSpace;
-	var $SysInfo_FreeInterDiskSpaceTr;
-	var $SysInfo_TotalInterDiskSpaceTr;
+	var $SysInfo_DestDiskSpace;
+	var $SysInfo_InterDiskSpace;
+	var $SysInfo_DestDiskSpaceContainer;
+	var $SysInfo_InterDiskSpaceContainer;
 	var $SysInfo_ArticleCache;
 	var $SysInfo_WriteBuffer;
 	var $SysInfo_ToolsTable;
@@ -73,18 +71,12 @@ var SystemInfo = (new function($)
 			var destDirOpt = Options.findOption(Options.options, 'DestDir');
 			var interDirOpt = Options.findOption(Options.options, 'InterDir');
 
-			renderDiskSpace(+status['FreeDiskSpaceMB'], +status['TotalDiskSpaceMB']);
+			
 
-			if (destDirOpt && interDirOpt && !pathsOnSameDisk(destDirOpt.Value, interDirOpt.Value))
+			if (destDirOpt && interDirOpt)
 			{
-				$SysInfo_FreeInterDiskSpaceTr.show();
-				$SysInfo_TotalInterDiskSpaceTr.show();
-				renderInterDiskSpace(+status['FreeInterDiskSpaceMB'], +status['TotalInterDiskSpaceMB']);
-			}
-			else
-			{
-				$SysInfo_FreeInterDiskSpaceTr.hide();
-				$SysInfo_TotalInterDiskSpaceTr.hide();
+				renderDiskSpace(+status['FreeDiskSpaceMB'], +status['TotalDiskSpaceMB'], destDirOpt.Value);
+				renderInterDiskSpace(+status['FreeInterDiskSpaceMB'], +status['TotalInterDiskSpaceMB'], interDirOpt.Value);
 			}
 		}
 	}
@@ -116,12 +108,10 @@ var SystemInfo = (new function($)
 		$SysInfo_CPUModel = $('#SysInfo_CPUModel');
 		$SysInfo_Arch = $('#SysInfo_Arch');
 		$SysInfo_IP = $('#SysInfo_IP');
-		$SysInfo_FreeDiskSpace = $('#SysInfo_FreeDiskSpace');
-		$SysInfo_TotalDiskSpace = $('#SysInfo_TotalDiskSpace');
-		$SysInfo_FreeInterDiskSpace = $('#SysInfo_FreeInterDiskSpace');
-		$SysInfo_TotalInterDiskSpace = $('#SysInfo_TotalInterDiskSpace');
-		$SysInfo_FreeInterDiskSpaceTr = $('#SysInfo_FreeInterDiskSpaceTr');
-		$SysInfo_TotalInterDiskSpaceTr = $('#SysInfo_TotalInterDiskSpaceTr');
+		$SysInfo_DestDiskSpace = $('#SysInfo_DestDiskSpace');
+		$SysInfo_InterDiskSpace = $('#SysInfo_InterDiskSpace');
+		$SysInfo_InterDiskSpaceContainer = $('#SysInfo_InterDiskSpaceContainer');
+		$SysInfo_DestDiskSpaceContainer = $('#SysInfo_DestDiskSpaceContainer');
 		$SysInfo_ArticleCache = $('#SysInfo_ArticleCache');
 		$SysInfo_WriteBuffer = $('#SysInfo_WriteBuffer');
 		$SysInfo_ToolsTable = $('#SysInfo_ToolsTable');
@@ -292,18 +282,22 @@ var SystemInfo = (new function($)
 		});
 	}
 
-	function renderDiskSpace(free, total)
+	function renderDiskSpace(free, total, path)
 	{
-		var percents = total !== 0 ? (free / total * 100).toFixed(1) + '%' : '0.0%';
-		$SysInfo_FreeDiskSpace.text(Util.formatSizeMB(free) + ' / ' + percents);
-		$SysInfo_TotalDiskSpace.text(Util.formatSizeMB(total));
+		$SysInfo_DestDiskSpace.text(formatDiskInfo(free, total));
+		$SysInfo_DestDiskSpaceContainer.attr('title', path);
 	}
 
-	function renderInterDiskSpace(free, total)
+	function renderInterDiskSpace(free, total, path)
+	{
+		$SysInfo_InterDiskSpace.text(formatDiskInfo(free, total));
+		$SysInfo_InterDiskSpaceContainer.attr('title', path);
+	}
+
+	function formatDiskInfo(free, total)
 	{
 		var percents = total !== 0 ? (free / total * 100).toFixed(1) + '%' : '0.0%';
-		$SysInfo_FreeInterDiskSpace.text(Util.formatSizeMB(free) + ' / ' + percents);
-		$SysInfo_TotalInterDiskSpace.text(Util.formatSizeMB(total));
+		return Util.formatSizeMB(free) + ' (' + percents + ') / ' + Util.formatSizeMB(total);
 	}
 
 	function renderIP(network)

--- a/webui/system-info.js
+++ b/webui/system-info.js
@@ -75,8 +75,10 @@ var SystemInfo = (new function($)
 
 			if (destDirOpt && interDirOpt)
 			{
-				renderDiskSpace(+status['FreeDiskSpaceMB'], +status['TotalDiskSpaceMB'], destDirOpt.Value);
-				renderInterDiskSpace(+status['FreeInterDiskSpaceMB'], +status['TotalInterDiskSpaceMB'], interDirOpt.Value);
+				var destDirPath = destDirOpt.Value;
+				var interDistPath = interDirOpt.Value ? interDirOpt : destDirPath;
+				renderDiskSpace(+status['FreeDiskSpaceMB'], +status['TotalDiskSpaceMB'], destDirPath);
+				renderInterDiskSpace(+status['FreeInterDiskSpaceMB'], +status['TotalInterDiskSpaceMB'], interDistPath);
 			}
 		}
 	}

--- a/webui/system-info.js
+++ b/webui/system-info.js
@@ -31,6 +31,10 @@ var SystemInfo = (new function($)
 	var $SysInfo_IP;
 	var $SysInfo_FreeDiskSpace;
 	var $SysInfo_TotalDiskSpace;
+	var $SysInfo_FreeInterDiskSpace;
+	var $SysInfo_TotalInterDiskSpace;
+	var $SysInfo_FreeInterDiskSpaceTr;
+	var $SysInfo_TotalInterDiskSpaceTr;
 	var $SysInfo_ArticleCache;
 	var $SysInfo_WriteBuffer;
 	var $SysInfo_ToolsTable;
@@ -65,7 +69,23 @@ var SystemInfo = (new function($)
 		update: function(status) 
 		{
 			$SysInfo_Uptime.text(Util.formatTimeHMS(status['UpTimeSec']));
+
+			var destDirOpt = Options.findOption(Options.options, 'DestDir');
+			var interDirOpt = Options.findOption(Options.options, 'InterDir');
+
 			renderDiskSpace(+status['FreeDiskSpaceMB'], +status['TotalDiskSpaceMB']);
+
+			if (destDirOpt && interDirOpt && !pathsOnSameDisk(destDirOpt.Value, interDirOpt.Value))
+			{
+				$SysInfo_FreeInterDiskSpaceTr.show();
+				$SysInfo_TotalInterDiskSpaceTr.show();
+				renderInterDiskSpace(+status['FreeInterDiskSpaceMB'], +status['TotalInterDiskSpaceMB']);
+			}
+			else
+			{
+				$SysInfo_FreeInterDiskSpaceTr.hide();
+				$SysInfo_TotalInterDiskSpaceTr.hide();
+			}
 		}
 	}
 
@@ -98,6 +118,10 @@ var SystemInfo = (new function($)
 		$SysInfo_IP = $('#SysInfo_IP');
 		$SysInfo_FreeDiskSpace = $('#SysInfo_FreeDiskSpace');
 		$SysInfo_TotalDiskSpace = $('#SysInfo_TotalDiskSpace');
+		$SysInfo_FreeInterDiskSpace = $('#SysInfo_FreeInterDiskSpace');
+		$SysInfo_TotalInterDiskSpace = $('#SysInfo_TotalInterDiskSpace');
+		$SysInfo_FreeInterDiskSpaceTr = $('#SysInfo_FreeInterDiskSpaceTr');
+		$SysInfo_TotalInterDiskSpaceTr = $('#SysInfo_TotalInterDiskSpaceTr');
 		$SysInfo_ArticleCache = $('#SysInfo_ArticleCache');
 		$SysInfo_WriteBuffer = $('#SysInfo_WriteBuffer');
 		$SysInfo_ToolsTable = $('#SysInfo_ToolsTable');
@@ -134,6 +158,17 @@ var SystemInfo = (new function($)
 			},
 			errorHandler
 		);
+	}
+
+	function pathsOnSameDisk(path1, path2) 
+	{
+		path1 = path1.replace(/\\/g, '/');
+		path2 = path2.replace(/\\/g, '/');
+	  
+		var drive1 = path1.match(/^[a-zA-Z]:\//i) ? path1.match(/^[a-zA-Z]:\//i)[0] : '/';
+		var drive2 = path2.match(/^[a-zA-Z]:\//i) ? path2.match(/^[a-zA-Z]:\//i)[0] : '/';
+
+		return drive1 === drive2;
 	}
 
 	function hideSpinner()
@@ -262,6 +297,13 @@ var SystemInfo = (new function($)
 		var percents = total !== 0 ? (free / total * 100).toFixed(1) + '%' : '0.0%';
 		$SysInfo_FreeDiskSpace.text(Util.formatSizeMB(free) + ' / ' + percents);
 		$SysInfo_TotalDiskSpace.text(Util.formatSizeMB(total));
+	}
+
+	function renderInterDiskSpace(free, total)
+	{
+		var percents = total !== 0 ? (free / total * 100).toFixed(1) + '%' : '0.0%';
+		$SysInfo_FreeInterDiskSpace.text(Util.formatSizeMB(free) + ' / ' + percents);
+		$SysInfo_TotalInterDiskSpace.text(Util.formatSizeMB(total));
 	}
 
 	function renderIP(network)


### PR DESCRIPTION
## Description

- InterDir disk info is now also displayed on the Status page
- the API method `status` now returns 6 additional properties:
  - FreeInterDiskSpaceLo `(int)` - Free disk space on `InterDir`, in bytes. This field contains the low 32-bits of 64-bit value
  - FreeInterDiskSpaceHi`(int)` - Free disk space on `InterDir`, in bytes. This field contains the high 32-bits of 64-bit value
  - FreeInterDiskSpaceMB `(int)` - Free disk space on `InterDir`, in MiB.
  - TotalInterDiskSpaceLo `(int)` - Total disk space on `InterDir`, in bytes. This field contains the low 32-bits of 64-bit value
  - TotalInterDiskSpaceHi `(int)` - otal disk space on `InterDir`, in bytes. This field contains the high 32-bits of 64-bit value
  - TotalInterDiskSpaceMB `(int)` - Total disk space on `InterDir`, in MiB.
- updated doc

## Testing

- Windows 11