### PR TITLE
Fix: xml-rpc bool type

### DIFF
--- a/daemon/extension/Extension.cpp
+++ b/daemon/extension/Extension.cpp
@@ -348,11 +348,11 @@ namespace Extension
 		Xml::AddNewNode(structNode, "Version", "string", script.GetVersion());
 		Xml::AddNewNode(structNode, "NZBGetMinVersion", "string", script.GetNzbgetMinVersion());
 
-		Xml::AddNewNode(structNode, "PostScript", "boolean", BoolToStr(script.GetPostScript()));
-		Xml::AddNewNode(structNode, "ScanScript", "boolean", BoolToStr(script.GetScanScript()));
-		Xml::AddNewNode(structNode, "QueueScript", "boolean", BoolToStr(script.GetQueueScript()));
-		Xml::AddNewNode(structNode, "SchedulerScript", "boolean", BoolToStr(script.GetSchedulerScript()));
-		Xml::AddNewNode(structNode, "FeedScript", "boolean", BoolToStr(script.GetFeedScript()));
+		Xml::AddNewNode(structNode, "PostScript", "boolean", Xml::BoolToStr(script.GetPostScript()));
+		Xml::AddNewNode(structNode, "ScanScript", "boolean", Xml::BoolToStr(script.GetScanScript()));
+		Xml::AddNewNode(structNode, "QueueScript", "boolean", Xml::BoolToStr(script.GetQueueScript()));
+		Xml::AddNewNode(structNode, "SchedulerScript", "boolean", Xml::BoolToStr(script.GetSchedulerScript()));
+		Xml::AddNewNode(structNode, "FeedScript", "boolean", Xml::BoolToStr(script.GetFeedScript()));
 
 		Xml::AddNewNode(structNode, "QueueEvents", "string", script.GetQueueEvents());
 		Xml::AddNewNode(structNode, "TaskTime", "string", script.GetTaskTime());
@@ -375,7 +375,7 @@ namespace Extension
 			Xml::AddNewNode(commandsNode, "Name", "string", command.name.c_str());
 			Xml::AddNewNode(commandsNode, "DisplayName", "string", command.displayName.c_str());
 			Xml::AddNewNode(commandsNode, "Action", "string", command.action.c_str());
-			Xml::AddNewNode(commandsNode, "Multi", "boolean", BoolToStr(command.section.multi));
+			Xml::AddNewNode(commandsNode, "Multi", "boolean", Xml::BoolToStr(command.section.multi));
 			Xml::AddNewNode(commandsNode, "Section", "string", command.section.name.c_str());
 			Xml::AddNewNode(commandsNode, "Prefix", "string", command.section.prefix.c_str());
 
@@ -392,7 +392,7 @@ namespace Extension
 		{
 			Xml::AddNewNode(optionsNode, "Name", "string", option.name.c_str());
 			Xml::AddNewNode(optionsNode, "DisplayName", "string", option.displayName.c_str());
-			Xml::AddNewNode(optionsNode, "Multi", "boolean", BoolToStr(option.section.multi));
+			Xml::AddNewNode(optionsNode, "Multi", "boolean", Xml::BoolToStr(option.section.multi));
 			Xml::AddNewNode(optionsNode, "Section", "string", option.section.name.c_str());
 			Xml::AddNewNode(optionsNode, "Prefix", "string", option.section.prefix.c_str());
 
@@ -441,10 +441,5 @@ namespace Extension
 		xmlFreeNode(rootNode);
 
 		return result;
-	}
-
-	const char* BoolToStr(bool value)
-	{
-		return value ? "true" : "false";
 	}
 }

--- a/daemon/extension/Extension.h
+++ b/daemon/extension/Extension.h
@@ -109,8 +109,6 @@ namespace Extension
 
 	std::string ToJsonStr(const Script& script);
 	std::string ToXmlStr(const Script& script);
-
-	const char* BoolToStr(bool value);
 }
 
 #endif

--- a/daemon/util/Xml.cpp
+++ b/daemon/util/Xml.cpp
@@ -49,4 +49,9 @@ namespace Xml {
 		xmlAddChild(memberNode, valueNode);
 		xmlAddChild(rootNode, memberNode);
 	}
+
+	const char* BoolToStr(bool value) noexcept
+	{
+		return value ? "1" : "0";
+	}
 }

--- a/daemon/util/Xml.h
+++ b/daemon/util/Xml.h
@@ -27,6 +27,7 @@ namespace Xml
 {
 	std::string Serialize(const xmlNodePtr rootNode);
 	void AddNewNode(xmlNodePtr rootNode, const char* name, const char* type, const char* value);
+	const char* BoolToStr(bool value) noexcept;
 }
 
 #endif

--- a/tests/extension/ExtensionTest.cpp
+++ b/tests/extension/ExtensionTest.cpp
@@ -121,11 +121,11 @@ BOOST_AUTO_TEST_CASE(ToXmlStrTest)
 <member><name>License</name><value><string>License</string></value></member>\
 <member><name>Version</name><value><string>Version</string></value></member>\
 <member><name>NZBGetMinVersion</name><value><string>23.1</string></value></member>\
-<member><name>PostScript</name><value><boolean>true</boolean></value></member>\
-<member><name>ScanScript</name><value><boolean>false</boolean></value></member>\
-<member><name>QueueScript</name><value><boolean>false</boolean></value></member>\
-<member><name>SchedulerScript</name><value><boolean>false</boolean></value></member>\
-<member><name>FeedScript</name><value><boolean>false</boolean></value></member>\
+<member><name>PostScript</name><value><boolean>1</boolean></value></member>\
+<member><name>ScanScript</name><value><boolean>0</boolean></value></member>\
+<member><name>QueueScript</name><value><boolean>0</boolean></value></member>\
+<member><name>SchedulerScript</name><value><boolean>0</boolean></value></member>\
+<member><name>FeedScript</name><value><boolean>0</boolean></value></member>\
 <member><name>QueueEvents</name><value><string>QueueEvents</string></value></member>\
 <member><name>TaskTime</name><value><string>TaskTime</string></value></member>\
 <Description>\
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(ToXmlStrTest)
 <member><name>Name</name><value><string>name</string></value></member>\
 <member><name>DisplayName</name><value><string>displayName</string></value></member>\
 <member><name>Action</name><value><string>action</string></value></member>\
-<member><name>Multi</name><value><boolean>true</boolean></value></member>\
+<member><name>Multi</name><value><boolean>1</boolean></value></member>\
 <member><name>Section</name><value><string>Section</string></value></member>\
 <member><name>Prefix</name><value><string>Prefix</string></value></member>\
 <Description>\
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(ToXmlStrTest)
 <Options>\
 <member><name>Name</name><value><string>name</string></value></member>\
 <member><name>DisplayName</name><value><string>displayName</string></value></member>\
-<member><name>Multi</name><value><boolean>true</boolean></value></member>\
+<member><name>Multi</name><value><boolean>1</boolean></value></member>\
 <member><name>Section</name><value><string>Section</string></value></member>\
 <member><name>Prefix</name><value><string>Prefix</string></value></member>\
 <member><name>Value</name><value><double>5.000000</double></value></member>\


### PR DESCRIPTION
## Description

- fixed invalid `bool` type in the `loadextensions` API method in XML format
- updated tests

## Testing
- Windows 11 with a custom test extension