### PR TITLE
Disk performance tests

### DIFF
--- a/daemon/main/nzbget.h
+++ b/daemon/main/nzbget.h
@@ -15,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -224,6 +224,7 @@ compiled */
 #include <variant>
 #include <limits>
 #include <type_traits>
+#include <random>
 
 #include <libxml/parser.h>
 #include <libxml/xmlreader.h>

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -363,10 +363,10 @@ public:
 	virtual void Execute();
 };
 
-class TestDiskSpeedXmlCommand: public SafeXmlCommand
+class TestDiskSpeedXmlCommand final : public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute();
 
 	std::string ToJsonStr(const std::pair<uint64_t, double>& res)
 	{
@@ -855,7 +855,7 @@ std::unique_ptr<XmlCommand> XmlRpcProcessor::CreateCommand(const char* methodNam
 	{
 		command = std::make_unique<TestServerSpeedXmlCommand>();
 	}
-		else if (!strcasecmp(methodName, "testdiskspeed"))
+	else if (!strcasecmp(methodName, "testdiskspeed"))
 	{
 		command = std::make_unique<TestDiskSpeedXmlCommand>();
 	}

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -366,25 +366,25 @@ public:
 class TestDiskSpeedXmlCommand final : public SafeXmlCommand
 {
 public:
-	void Execute();
+	void Execute() override;
 
-	std::string ToJsonStr(const std::pair<uint64_t, double>& res)
+	std::string ToJsonStr(uint64_t size, double time)
 	{
 		Json::JsonObject json;
 
-		json["SizeMB"] = res.first / 1024ull / 1024ull;
-		json["DurationMS"] = res.second;
+		json["SizeMB"] = size / 1024ull / 1024ull;
+		json["DurationMS"] = time;
 
 		return Json::Serialize(json);
 	}
 
-	std::string ToXmlStr(const std::pair<uint64_t, double>& res)
+	std::string ToXmlStr(uint64_t size, double time)
 	{
 		xmlNodePtr rootNode = xmlNewNode(nullptr, BAD_CAST "value");
 		xmlNodePtr structNode = xmlNewNode(nullptr, BAD_CAST "struct");
 
-		std::string sizeMB = std::to_string(res.first / 1024ull / 1024ull);
-		std::string durationMS = std::to_string(res.second);
+		std::string sizeMB = std::to_string(size / 1024ull / 1024ull);
+		std::string durationMS = std::to_string(time);
 
 		Xml::AddNewNode(structNode, "SizeMB", "i4", sizeMB.c_str());
 		Xml::AddNewNode(structNode, "DurationMS", "double", durationMS.c_str());
@@ -3795,7 +3795,7 @@ void TestDiskSpeedXmlCommand::Execute()
 		uint64_t maxFileSizeBytes = maxFileSizeGiB * 1024ull * 1024ull * 1024ull;
 		 
 		Benchmark::DiskBenchmark db;
-		auto res = db.Run(
+		auto [size, time] = db.Run(
 			dirPath, 
 			bufferSizeBytes, 
 			maxFileSizeBytes, 
@@ -3803,8 +3803,8 @@ void TestDiskSpeedXmlCommand::Execute()
 		);
 
 		std::string jsonStr = IsJson() ?
-			ToJsonStr(res) :
-			ToXmlStr(res);
+			ToJsonStr(size, time) :
+			ToXmlStr(size, time);
 
 		AppendResponse(jsonStr.c_str());
 	}

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -39,6 +39,8 @@
 #include "UrlCoordinator.h"
 #include "ExtensionManager.h"
 #include "SystemInfo.h"
+#include "Benchmark.h"
+#include "Xml.h"
 
 extern void ExitProc();
 extern void Reload();
@@ -359,6 +361,42 @@ class TestServerSpeedXmlCommand: public SafeXmlCommand
 {
 public:
 	virtual void Execute();
+};
+
+class TestDiskSpeedXmlCommand: public SafeXmlCommand
+{
+public:
+	virtual void Execute();
+
+	std::string ToJsonStr(const std::pair<uint64_t, double>& res)
+	{
+		Json::JsonObject json;
+
+		json["SizeMB"] = res.first / 1024ull / 1024ull;
+		json["DurationMS"] = res.second;
+
+		return Json::Serialize(json);
+	}
+
+	std::string ToXmlStr(const std::pair<uint64_t, double>& res)
+	{
+		xmlNodePtr rootNode = xmlNewNode(nullptr, BAD_CAST "value");
+		xmlNodePtr structNode = xmlNewNode(nullptr, BAD_CAST "struct");
+
+		std::string sizeMB = std::to_string(res.first / 1024ull / 1024ull);
+		std::string durationMS = std::to_string(res.second);
+
+		Xml::AddNewNode(structNode, "SizeMB", "i4", sizeMB.c_str());
+		Xml::AddNewNode(structNode, "DurationMS", "double", durationMS.c_str());
+
+		xmlAddChild(rootNode, structNode);
+		
+		std::string result = Xml::Serialize(rootNode);
+
+		xmlFreeNode(rootNode);
+
+		return result;
+	}
 };
 
 class StartScriptXmlCommand : public XmlCommand
@@ -816,6 +854,10 @@ std::unique_ptr<XmlCommand> XmlRpcProcessor::CreateCommand(const char* methodNam
 	else if (!strcasecmp(methodName, "testserverspeed"))
 	{
 		command = std::make_unique<TestServerSpeedXmlCommand>();
+	}
+		else if (!strcasecmp(methodName, "testdiskspeed"))
+	{
+		command = std::make_unique<TestDiskSpeedXmlCommand>();
 	}
 	else if (!strcasecmp(methodName, "startscript"))
 	{
@@ -3694,6 +3736,82 @@ void TestServerSpeedXmlCommand::Execute()
 	g_UrlCoordinator->AddUrlToQueue(std::move(nzbInfo), true);
 
 	BuildBoolResponse(true);
+}
+
+
+
+void TestDiskSpeedXmlCommand::Execute()
+{
+	char* dirPath;
+	int writeBufferKiB;
+	int maxFileSizeGiB;
+	int timeoutSec;
+
+	if (!NextParamAsStr(&dirPath))
+	{
+		BuildErrorResponse(2, "Invalid argument (Path)");
+		return;
+	}
+
+	if (!NextParamAsInt(&writeBufferKiB))
+	{
+		BuildErrorResponse(2, "Invalid argument (Write Buffer)");
+		return;
+	}
+
+	if (writeBufferKiB < 0)
+	{
+		BuildErrorResponse(2, "Write Buffer cannot be negative");
+		return;
+	}
+
+	if (!NextParamAsInt(&maxFileSizeGiB))
+	{
+		BuildErrorResponse(2, "Invalid argument (Max file size)");
+		return;
+	}
+
+	if (maxFileSizeGiB < 1)
+	{
+		BuildErrorResponse(2, "Max file size must be positive");
+		return;
+	}
+
+	if (!NextParamAsInt(&timeoutSec))
+	{
+		BuildErrorResponse(2, "Invalid argument (Timeout)");
+		return;
+	}
+
+	if (timeoutSec < 1)
+	{
+		BuildErrorResponse(2, "Timeout must be positive");
+		return;
+	}
+
+	try
+	{
+		size_t bufferSizeBytes = writeBufferKiB * 1024;
+		uint64_t maxFileSizeBytes = maxFileSizeGiB * 1024ull * 1024ull * 1024ull;
+		 
+		Benchmark::DiskBenchmark db;
+		auto res = db.Run(
+			dirPath, 
+			bufferSizeBytes, 
+			maxFileSizeBytes, 
+			std::chrono::seconds(timeoutSec)
+		);
+
+		std::string jsonStr = IsJson() ?
+			ToJsonStr(res) :
+			ToXmlStr(res);
+
+		AppendResponse(jsonStr.c_str());
+	}
+	catch (const std::exception& e)
+	{
+		BuildErrorResponse(2, e.what());
+	}
 }
 
 // bool startscript(string script, string command, string context, struct[] options);

--- a/daemon/sources.cmake
+++ b/daemon/sources.cmake
@@ -93,6 +93,7 @@ set(SRC
 	${CMAKE_SOURCE_DIR}/daemon/util/Util.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/Json.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/Xml.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/Benchmark.cpp
 
 	${CMAKE_SOURCE_DIR}/daemon/system/SystemInfo.cpp
 	${CMAKE_SOURCE_DIR}/daemon/system/OS.cpp

--- a/daemon/util/Benchmark.cpp
+++ b/daemon/util/Benchmark.cpp
@@ -1,0 +1,173 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "nzbget.h"
+
+#include <exception>
+#include <random>
+#include "FileSystem.h"
+#include "Benchmark.h"
+
+namespace Benchmark
+{
+	using namespace std::chrono;
+
+	std::pair<uint64_t, double> DiskBenchmark::Run(
+		const std::string& dir,
+		size_t bufferSizeBytes,
+		uint64_t maxFileSizeBytes,
+		seconds timeout) const noexcept(false)
+	{
+		ValidateBufferSize(bufferSizeBytes);
+
+		const std::string filename = dir + PATH_SEPARATOR + GetUniqueFilename();
+		std::ofstream file = OpenFile(filename);
+
+		std::vector<char> buffer;
+		UseBuffer(file, buffer, bufferSizeBytes);
+
+		size_t dataSize = bufferSizeBytes > 0 ? bufferSizeBytes : 1024;
+		std::vector<char> data = GenerateRandomCharsVec(dataSize);
+
+		return RunBench(file, filename, data, maxFileSizeBytes, timeout);
+	}
+
+	std::pair<uint64_t, double> DiskBenchmark::RunBench(
+		std::ofstream& file,
+		const std::string& filename,
+		const std::vector<char>& data,
+		uint64_t maxFileSizeBytes,
+		std::chrono::seconds timeout) const noexcept(false)
+	{
+		const char* dataToWrite = data.data();
+		size_t dataSize = data.size();
+		uint64_t totalWritten = 0;
+
+		auto start = high_resolution_clock::now();
+		try
+		{
+			while (
+				totalWritten < maxFileSizeBytes &&
+				duration_cast<seconds>(high_resolution_clock::now() - start) < timeout)
+			{
+				file.write(dataToWrite, dataSize);
+				totalWritten += dataSize;
+			}
+		}
+		catch (const std::exception& e)
+		{
+			CleanUp(file, filename);
+
+			std::string errMsg = "Failed to write data to file " + filename + ". " + e.what();
+			throw std::runtime_error(errMsg);
+		}
+		auto finish = high_resolution_clock::now();
+
+		CleanUp(file, filename);
+
+		double elapsed = duration<double, std::milli>(finish - start).count();
+
+		return { totalWritten, elapsed };
+	}
+
+	void DiskBenchmark::DeleteFile(const std::string& filename) const noexcept(false)
+	{
+		if (!FileSystem::DeleteFile(filename.c_str()))
+		{
+			std::string errMsg = "Failed to delete " + filename + " test file";
+			throw std::runtime_error(errMsg);
+		}
+	}
+
+	void DiskBenchmark::CleanUp(
+		std::ofstream& file,
+		const std::string& filename) const noexcept(false)
+	{
+		file.close();
+		DeleteFile(filename);
+	}
+
+	std::string DiskBenchmark::GetUniqueFilename() const noexcept(false)
+	{
+		return std::to_string(
+			high_resolution_clock::now().time_since_epoch().count()
+		) + ".bin";
+	}
+
+	std::ofstream DiskBenchmark::OpenFile(const std::string& filename) const noexcept(false)
+	{
+		std::ofstream file(filename, std::ios::binary);
+
+		if (!file.is_open())
+		{
+			std::string errMsg = std::string("Failed to create test file: ") + strerror(errno);
+			throw std::runtime_error(errMsg);
+		}
+
+		file.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+		file.sync_with_stdio(false);
+
+		return file;
+	}
+
+	void DiskBenchmark::ValidateBufferSize(size_t bufferSz) const noexcept(false)
+	{
+		if (bufferSz > m_maxBufferSize)
+		{
+			throw std::invalid_argument("The buffer size is too big");
+		}
+	}
+
+	void DiskBenchmark::UseBuffer(
+		std::ofstream& file,
+		std::vector<char>& buffer,
+		size_t buffSize
+	) const noexcept(false)
+	{
+		if (buffSize > 0)
+		{
+			buffer.resize(buffSize);
+			file.rdbuf()->pubsetbuf(buffer.data(), buffSize);
+		}
+		else
+		{
+			file.rdbuf()->pubsetbuf(nullptr, 0);
+		}
+	}
+
+	std::vector<char> DiskBenchmark::GenerateRandomCharsVec(size_t size) const noexcept(false)
+	{
+		if (size == 0)
+		{
+			return {};
+		}
+
+		std::random_device rd;
+		std::mt19937 gen(rd());
+		std::uniform_int_distribution<> distrib(0, 127);
+
+		std::vector<char> v(size);
+		std::generate(begin(v), end(v), [&distrib, &gen]()
+			{
+				return static_cast<char>(distrib(gen));
+			});
+
+		return v;
+	}
+}

--- a/daemon/util/Benchmark.cpp
+++ b/daemon/util/Benchmark.cpp
@@ -45,7 +45,9 @@ namespace Benchmark
 		size_t dataSize = bufferSizeBytes > 0 ? bufferSizeBytes : 1024;
 		std::vector<char> data = GenerateRandomCharsVec(dataSize);
 
-		return RunBench(file, filename, data, maxFileSizeBytes, timeout);
+		nanoseconds timeoutNS = duration_cast<nanoseconds>(timeout);
+
+		return RunBench(file, filename, data, maxFileSizeBytes, timeoutNS);
 	}
 
 	std::pair<uint64_t, double> DiskBenchmark::RunBench(
@@ -53,11 +55,10 @@ namespace Benchmark
 		const std::string& filename,
 		const std::vector<char>& data,
 		uint64_t maxFileSizeBytes,
-		std::chrono::seconds timeout) const noexcept(false)
+		std::chrono::nanoseconds timeoutNS) const noexcept(false)
 	{
 		uint64_t totalWritten = 0;
 
-		auto timeoutNS = duration_cast<nanoseconds>(timeout);
 		auto start = steady_clock::now();
 		try
 		{

--- a/daemon/util/Benchmark.cpp
+++ b/daemon/util/Benchmark.cpp
@@ -55,19 +55,16 @@ namespace Benchmark
 		uint64_t maxFileSizeBytes,
 		std::chrono::seconds timeout) const noexcept(false)
 	{
-		const char* dataToWrite = data.data();
-		size_t dataSize = data.size();
 		uint64_t totalWritten = 0;
 
-		auto start = high_resolution_clock::now();
+		auto timeoutNS = duration_cast<nanoseconds>(timeout);
+		auto start = steady_clock::now();
 		try
 		{
-			while (
-				totalWritten < maxFileSizeBytes &&
-				duration_cast<seconds>(high_resolution_clock::now() - start) < timeout)
+			while (totalWritten < maxFileSizeBytes && (steady_clock::now() - start) < timeoutNS)
 			{
-				file.write(dataToWrite, dataSize);
-				totalWritten += dataSize;
+				file.write(data.data(), data.size());
+				totalWritten += data.size();
 			}
 		}
 		catch (const std::exception& e)
@@ -77,11 +74,10 @@ namespace Benchmark
 			std::string errMsg = "Failed to write data to file " + filename + ". " + e.what();
 			throw std::runtime_error(errMsg);
 		}
-		auto finish = high_resolution_clock::now();
+		auto finish = steady_clock::now();
+		double elapsed = duration<double, std::milli>(finish - start).count();
 
 		CleanUp(file, filename);
-
-		double elapsed = duration<double, std::milli>(finish - start).count();
 
 		return { totalWritten, elapsed };
 	}

--- a/daemon/util/Benchmark.h
+++ b/daemon/util/Benchmark.h
@@ -41,7 +41,7 @@ namespace Benchmark
 			const std::string& filename,
 			const std::vector<char>& data,
 			uint64_t maxFileSizeBytes,
-			std::chrono::seconds timeout) const noexcept(false);
+			std::chrono::nanoseconds timeoutNS) const noexcept(false);
 
 		void DeleteFile(const std::string& filename) const noexcept(false);
 

--- a/daemon/util/Benchmark.h
+++ b/daemon/util/Benchmark.h
@@ -1,0 +1,70 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef BENCHMARK_H
+#define BENCHMARK_H
+
+#include <chrono>
+#include <string>
+#include <fstream>
+
+namespace Benchmark
+{
+	class DiskBenchmark final
+	{
+	public:
+		std::pair<uint64_t, double> Run(
+			const std::string& dir,
+			size_t bufferSizeBytes,
+			uint64_t maxFileSizeBytes,
+			std::chrono::seconds timeout) const noexcept(false);
+
+	private:
+		std::pair<uint64_t, double> RunBench(
+			std::ofstream& file,
+			const std::string& filename,
+			const std::vector<char>& data,
+			uint64_t maxFileSizeBytes,
+			std::chrono::seconds timeout) const noexcept(false);
+
+		void DeleteFile(const std::string& filename) const noexcept(false);
+
+		std::string GetUniqueFilename() const noexcept(false);
+
+		void CleanUp(
+			std::ofstream& file,
+			const std::string& filename) const noexcept(false);
+
+		std::ofstream OpenFile(const std::string& filename) const noexcept(false);
+
+		void ValidateBufferSize(size_t bufferSz) const noexcept(false);
+
+		void UseBuffer(
+			std::ofstream& file,
+			std::vector<char>& buffer,
+			size_t buffSize
+		) const noexcept(false);
+
+		std::vector<char> GenerateRandomCharsVec(size_t size) const noexcept(false);
+
+		const uint32_t m_maxBufferSize = 1024 * 1024 * 512;
+	};
+}
+
+#endif

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -96,3 +96,4 @@ If HTTP basic authentication is somewhat problematic the username/password can a
 - [testextension](TESTEXTENSION.md)
 - [testserver](TESTSERVER.md)
 - [testserverspeed](TESTSERVERSPEED.md)
+- [testdiskspeed](TESTDISKSPEED.md)

--- a/docs/api/TESTDISKSPEED.md
+++ b/docs/api/TESTDISKSPEED.md
@@ -23,5 +23,5 @@ The function writes data to a file until either the maximum file size is reached
 - **timeout** `(int)` - Test timeout (in seconds).
 
 ### Return value
-- **SizeMB** `(int)` - Written data size (in MiB)`.
-- **DurationMS** `(int)` - Test duration (in miliseconds).
+- **SizeMB** `(int)` - Written data size (in MiB).
+- **DurationMS** `(int)` - Test duration (in milliseconds).

--- a/docs/api/TESTDISKSPEED.md
+++ b/docs/api/TESTDISKSPEED.md
@@ -1,0 +1,27 @@
+## API-method `testdiskspeed`
+
+## Since 
+`v24.3`
+
+### Signature
+``` c++
+bool testdiskspeed(
+    string dirPath, 
+    int writeBufferSize, 
+    int maxFileSize,
+    int timeout,
+);
+```
+
+### Description
+The function writes data to a file until either the maximum file size is reached or the timeout period expires.
+
+### Arguments
+- **dirPath** `(string)` - The path to the directory where the test file will be created.
+- **writeBuffer** `(int)` - The size of the buffer used for writing data to the file (in KiB).
+- **maxFileSize** `(int)` - The maximum size of the file to be created (in GiB).
+- **timeout** `(int)` - Test timeout (in seconds).
+
+### Return value
+- **SizeMB** `(int)` - Written data size (in MiB)`.
+- **DurationMS** `(int)` - Test duration (in miliseconds).

--- a/tests/util/Benchmark.cpp
+++ b/tests/util/Benchmark.cpp
@@ -1,0 +1,48 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <exception>
+#include "Benchmark.h"
+
+BOOST_AUTO_TEST_CASE(BenchmarkTest)
+{
+	Benchmark::DiskBenchmark db;
+	{
+		size_t tooBigBuffer = 1024ul * 1024ul * 1024ul;
+		BOOST_CHECK_THROW(
+			db.Run("./", tooBigBuffer, 1024, std::chrono::seconds(1)), std::invalid_argument
+		);
+	}
+
+	{
+		BOOST_CHECK_THROW(
+			db.Run("InvalidPath", 1024, 1024, std::chrono::seconds(1)), std::runtime_error
+		);
+	}
+
+	{
+		uint64_t  maxFileSize = 1024 * 1024;
+		auto [size, duration] = db.Run("./", 1024, maxFileSize, std::chrono::seconds(1));
+		BOOST_CHECK(size >= maxFileSize || duration < 1.3);
+	}
+}

--- a/tests/util/CMakeLists.txt
+++ b/tests/util/CMakeLists.txt
@@ -4,12 +4,14 @@ file(GLOB UtilTestSrc
 	UtilTest.cpp
 	NStringTest.cpp
 	JsonTest.cpp
+	BenchmarkTest.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/FileSystem.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/NString.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Util.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Json.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Xml.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Log.cpp 
+	${CMAKE_SOURCE_DIR}/daemon/util/Benchmark.cpp
 )
 
 add_executable(UtilTests ${UtilTestSrc})

--- a/webui/index.html
+++ b/webui/index.html
@@ -661,13 +661,86 @@
 													</div>
 												</div>
 
+												<div class="modal hide in" id="DiskSpeedTest_Modal">
+													<div>
+														<div class="modal-header">
+															<button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+															<h3>Disk speed test</h3>
+														</div>
+														<div class="modal-body">
+															<div class="control-group">
+																<div>
+																	<p>
+																		<label class="control-label" for="SysInfo_DiskSpeedTestTimeout">
+																			Timeout
+																		</label>
+																		<div class="controls">
+																			<div class="input-append">
+																				<select class="dist-speedtest__select--width" id="SysInfo_DiskSpeedTestTimeout">
+																					<option value="1" selected>1</option>
+																					<option value="2">2</option>
+																					<option value="3">3</option>
+																					<option value="4">4</option>
+																					<option value="5">5</option>
+																				</select>
+																				<span class="add-on">Seconds</span>
+																			</div>
+																		</div>
+																	</p>
+
+																	<p>
+																		<label class="control-label" for="SysInfo_DiskSpeedTestMaxSize">
+																			Max size
+																		</label>
+																		<div class="controls">
+																			<div class="input-append">
+																				<select class="dist-speedtest__select--width" id="SysInfo_DiskSpeedTestMaxSize">
+																					<option value="1">1</option>
+																					<option value="2">2</option>
+																					<option value="4" selected>4</option>
+																					<option value="8">8</option>
+																					<option value="16">16</option>
+																				</select>
+																				<span class="add-on">GiB</span>
+																			</div>
+																		</div>
+																	</p>
+
+																	<p>
+																		<label class="control-label" for="SysInfo_DiskSpeedTestWriteBufferInput">
+																			WriteBuffer
+																		</label>
+																		<div class="controls">
+																			<div class="input-append">
+																				<input type="text" id="SysInfo_DiskSpeedTestWriteBufferInput" class="editnumeric" required>
+																				<span class="add-on">KiB</span>
+																			</div>
+																		</div>
+																	</p>
+																</div>
+
+																<hr>
+
+																<label class="control-label" for="SysInfo_DiskSpeedTestInput" id="SysInfo_DiskSpeedTestInputLabel"></label>
+																<div class="controls">
+																	<div class="dist-speedtest__controls">
+																		<input type="text" id="SysInfo_DiskSpeedTestInput" class="editlarge" required>
+																		<button type="button" style="width: 115px;" class="btn btn-default" id="SysInfo_DiskSpeedTestBtn"></button>
+																	</div>
+																	<p class="help-text-error" id="SysInfo_DiskSpeedTestErrorTxt"></p>
+																</div>
+															</div>
+														</div>
+													</div>
+												</div>
+
 												<div id="SystemInfo_Spinner" class="system-info__spinner-container ">
 													<i class="material-icon spinner system-info__spinner ">progress_activity</i>
 												</div>
 
 												<div class="alert alert-danger alert-block" style="display:none;" id="SystemInfoErrorAlert">
 													<h4 class="alert-heading">Error</h4>
-													<em id="SystemInfoAlert-text"></em>
+													<em id="SystemInfo_alertText"></em>
 												</div>
 
 												<div id="SystemInfo_MainContent">
@@ -731,11 +804,21 @@
 															</tr>
 															<tr id="SysInfo_DestDiskSpaceContainer">
 																<td width="50%">Free / Total disk space (DestDir)</td>
-																<td id="SysInfo_DestDiskSpace" width="50%"></td>
+																<td width="50%" class="flex-center">
+																	<span id="SysInfo_DestDiskSpace"></span>
+																	<button type="button" id="SysInfo_DestDirDiskTestBtn" data-toggle="modal" data-target="#DiskSpeedTest_Modal" class="btn btn-default">
+																		Speed
+																	</button>
+																</td>
 															</tr>
 															<tr id="SysInfo_InterDiskSpaceContainer">
 																<td width="50%">Free / Total disk space (InterDir)</td>
-																<td id="SysInfo_InterDiskSpace" width="50%"></td>
+																<td width="50%" class="flex-center">
+																	<span id="SysInfo_InterDiskSpace"></span>
+																	<button type="button" id="SysInfo_InterDirDiskTestBtn" data-toggle="modal" data-target="#DiskSpeedTest_Modal" class="btn btn-default">
+																		Speed
+																	</button>
+																</td>
 															</tr>
 															<tr>
 																<td width="50%">Write buffer</td>

--- a/webui/index.html
+++ b/webui/index.html
@@ -677,8 +677,8 @@
 																		<div class="controls">
 																			<div class="input-append">
 																				<select class="dist-speedtest__select--width" id="SysInfo_DiskSpeedTestTimeout">
-																					<option value="1" selected>1</option>
-																					<option value="2">2</option>
+																					<option value="1">1</option>
+																					<option value="2" selected>2</option>
 																					<option value="3">3</option>
 																					<option value="4">4</option>
 																					<option value="5">5</option>

--- a/webui/index.html
+++ b/webui/index.html
@@ -677,8 +677,8 @@
 																		<div class="controls">
 																			<div class="input-append">
 																				<select class="dist-speedtest__select--width" id="SysInfo_DiskSpeedTestTimeout">
-																					<option value="1">1</option>
-																					<option value="2" selected>2</option>
+																					<option value="1" selected>1</option>
+																					<option value="2">2</option>
 																					<option value="3">3</option>
 																					<option value="4">4</option>
 																					<option value="5">5</option>

--- a/webui/index.js
+++ b/webui/index.js
@@ -853,6 +853,7 @@ var Refresher = (new function($)
 			'readurl', 
 			'servervolumes',
 			'testserverspeed',
+			'testdiskspeed',
 		];
 
 		$('#RefreshMenu li a').click(refreshIntervalClick);

--- a/webui/style.css
+++ b/webui/style.css
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
   
-* {
+ * {
 	scrollbar-width: thin;
 }
 
@@ -49,6 +49,13 @@
 body {
 	padding-left: 0;
 	padding-right: 0;
+}
+
+.flex-center {
+	display: flex;
+	align-items: center;
+	width: inherit;
+	gap: 5px;
 }
 
 #AddDialog_URLProp {
@@ -85,6 +92,23 @@ body {
 
 .system-info__spinner {
 	font-size: 128px;
+}
+
+.dist-speedtest__controls {
+	display: flex;
+	gap: 10px;
+}
+
+#ConfigContent select.dist-speedtest__select--width {
+	width: 80px;
+}
+
+.help-text-error {
+	color: #b94a48;
+}
+
+#SysInfo_DiskSpeedTestBtn.btn--disabled {
+	opacity: 0.6 !important;
 }
 
 .spinner {


### PR DESCRIPTION
## Description

- added disk performance tests
- added the new `testdiskspeed` API method:
    #### Arguments
    - **dirPath** `(string)` - The path to the directory where the test file will be created.
    - **writeBuffer** `(int)` - The size of the buffer used for writing data to the file (in KiB).
    - **maxFileSize** `(int)` - The maximum size of the file to be created (in GiB).
    - **timeout** `(int)` - Test timeout (in seconds).
    
    #### Return value
    - **SizeMB** `(int)` - Written data size (in MiB)`.
    - **DurationMS** `(int)` - Test duration (in milliseconds).

## Testing

- Windows 11
- macOS Ventura
- FreeBSD 14
- Linux Debian 12
- Docker:
  - armv7
  - arm64
  - amd64
