### PR TITLE
Fix: default value for OutputMode when disable curses

### DIFF
--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -431,7 +431,11 @@ void Options::InitDefaults()
 	SetOption(OPTION_WRITELOG, "append");
 	SetOption(OPTION_ROTATELOG, "3");
 	SetOption(OPTION_APPENDCATEGORYDIR, "yes");
+#ifdef DISABLE_CURSES
+	SetOption(OPTION_OUTPUTMODE, "color");
+#else
 	SetOption(OPTION_OUTPUTMODE, "curses");
+#endif
 	SetOption(OPTION_DUPECHECK, "yes");
 	SetOption(OPTION_DOWNLOADRATE, "0");
 	SetOption(OPTION_CONTROLIP, "0.0.0.0");


### PR DESCRIPTION
## Description

When curses is disable using `DISABLE_CURSES=ON` the tests fails because default value of OutputMode is set to curses regardless.

I think if build without curses we could set this option to other values (color or log).

Although `nzbget.conf` still have set it to curses, it dont break any tests.

## Testing

This will fix the tests when building with disabled curses.