### PR TITLE
Fix: file corruption on x32 architectures

### DIFF
--- a/daemon/main/nzbget.h
+++ b/daemon/main/nzbget.h
@@ -356,6 +356,7 @@ typedef int pid_t;
 #define FOPEN_WB "wb"
 #define FOPEN_AB "ab"
 #define CHILD_WATCHDOG 1
+#define fseek fseeko
 
 #endif /* POSIX */
 

--- a/daemon/queue/DiskState.cpp
+++ b/daemon/queue/DiskState.cpp
@@ -1233,8 +1233,12 @@ bool DiskState::SaveFileState(FileInfo* fileInfo, StateDiskFile& outfile, bool c
 	outfile.PrintLine("%i", (int)fileInfo->GetArticles()->size());
 	for (ArticleInfo* articleInfo : fileInfo->GetArticles())
 	{
-		outfile.PrintLine("%i,%u,%i,%u", (int)articleInfo->GetStatus(), (uint32)articleInfo->GetSegmentOffset(),
-			articleInfo->GetSegmentSize(), (uint32)articleInfo->GetCrc());
+		outfile.PrintLine("%i,%" PRIi64 ",%i,%u", 
+			(int)articleInfo->GetStatus(), 
+			articleInfo->GetSegmentOffset(),
+			articleInfo->GetSegmentSize(), 
+			articleInfo->GetCrc()
+		);
 	}
 
 	outfile.Close();
@@ -1313,9 +1317,10 @@ bool DiskState::LoadFileState(FileInfo* fileInfo, Servers* servers, StateDiskFil
 
 		if (formatVersion >= 2)
 		{
-			uint32 segmentOffset, crc;
+			int64 segmentOffset;
+			uint32 crc;
 			int segmentSize;
-			if (infile.ScanLine("%i,%u,%i,%u", &statusInt, &segmentOffset, &segmentSize, &crc) != 4) goto error;
+			if (infile.ScanLine("%i,%" PRIi64 ",%i,%u", &statusInt, &segmentOffset, &segmentSize, &crc) != 4) goto error;
 			pa->SetSegmentOffset(segmentOffset);
 			pa->SetSegmentSize(segmentSize);
 			pa->SetCrc(crc);


### PR DESCRIPTION
## Description

- fixed corruption of downloaded files on x32 architectures due to `segmentOffset` overflow and using `fseek` instead of `fseeko` function which can handle int64 width

## Testing

- Windows 11 x86/amd64
- Linux Debian 12 amd64/ararch64/armhf/armel
- FreeBSD 14 amd64
- macOS Ventura amd64
- Synology DS215j (DSM 7.1.1-42962 Update 6) - armhf