### PR TITLE
Bits/s in the speed test results

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -655,7 +655,24 @@
 														<div class="modal-body">
 															<table class="table table-striped table-bordered datatable" id="SpeedTest_StatsTable">
 																<thead><tr><th>Statistics</th><th class="text-center">Data</th></tr></thead>
-																<tbody></tbody>
+																<tbody>
+																	<tr>
+																		<td>Download speed</td>
+																		<td class="text-center" id="SpeedTest_StatsSpeed"></td>
+																	</tr>
+																	<tr>
+																		<td>Download size</td>
+																		<td class="text-center" id="SpeedTest_StatsSize"></td>
+																	</tr>
+																	<tr>
+																		<td>Download time</td>
+																		<td class="text-center" id="SpeedTest_StatsTime"></td>
+																	</tr>
+																	<tr>
+																		<td>Date</td>
+																		<td class="text-center" id="SpeedTest_StatsDate"></td>
+																	</tr>
+																</tbody>
 															</table>
 														</div>
 													</div>

--- a/webui/style.css
+++ b/webui/style.css
@@ -79,8 +79,14 @@ body {
 
 .test-server-dropdwon-menu
 {
-	width: 150px;
+	width: 195px;
 	min-width: auto;
+}
+
+.approx-speed-txt {
+	padding-left: 3px;
+	color: darkgray;
+	font-style: italic;
 }
 
 .system-info__spinner-container {

--- a/webui/util.js
+++ b/webui/util.js
@@ -172,6 +172,12 @@ var Util = (new function($)
 		return Util.round0(bytesPerSec / 1024.0) + ' KB/s';
 	}
 
+	this.formatSpeedWithCustomUnit = function (bytesPerSec, unit) 
+	{
+		var res = this.formatSpeed(bytesPerSec);
+		return res.replace('B', unit);
+	}
+
 	this.formatAge = function(time)
 	{
 		if (time == 0)


### PR DESCRIPTION
## Description

- added Bits/s units to the speed test results.

## Testing

- Windows 11:
  - Chrome 130
  - Edge 128
- macOS Ventura:
  - Safari 17.6