### PR TITLE
Fix: disk status shows 0.0%

### DIFF
--- a/webui/system-info.js
+++ b/webui/system-info.js
@@ -463,7 +463,12 @@ var SystemInfo = (new function($)
 
 	function formatDiskInfo(free, total)
 	{
-		var percents = total !== 0 ? (free / total * 100).toFixed(1) + '%' : '0.0%';
+		if (free === 0 || total === 0)
+		{
+			return 'N/A';
+		}
+
+		var percents = (free / total * 100).toFixed(1) + '%';
 		return Util.formatSizeMB(free) + ' (' + percents + ') / ' + Util.formatSizeMB(total);
 	}
 


### PR DESCRIPTION
## Description

-  show “N/A” instead of 0.0% if the directory does not exist

## Testing

- Windows 11/ Chrome 119