### PR TITLE
Fix: DaemonUsername check on QNAP

### DIFF
--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -1006,8 +1006,13 @@ void NZBGet::Daemonize()
 		}
 	}
 
+	/* Backward compatibility with QNAP which doesn't have a "root" user,
+	but for historical reasons in nzbget.conf we use "root" as the default value in DaemonUsername
+	which causes problems when running nzbget as a daemon on QNAP. */
+	bool backwardCompRoot = strcmp(m_options->GetDaemonUsername(), "root") == 0;
+
 	/* Drop user if there is one, and we were run as root */
-	if (getuid() == 0 || geteuid() == 0)
+	if (!backwardCompRoot && (getuid() == 0 || geteuid() == 0))
 	{
 		struct passwd *pw = getpwnam(m_options->GetDaemonUsername());
 		if (pw == nullptr)

--- a/nzbget.conf
+++ b/nzbget.conf
@@ -453,9 +453,9 @@ UpdateCheck=stable
 # This allows NZBGet daemon to be launched in rc.local (at boot), and
 # download items as a specific user id.
 #
-# NOTE: This option has effect only if the program was started from
-# root-account, otherwise it is ignored and the daemon runs under
-# current user id.
+# NOTE: If DaemonUsername is not "root" and doesn't exist the daemon will not start.
+# NOTE: If the daemon is running as root (superuser) and DaemonUsername exists, 
+# nzbget will drop root privileges to the user specified by DaemonUsername.
 DaemonUsername=root
 
 # Specify default umask, POSIX only (000-1000).


### PR DESCRIPTION
## Description

- added additional check for DaemonUsername if it's equal to "root" for Backward compatibility with QNAP which doesn't have a "root" user, but for historical reasons in nzbget.conf we use "root" as the default value in DaemonUsername which causes problems when running nzbget as a daemon on QNAP.

## Testing

- Linux Debian 12