### PR TITLE
Fix: password-protected unpacking 

### DIFF
--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -675,6 +675,12 @@ void NZBGet::ProcessStandalone()
 		return;
 	}
 	std::unique_ptr<NzbInfo> nzbInfo = nzbFile.DetachNzbInfo();
+
+	if (!nzbFile.GetPassword().empty())
+	{
+		nzbInfo->GetParameters()->SetParameter("*Unpack:Password", nzbFile.GetPassword().c_str());
+	}
+
 	m_scanner->InitPPParameters(category, nzbInfo->GetParameters(), false);
 	m_queueCoordinator->AddNzbFileToQueue(std::move(nzbInfo), nullptr, false);
 }

--- a/daemon/queue/NzbFile.h
+++ b/daemon/queue/NzbFile.h
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 2004 Sven Henkel <sidddy@users.sourceforge.net>
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -30,16 +31,16 @@ class NzbFile
 public:
 	NzbFile(const char* fileName, const char* category);
 	bool Parse();
-	const char* GetFileName() const { return m_fileName; }
+	const char* GetFileName() const { return m_fileName.c_str(); }
 	std::unique_ptr<NzbInfo> DetachNzbInfo() { return std::move(m_nzbInfo); }
-	const char* GetPassword() { return m_password; }
+	const std::string& GetPassword() const { return m_password; }
 
 	void LogDebugInfo();
 
 private:
 	std::unique_ptr<NzbInfo> m_nzbInfo;
-	CString m_fileName;
-	CString m_password;
+	std::string m_fileName;
+	std::string m_password;
 
 	void AddArticle(FileInfo* fileInfo, std::unique_ptr<ArticleInfo> articleInfo);
 	void AddFileInfo(std::unique_ptr<FileInfo> fileInfo);
@@ -48,7 +49,6 @@ private:
 	void ProcessFiles();
 	void CalcHashes();
 	bool HasDuplicateFilenames();
-	void ReadPasswordFromNzb();
 	void ReadPasswordFromFilename();
 	
 

--- a/daemon/queue/Scanner.cpp
+++ b/daemon/queue/Scanner.cpp
@@ -458,9 +458,9 @@ bool Scanner::AddFileToQueue(const char* filename, const char* nzbName, const ch
 		nzbInfo->SetSkipDiskWrite(urlInfo->GetSkipDiskWrite());
 	}
 
-	if (nzbFile.GetPassword())
+	if (!nzbFile.GetPassword().empty())
 	{
-		nzbInfo->GetParameters()->SetParameter("*Unpack:Password", nzbFile.GetPassword());
+		nzbInfo->GetParameters()->SetParameter("*Unpack:Password", nzbFile.GetPassword().c_str());
 	}
 
 	nzbInfo->GetParameters()->CopyFrom(parameters);

--- a/tests/queue/NzbFileTest.cpp
+++ b/tests/queue/NzbFileTest.cpp
@@ -15,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -91,11 +91,11 @@ void TestNzb(std::string testFilename)
 
 	if(strcmp(lastBuffer, buffer) == 0)
 	{
-		BOOST_CHECK(nzbFile.GetPassword() == nullptr);
+		BOOST_CHECK(nzbFile.GetPassword().empty());
 	}
 	else
 	{
-		BOOST_CHECK(std::string(nzbFile.GetPassword()) == std::string(buffer));
+		BOOST_CHECK(nzbFile.GetPassword() == std::string(buffer));
 	}
 
 	fclose(infofile);


### PR DESCRIPTION
## Description

#397
- fixed behavior when nzbget didn't use the password found in the nzb file name or in the nzb file itself if the nzb file was added to the queue via command line

## Testing

- Windows 11
  - unrar 7
- Linux Debian 12
  - unrar 6
  - unrar 7
- macOS Ventura
  - unrar 7