### PR TITLE
Fix: excessive CPU usage

### DIFF
--- a/daemon/connect/Connection.cpp
+++ b/daemon/connect/Connection.cpp
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 2004 Sven Henkel <sidddy@users.sourceforge.net>
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -715,7 +716,7 @@ bool Connection::DoConnect()
 	}
 
 #ifndef DISABLE_TLS
-	if (m_tls && !StartTls(true, nullptr, nullptr))
+	if (m_tls && !StartTls(true, "", ""))
 	{
 		return false;
 	}

--- a/daemon/connect/TlsSocket.cpp
+++ b/daemon/connect/TlsSocket.cpp
@@ -199,7 +199,10 @@ void TlsSocket::InitOptions(const char* certStore)
 #ifdef HAVE_OPENSSL
 void TlsSocket::InitX509Store(const std::string& certStore)
 {
-	if (m_X509Store || certStore.empty()) return;
+	if (m_X509Store) 
+	{
+		FreeX509Store(m_X509Store);
+	}
 
 	m_X509Store = X509_STORE_new();
 	if (!m_X509Store)
@@ -210,11 +213,16 @@ void TlsSocket::InitX509Store(const std::string& certStore)
 
 	if (!X509_STORE_load_locations(m_X509Store, certStore.c_str(), nullptr))
 	{
-		X509_STORE_free(m_X509Store);
-		m_X509Store = nullptr;
+		FreeX509Store(m_X509Store);
 		error("Could not load certificate store location");
 		return;
 	}
+}
+
+void TlsSocket::FreeX509Store(X509_STORE* store)
+{
+	X509_STORE_free(m_X509Store);
+	m_X509Store = nullptr;
 }
 #endif
 

--- a/daemon/connect/TlsSocket.h
+++ b/daemon/connect/TlsSocket.h
@@ -60,6 +60,7 @@ protected:
 private:
 #ifdef HAVE_OPENSSL
 	static void InitX509Store(const std::string& certStore);
+	static void FreeX509Store(X509_STORE* store);
 
 	static X509_STORE* m_X509Store;
 #endif

--- a/daemon/connect/TlsSocket.h
+++ b/daemon/connect/TlsSocket.h
@@ -58,9 +58,12 @@ protected:
 	virtual void PrintError(const char* errMsg);
 
 private:
+#ifdef HAVE_OPENSSL
 	static void InitX509Store(const std::string& certStore);
-	static std::string m_certStore;
+
 	static X509_STORE* m_X509Store;
+#endif
+	static std::string m_certStore;
 
 	SOCKET m_socket;
 

--- a/daemon/connect/TlsSocket.h
+++ b/daemon/connect/TlsSocket.h
@@ -56,6 +56,7 @@ private:
 	bool m_connected = false;
 	int m_retCode;
 	static CString m_certStore;
+	static X509_STORE* m_X509Store;
 	int m_certVerifLevel;
 
 	// using "void*" to prevent the including of GnuTLS/OpenSSL header files into TlsSocket.h

--- a/daemon/connect/TlsSocket.h
+++ b/daemon/connect/TlsSocket.h
@@ -36,10 +36,10 @@ public:
 		int certVerifLevel)
 		: m_socket(socket)
 		, m_isClient(isClient)
-		, m_host(std::string(host))
-		, m_certFile(std::string(certFile))
-		, m_keyFile(std::string(keyFile))
-		, m_cipher(std::string(cipher))
+		, m_host(host ? host : "")
+		, m_certFile(certFile ? certFile : "")
+		, m_keyFile(keyFile ? keyFile : "")
+		, m_cipher(cipher ? cipher : "")
 		, m_certVerifLevel(certVerifLevel) {}
 
 	virtual ~TlsSocket();

--- a/daemon/connect/TlsSocket.h
+++ b/daemon/connect/TlsSocket.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2008-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2024 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef TLSSOCKET_H
@@ -22,19 +23,31 @@
 
 #ifndef DISABLE_TLS
 
-#include "NString.h"
-
 class TlsSocket
 {
 public:
-	TlsSocket(SOCKET socket, bool isClient, const char* host,
-		const char* certFile, const char* keyFile, const char* cipher, int certVerifLevel) :
-		m_socket(socket), m_isClient(isClient), m_host(host),
-		m_certFile(certFile), m_keyFile(keyFile), m_cipher(cipher), m_certVerifLevel(certVerifLevel) {}
+	TlsSocket(
+		SOCKET socket,
+		bool isClient,
+		const char* host,
+		const char* certFile,
+		const char* keyFile,
+		const char* cipher,
+		int certVerifLevel)
+		: m_socket(socket)
+		, m_isClient(isClient)
+		, m_host(std::string(host))
+		, m_certFile(std::string(certFile))
+		, m_keyFile(std::string(keyFile))
+		, m_cipher(std::string(cipher))
+		, m_certVerifLevel(certVerifLevel) {}
+
 	virtual ~TlsSocket();
+
 	static void Init();
-	static void InitOptions(const char* certStore) { m_certStore = certStore; }
+	static void InitOptions(const char* certStore);
 	static void Final();
+
 	bool Start();
 	void Close();
 	int Send(const char* buffer, int size);
@@ -45,18 +58,23 @@ protected:
 	virtual void PrintError(const char* errMsg);
 
 private:
+	static void InitX509Store(const std::string& certStore);
+	static std::string m_certStore;
+	static X509_STORE* m_X509Store;
+
 	SOCKET m_socket;
+
+	std::string m_host;
+	std::string m_certFile;
+	std::string m_keyFile;
+	std::string m_cipher;
+
 	bool m_isClient;
-	CString m_host;
-	CString m_certFile;
-	CString m_keyFile;
-	CString m_cipher;
 	bool m_suppressErrors = false;
 	bool m_initialized = false;
 	bool m_connected = false;
+
 	int m_retCode;
-	static CString m_certStore;
-	static X509_STORE* m_X509Store;
 	int m_certVerifLevel;
 
 	// using "void*" to prevent the including of GnuTLS/OpenSSL header files into TlsSocket.h

--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -303,7 +303,7 @@ void NZBGet::Init()
 	m_scanner->InitOptions();
 	m_queueScriptCoordinator->InitOptions();
 #ifndef DISABLE_TLS
-	TlsSocket::InitOptions(g_Options->GetCertCheck() ? g_Options->GetCertStore() : nullptr);
+	TlsSocket::InitOptions(g_Options->GetCertCheck() ? g_Options->GetCertStore() : "");
 #endif
 
 	if (m_commandLineParser->GetDaemonMode())

--- a/daemon/nntp/NntpConnection.cpp
+++ b/daemon/nntp/NntpConnection.cpp
@@ -194,14 +194,8 @@ bool NntpConnection::Connect()
 	{
 		return true;
 	}
-	auto now = std::chrono::steady_clock::now();
 
-	bool connected = Connection::Connect();
-
-	double elapsedMS = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - now).count();
-
-	detail("Connection elapsed time: %f", elapsedMS);
-	if (!connected)
+	if (!Connection::Connect())
 	{
 		return false;
 	}

--- a/daemon/nntp/NntpConnection.cpp
+++ b/daemon/nntp/NntpConnection.cpp
@@ -194,8 +194,14 @@ bool NntpConnection::Connect()
 	{
 		return true;
 	}
+	auto now = std::chrono::steady_clock::now();
 
-	if (!Connection::Connect())
+	bool connected = Connection::Connect();
+
+	double elapsedMS = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - now).count();
+
+	detail("Connection elapsed time: %f", elapsedMS);
+	if (!connected)
 	{
 		return false;
 	}

--- a/daemon/util/Util.cpp
+++ b/daemon/util/Util.cpp
@@ -884,13 +884,9 @@ int64 Util::CurrentTicks()
 #endif
 }
 
-void Util::Sleep(int milliseconds)
+void Util::Sleep(int ms)
 {
-#ifdef WIN32
-	::Sleep(milliseconds);
-#else
-	usleep(milliseconds * 1000);
-#endif
+	std::this_thread::sleep_for(std::chrono::milliseconds(ms));
 }
 
 uint32 WebUtil::DecodeBase64(char* inputBuffer, int inputBufferLength, char* outputBuffer)


### PR DESCRIPTION
## Description

- fixed excessive CPU usage by decreasing cert.pem certificate loading for TLS connections
- refactoring: using more safe std::string instead of CString

## Testing

- Windows 11
- Linux Debian 12
- macOS Ventura
- FreeBSD 14
