### PR TITLE
Fix: incorrect Windows 7 version on the STATUS page

### DIFF
--- a/daemon/system/OS.cpp
+++ b/daemon/system/OS.cpp
@@ -74,6 +74,7 @@ namespace System
 		if (buildNum >= m_win11BuildVersion) m_version = "11";
 		else if (buildNum >= m_win10BuildVersion) m_version = "10";
 		else if (buildNum >= m_win8BuildVersion) m_version = "8";
+		else if (buildNum >= m_win7BuildVersion) m_version = "7";
 		else if (buildNum >= m_winXPBuildVersion) m_version = "XP";
 		else
 		{


### PR DESCRIPTION
## Description

- STATUS page now shows the correct Windows version `Windows 7` instead of incorrectly showing `Windows XP` running the app on Windows 7

## Testing

- Windows 7
- Windows 11
