### PR TITLE
fix: Par2 repairing status

### DIFF
--- a/daemon/postprocess/ParChecker.cpp
+++ b/daemon/postprocess/ParChecker.cpp
@@ -59,7 +59,7 @@ class Repairer final : public Par2::Par2Repairer, public ParChecker::AbstractRep
 {
 public:
 	Repairer(ParChecker* owner)
-		: Par2::Par2Repairer(owner->m_parCout, owner->m_parCerr, Par2::nlQuiet)
+		: Par2::Par2Repairer(owner->m_parCout, owner->m_parCerr, Par2::nlNormal)
 		, m_owner(owner)
 		, m_commandLine() 
 	{

--- a/daemon/postprocess/ParRenamer.cpp
+++ b/daemon/postprocess/ParRenamer.cpp
@@ -37,7 +37,7 @@
 class ParRenamerRepairer final : public Par2::Par2Repairer
 {
 public:
-	ParRenamerRepairer() : Par2::Par2Repairer(m_nout, m_nout, Par2::nlQuiet) {};
+	ParRenamerRepairer() : Par2::Par2Repairer(m_nout, m_nout, Par2::nlNormal) {};
 	friend class ParRenamer;
 private:
 	class NullStreamBuf : public std::streambuf {};

--- a/daemon/queue/DirectRenamer.cpp
+++ b/daemon/queue/DirectRenamer.cpp
@@ -57,7 +57,7 @@ private:
 class DirectParRepairer : public Par2::Par2Repairer
 {
 public:
-	DirectParRepairer() : Par2::Par2Repairer(m_nout, m_nout, Par2::nlQuiet) {};
+	DirectParRepairer() : Par2::Par2Repairer(m_nout, m_nout, Par2::nlNormal) {};
 	friend class DirectParLoader;
 
 private:


### PR DESCRIPTION
## Description

[issue](https://github.com/nzbgetcom/nzbget/pull/420#issuecomment-2476408211)
- fixed Par2 repair status showing in the webui

## Testing

- Windows 11