### PR TITLE
Fix: build workflow failure due to lack of cleanup before downloading artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,9 @@ jobs:
     if: github.ref_name == 'develop'
     steps:
 
+    - name: Checkout
+      uses: actions/checkout@v4
+
     - name: Delete tag and release
       uses: dev-drprasad/delete-tag-and-release@v0.2.1
       with:


### PR DESCRIPTION
## Description

- added a checkout step to the make-testing-release job in `build` workflow to make sure the runner directory does not contain old deprecated files