### PR TITLE
Update POSIX doc and correct FreeBSD installation supported versions warning

### DIFF
--- a/docs/POSIX.md
+++ b/docs/POSIX.md
@@ -41,11 +41,17 @@ download the libraries at the given URLs and compile them (see hints below).
 
 ### Debian:  
 ```
-apt install cmake build-essential libncurses-dev libssl-dev libxml2-dev zlib1g-dev libboost-json1.81-dev
+apt install cmake build-essential libncurses-dev libssl-dev libxml2-dev zlib1g-dev
 ```
-  - For tests:
+  - Debian 12 (bookworm)
+```bash
+apt install libboost-json1.81-dev
+apt install libboost-test1.81-dev #(optional: for testing)
 ```
-apt install libboost-test1.81-dev
+  - Debian 13 (trixie)
+```bash
+apt install libboost-json-dev 
+apt install libboost-test-dev #(optional: for testing)
 ```
   - For static code analysis:
 ```

--- a/linux/installer.sh
+++ b/linux/installer.sh
@@ -87,7 +87,7 @@ PrintHelp()
         Info "This installer supports Linux kernel 2.6 or newer and the following CPU architectures:"
     fi
     if test "$PLATFORM" = "freebsd"; then
-        Info "This installer supports FreeBSD 9.1 or newer and the following CPU architectures:"
+        Info "This installer supports FreeBSD 13 or newer and the following CPU architectures:"
     fi
     PrintArch "i686"     "    i686     - x86, 32 or 64 Bit"
     PrintArch "x86_64"   "    x86_64   - x86, 64 Bit"


### PR DESCRIPTION
## Description

- updated POSIX documentation to reflect Debian 13
- fixed the supported versions warning when installing FreeBSD