### PR TITLE
Upgrade par2-turbo to v1.2.0

### DIFF
--- a/cmake/par2-turbo.cmake
+++ b/cmake/par2-turbo.cmake
@@ -28,7 +28,7 @@ ExternalProject_add(
 	par2-turbo
 	PREFIX			par2-turbo
 	GIT_REPOSITORY	https://github.com/nzbgetcom/par2cmdline-turbo.git
-	GIT_TAG			v1.1.1-nzbget-20241128
+	GIT_TAG			v1.2.0-nzbget
 	TLS_VERIFY		TRUE
 	GIT_SHALLOW		TRUE
 	GIT_PROGRESS	TRUE


### PR DESCRIPTION
## Lib changes

- upgraded par2-turbo to v1.2.0

## Testing

- Windows 11
- Linux Debian 12
- macOS Ventura