### PR TITLE
Fix: attempting to load the certificate even if CertCheck is turned off

### DIFF
--- a/daemon/connect/TlsSocket.cpp
+++ b/daemon/connect/TlsSocket.cpp
@@ -189,6 +189,9 @@ void TlsSocket::Init()
 
 void TlsSocket::InitOptions(const char* certStore)
 {
+	if (Util::EmptyStr(certStore)) 
+		return;
+
 	m_certStore = certStore;
 
 #ifdef HAVE_OPENSSL


### PR DESCRIPTION
## Description

- fixed: loading of the certificate occurs even when CertCheck is disabled

## Testing

- Windows 11