### PR TITLE
Network speed tests

### DIFF
--- a/daemon/connect/HttpClient.cpp
+++ b/daemon/connect/HttpClient.cpp
@@ -23,7 +23,7 @@
 #include "HttpClient.h"
 #include "Util.h"
 
-namespace HttpClient
+namespace Network
 {
 	namespace asio = boost::asio;
 	using tcp = boost::asio::ip::tcp;

--- a/daemon/connect/HttpClient.h
+++ b/daemon/connect/HttpClient.h
@@ -29,7 +29,7 @@
 #include <boost/asio/ssl.hpp>
 #endif
 
-namespace HttpClient
+namespace Network
 {
 #if !defined(DISABLE_TLS) && defined(HAVE_OPENSSL)
 	using Socket = boost::asio::ssl::stream<boost::asio::ip::tcp::socket>;

--- a/daemon/connect/NetworkSpeedTest.cpp
+++ b/daemon/connect/NetworkSpeedTest.cpp
@@ -1,0 +1,177 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "nzbget.h"
+
+#include <sstream>
+#include "Util.h"
+#include "NetworkSpeedTest.h"
+#include "Connection.h"
+#include "Log.h"
+
+using namespace std::chrono;
+
+namespace Network
+{
+	double SpeedTest::RunTest() noexcept(false)
+	{
+		info("Download speed test starting...");
+
+		for (TestSpec test : m_testSpecs)
+		{
+			if (!RunTest(test)) break;
+			if (!IsRequiredMoreTests()) break;
+		}
+
+		if (m_dataset.empty())
+		{
+			error(m_errMsg);
+			throw std::runtime_error(m_errMsg);
+		}
+
+		double finalSpeed = GetFinalSpeed();
+
+		info("Download speed %.2f Mbps", finalSpeed);
+
+		return finalSpeed;
+	}
+
+	bool SpeedTest::RunTest(TestSpec testSpec)
+	{
+		DataAnalytics data;
+		auto [name, size, iterations, timeout] = testSpec;
+		int failures = 0;
+
+		while (--iterations)
+		{
+			auto [downloaded, elapsedTime] = ExecuteTest(MakeRequest(size), timeout);
+			if (elapsedTime == seconds{ 0 } || downloaded < size)
+			{
+				++failures;
+				if (HasExceededMaxFailures(failures, iterations))
+				{
+					break;
+				}
+
+				continue;
+			}
+
+			double speed = CalculateSpeedInMbps(downloaded, elapsedTime.count());
+			data.AddMeasurement(speed);
+
+			info("Downloaded %s at %.2f Mbps", name, speed);
+		}
+
+		data.Compute();
+		m_dataset.push_back(std::move(data));
+
+		return true;
+	}
+
+	std::pair<uint32_t, duration<double>> SpeedTest::ExecuteTest(std::string request, seconds timeout)
+	{
+		Connection connection(m_host.data(), m_port, m_useTls);
+		connection.SetTimeout(1);
+
+		if (!connection.Connect())
+		{
+			return { 0, seconds{0} };
+		}
+
+		if (!connection.Send(request.c_str(), request.size()))
+		{
+			return { 0, seconds{0} };
+		}
+
+		uint32_t totalRecieved = 0;
+		char buffer[m_bufferSize];
+		auto start = steady_clock::now();
+		while (int recieved = connection.TryRecv(buffer, m_bufferSize))
+		{
+			if (recieved <= 0 || (steady_clock::now() - start) >= timeout)
+			{
+				break;
+			}
+
+			totalRecieved += recieved;
+		}
+		auto finish = steady_clock::now();
+
+		return { totalRecieved, duration<double>(finish - start) };
+	}
+
+	double SpeedTest::CalculateSpeedInMbps(uint32_t bytes, double timeSec) const
+	{
+		double bits = bytes * 8.0;
+		double speed = bits / timeSec;
+		double mbps = speed / 1000000.0;
+		return mbps;
+	}
+
+	bool SpeedTest::IsRequiredMoreTests() const
+	{
+		if (m_dataset.size() < 2)
+			return true;
+
+		const DataAnalytics& curr = m_dataset.back();
+		const DataAnalytics& prev = m_dataset[m_dataset.size() - 2];
+
+		if (curr.GetMedian() > prev.GetPercentile25())
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	bool SpeedTest::HasExceededMaxFailures(int failures, int iterations) const
+	{
+		return failures > std::max(iterations / 2, 2);
+	}
+
+	double SpeedTest::GetFinalSpeed() const
+	{
+		const auto& dataAnalytics = m_dataset.front();
+
+		double maxSpeed = dataAnalytics.GetMedian();
+		for (const auto& analytics : m_dataset)
+		{
+			double speed = analytics.GetPercentile90();
+			if (maxSpeed < speed)
+			{
+				maxSpeed = speed;
+			}
+		}
+
+		return maxSpeed;
+	}
+
+	std::string SpeedTest::MakeRequest(uint32_t filesize) const
+	{
+		std::ostringstream request;
+
+		request << "GET /" << m_path;
+		request << m_query << std::to_string(filesize);
+		request << " HTTP/1.1\r\n";
+		request << "Host: " << m_host << "\r\n";
+		request << "Connection: close\r\n\r\n";
+
+		return request.str();
+	}
+}

--- a/daemon/connect/NetworkSpeedTest.h
+++ b/daemon/connect/NetworkSpeedTest.h
@@ -1,0 +1,96 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef NETWORK_SPEED_TEST_H
+#define NETWORK_SPEED_TEST_H
+
+#include <array>
+#include <chrono>
+#include <string_view>
+
+#include "DataAnalytics.h"
+
+namespace Network
+{
+	class SpeedTest final
+	{
+	public:
+		SpeedTest() = default;
+		SpeedTest(const SpeedTest&) = delete;
+		SpeedTest operator=(const SpeedTest&) = delete;
+
+		double RunTest() noexcept(false);
+
+	private:
+		struct TestSpec
+		{
+			const char* name;
+			uint32_t bytes;
+			int iterations;
+			std::chrono::seconds timeout;
+		};
+
+		enum BytesToDownload : uint32_t
+		{
+			KiB = 1024,
+			KiB100 = 1024 * 100,
+			MiB1 = 1024 * 1024,
+			MiB10 = 1024 * 1024 * 10,
+			MiB25 = 1024 * 1024 * 25,
+			MiB100 = 1024 * 1024 * 100,
+			MiB250 = 1024 * 1024 * 250,
+			GiB1 = 1024 * 1024 * 1024,
+		};
+
+		static constexpr std::array<TestSpec, 7> m_testSpecs
+		{ {
+			{ "100 KiB", KiB100, 10, std::chrono::seconds{1} },
+			{ "1 MiB", MiB1, 8, std::chrono::seconds{2} },
+			{ "10 MiB", MiB10, 6, std::chrono::seconds{2} },
+			{ "25 MiB", MiB25, 4, std::chrono::seconds{2} },
+			{ "100 MiB", MiB100, 3, std::chrono::seconds{3} },
+			{ "250 MiB", MiB250, 2, std::chrono::seconds{4} },
+			{ "1 GiB", GiB1, 2, std::chrono::seconds{5} },
+		} };
+		static constexpr size_t m_bufferSize = 8 * KiB;
+		static constexpr std::string_view m_host = "speed.cloudflare.com";
+		static constexpr std::string_view m_path = "__down";
+		static constexpr std::string_view m_query = "?bytes=";
+		const char* m_errMsg = "No speed data was collected during the network speed test";
+
+		bool RunTest(TestSpec testSpec);
+		std::pair<uint32_t, std::chrono::duration<double>> ExecuteTest(std::string request, std::chrono::seconds timeout);
+		std::string MakeRequest(uint32_t filesize) const;
+		double CalculateSpeedInMbps(uint32_t bytes, double timeSec) const;
+		bool IsRequiredMoreTests() const;
+		bool HasExceededMaxFailures(int failures, int iterations) const;
+		double GetFinalSpeed() const;
+
+#ifdef DISABLE_TLS
+		bool m_useTls = false;
+		int m_port = 80;
+#else
+		bool m_useTls = true;
+		int m_port = 443;
+#endif
+		std::vector<DataAnalytics> m_dataset;
+	};
+}
+
+#endif

--- a/daemon/main/nzbget.h
+++ b/daemon/main/nzbget.h
@@ -158,6 +158,7 @@
 #include <unordered_map>
 #include <iterator>
 #include <algorithm>
+#include <numeric>
 #include <fstream>
 #include <memory>
 #include <functional>

--- a/daemon/sources.cmake
+++ b/daemon/sources.cmake
@@ -3,6 +3,7 @@ set(SRC
 	${CMAKE_SOURCE_DIR}/daemon/connect/TlsSocket.cpp
 	${CMAKE_SOURCE_DIR}/daemon/connect/WebDownloader.cpp
 	${CMAKE_SOURCE_DIR}/daemon/connect/HttpClient.cpp
+	${CMAKE_SOURCE_DIR}/daemon/connect/NetworkSpeedTest.cpp
 
 	${CMAKE_SOURCE_DIR}/daemon/extension/CommandScript.cpp
 	${CMAKE_SOURCE_DIR}/daemon/extension/FeedScript.cpp
@@ -96,6 +97,7 @@ set(SRC
 	${CMAKE_SOURCE_DIR}/daemon/util/Json.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/Xml.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/Benchmark.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/DataAnalytics.cpp
 
 	${CMAKE_SOURCE_DIR}/daemon/system/SystemInfo.cpp
 	${CMAKE_SOURCE_DIR}/daemon/system/OS.cpp

--- a/daemon/system/Network.h
+++ b/daemon/system/Network.h
@@ -24,6 +24,8 @@
 
 namespace System
 {
+	inline const char* IP_SERVICE = "ip.nzbget.com";
+
 	struct Network
 	{
 		std::string publicIP;

--- a/daemon/util/DataAnalytics.cpp
+++ b/daemon/util/DataAnalytics.cpp
@@ -1,0 +1,82 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "nzbget.h"
+
+#include "DataAnalytics.h"
+
+double DataAnalytics::GetMin() const { return m_min; }
+double DataAnalytics::GetMax() const { return m_max; }
+double DataAnalytics::GetAvg() const { return m_avg; }
+double DataAnalytics::GetMedian() const { return m_median; }
+double DataAnalytics::GetPercentile25() const { return m_percentile25; }
+double DataAnalytics::GetPercentile75() const { return m_percentile75; }
+double DataAnalytics::GetPercentile90() const { return m_percentile90; }
+
+void DataAnalytics::Compute()
+{
+	if (m_measurements.empty())
+	{
+		return;
+	}
+
+	std::sort(begin(m_measurements), end(m_measurements));
+
+	m_min = m_measurements.front();
+	m_max = m_measurements.back();
+	m_avg = std::accumulate(cbegin(m_measurements), cend(m_measurements), 0.0) / m_measurements.size();
+	m_median = CalculatePercentile(0.5);
+	m_percentile25 = CalculatePercentile(0.25);
+	m_percentile75 = CalculatePercentile(0.75);
+	m_percentile90 = CalculatePercentile(0.90);
+}
+
+void DataAnalytics::AddMeasurement(double measuremen)
+{
+	m_measurements.push_back(measuremen);
+}
+
+double DataAnalytics::CalculatePercentile(double percentile)
+{
+	if (m_measurements.empty())
+	{
+		return 0.0;
+	}
+
+	if (percentile == 0.0)
+	{
+		return m_measurements.front();
+	}
+
+	if (percentile == 1.0)
+	{
+		return m_measurements.back();
+	}
+
+	double rank = percentile * (m_measurements.size() - 1);
+	size_t idx = static_cast<size_t>(rank);
+	double fraction = rank - idx;
+
+	if (idx + 1 < m_measurements.size()) {
+		return m_measurements[idx] * (1.0 - fraction) + m_measurements[idx + 1] * fraction;
+	}
+
+	return m_measurements[idx];
+}

--- a/daemon/util/DataAnalytics.h
+++ b/daemon/util/DataAnalytics.h
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,35 +17,34 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <vector>
 
-#include "nzbget.h"
-
-#include "Network.h"
-#include "Util.h"
-#include "Log.h"
-#include "HttpClient.h"
-
-namespace System
+class DataAnalytics final
 {
-	Network GetNetwork()
-	{
-		Network network;
+public:
+	DataAnalytics() = default;
+	~DataAnalytics() = default;
 
-		try
-		{
-			::Network::HttpClient httpClient;
-			auto result = httpClient.GET(IP_SERVICE).get();
-			if (result.statusCode == 200)
-			{
-				network.publicIP = std::move(result.body);
-				network.privateIP = httpClient.GetLocalIP();
-			}
-		}
-		catch (const std::exception& e)
-		{
-			detail("Failed to get public and private IP: %s", e.what());
-		}
+	double GetMin() const;
+	double GetMax() const;
+	double GetAvg() const;
+	double GetMedian() const;
+	double GetPercentile25() const;
+	double GetPercentile75() const;
+	double GetPercentile90() const;
 
-		return network;
-	}
-}
+	void Compute();
+	void AddMeasurement(double measuremen);
+
+private:
+	double CalculatePercentile(double percentile);
+
+	double m_min = 0.0;
+	double m_max = 0.0;
+	double m_avg = 0.0;
+	double m_median = 0.0;
+	double m_percentile25 = 0.0;
+	double m_percentile75 = 0.0;
+	double m_percentile90 = 0.0;
+	std::vector<double> m_measurements;
+};

--- a/docs/api/TESTDISKSPEED.md
+++ b/docs/api/TESTDISKSPEED.md
@@ -5,7 +5,7 @@
 
 ### Signature
 ``` c++
-bool testdiskspeed(
+struct testdiskspeed(
     string dirPath, 
     int writeBufferSize, 
     int maxFileSize,

--- a/docs/api/TESTNETWORKSPEED.md
+++ b/docs/api/TESTNETWORKSPEED.md
@@ -1,0 +1,15 @@
+## API-method `testnetworkspeed`
+
+## Since 
+`v24.6`
+
+### Signature
+``` c++
+struct testnetworkspeed();
+```
+
+### Description
+Starts the network speed test.
+
+### Return value
+- **SpeedMbps** `(double)` - The measured network speed in Mbps.

--- a/tests/util/CMakeLists.txt
+++ b/tests/util/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UtilTestSrc
 	NStringTest.cpp
 	JsonTest.cpp
 	BenchmarkTest.cpp
+	DataAnalyticsTest.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/FileSystem.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/NString.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Util.cpp 
@@ -12,6 +13,7 @@ set(UtilTestSrc
 	${CMAKE_SOURCE_DIR}/daemon/util/Xml.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Log.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Benchmark.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/DataAnalytics.cpp
 )
 
 if(WIN32)

--- a/tests/util/DataAnalyticsTest.cpp
+++ b/tests/util/DataAnalyticsTest.cpp
@@ -1,0 +1,47 @@
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+#include "DataAnalytics.h"
+
+BOOST_AUTO_TEST_CASE(test_data_analytics)
+{
+	DataAnalytics da;
+
+	da.Compute();
+
+	BOOST_CHECK_EQUAL(da.GetMin(), 0.0);
+	BOOST_CHECK_EQUAL(da.GetMax(), 0.0);
+	BOOST_CHECK_EQUAL(da.GetAvg(), 0.0);
+	BOOST_CHECK_EQUAL(da.GetMedian(), 0.0);
+	BOOST_CHECK_EQUAL(da.GetPercentile25(), 0.0);
+	BOOST_CHECK_EQUAL(da.GetPercentile75(), 0.0);
+	BOOST_CHECK_EQUAL(da.GetPercentile90(), 0.0);
+
+	da.AddMeasurement(5.0);
+	da.AddMeasurement(10.0);
+	da.AddMeasurement(15.0);
+
+	da.Compute();
+
+	BOOST_CHECK_EQUAL(da.GetMin(), 5.0);
+	BOOST_CHECK_EQUAL(da.GetMax(), 15.0);
+	BOOST_CHECK_EQUAL(da.GetAvg(), 10.0);
+	BOOST_CHECK_EQUAL(da.GetMedian(), 10.0);
+	BOOST_CHECK_EQUAL(da.GetPercentile25(), 7.5);
+	BOOST_CHECK_EQUAL(da.GetPercentile75(), 12.5);
+	BOOST_CHECK_EQUAL(da.GetPercentile90(), 14.0);
+
+
+	da.AddMeasurement(2.0);
+	da.AddMeasurement(8.0);
+
+	da.Compute();
+
+	BOOST_CHECK_EQUAL(da.GetMin(), 2.0);
+	BOOST_CHECK_EQUAL(da.GetMax(), 15.0);
+	BOOST_CHECK_EQUAL(da.GetAvg(), 8.0);
+	BOOST_CHECK_EQUAL(da.GetMedian(), 8.0);
+	BOOST_CHECK_EQUAL(da.GetPercentile25(), 5.0);
+	BOOST_CHECK_EQUAL(da.GetPercentile75(), 10.0);
+	BOOST_CHECK_EQUAL(da.GetPercentile90(), 13.0);
+}

--- a/webui/index.html
+++ b/webui/index.html
@@ -847,7 +847,13 @@
 															</tr>
 															<tr>
 																<td width="50%">Private / Public IP</td>
-																<td id="SysInfo_IP" width="50%"></td>
+																<td width="50%" class="flex-center">
+																	<span id="SysInfo_IP"></span>
+																	<button class="system-info__network-speed-test-btn btn btn-default" type="button" id="SysInfo_NetworkSpeedTestBtn">
+																		Run test
+																	</button>
+																	<span class="help-text-error" id="SysInfo_NetworkSpeedTestErrorTxt"></span>
+																</td>
 															</tr>
 														</tbody>
 													</table>

--- a/webui/style.css
+++ b/webui/style.css
@@ -105,6 +105,7 @@ body {
 	gap: 10px;
 }
 
+.system-info__network-speed-test-btn,
 #ConfigContent select.dist-speedtest__select--width {
 	width: 80px;
 }
@@ -122,10 +123,6 @@ body {
     -webkit-animation:spin 1s linear infinite;
     -moz-animation:spin 1s linear infinite;
     animation:spin 1s linear infinite;
-}
-
-.spinner.material-icon {
-    color: inherit;
 }
 
 @-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
@@ -161,7 +158,7 @@ body {
 }
 
 .btn--disabled {
-	opacity: 0.2 !important;
+	opacity: 0.7 !important;
 	pointer-events: none;
 }
 

--- a/webui/util.js
+++ b/webui/util.js
@@ -31,6 +31,27 @@ var Util = (new function($)
 {
 	'use strict';
 
+	this.saveToLocalStorage = function(key, val)
+	{
+		try 
+		{
+			localStorage.setItem(key, val);
+		} catch (error) 
+		{
+			console.error(error);
+		}
+	}
+
+	this.getFromLocalStorage = function(key)
+	{
+		return localStorage.getItem(key);
+	}
+
+	this.removeFromLocalStorage = function(key)
+	{
+		return localStorage.removeItem(key);
+	}
+
 	this.formatTimeHMS = function(sec)
 	{
 		var hms = '';
@@ -83,8 +104,18 @@ var Util = (new function($)
 		return seconds + 's';
 	}
 
+	this.isNumber = function(value)
+	{
+		return typeof value === 'number';
+	}
+
 	this.formatDateTime = function(unixTime)
 	{
+		if (!Util.isNumber(unixTime) || unixTime < 0)
+		{
+			return '';
+		}
+
 		var dt = new Date(unixTime * 1000);
 		var h = dt.getHours();
 		var m = dt.getMinutes();
@@ -139,7 +170,7 @@ var Util = (new function($)
 
 	this.formatSpeed = function (bytesPerSec) 
 	{
-		if (bytesPerSec <= 0)
+		if (!Util.isNumber(bytesPerSec) || bytesPerSec <= 0) 
 		{
 			return '';
 		}
@@ -170,6 +201,42 @@ var Util = (new function($)
 		}
 
 		return Util.round0(bytesPerSec / 1024.0) + ' KB/s';
+	}
+
+	this.formatNetworkSpeed = function(speedMbps) 
+	{
+		if (!Util.isNumber(speedMbps))
+		{
+			return '';
+		}
+
+		if (!speedMbps || speedMbps < 0)
+		{
+			return '';
+		}
+
+		if (speedMbps >= 10000) 
+		{
+			return Util.round1(speedMbps / 10000) + ' Gbps';
+		}
+		if (speedMbps >= 1000) 
+		{
+			return Util.round1(speedMbps / 1000) + ' Gbps';
+		} 
+		else if (speedMbps >= 100) 
+		{
+			return Util.round0(speedMbps) + ' Mbps';
+		} 
+		else if (speedMbps >= 10) 
+		{
+			return Util.round1(speedMbps) + ' Mbps';
+		} 
+		else if (speedMbps >= 1) 
+		{
+			return Util.round2(speedMbps) + ' Mbps';
+		}
+
+		return Util.round0(speedMbps * 1000) + ' Kbps';
 	}
 
 	this.formatSpeedWithCustomUnit = function (bytesPerSec, unit) 


### PR DESCRIPTION
## Description

- added network speed tests
- added the new `testnetworkspeed` API method:
    #### Return value
    - **SpeedMbps** `(double)` - The measured network speed in Mbps.
    
    
## Testing

- Windows 11 amd64 
- Linux Debian 12 amd64
- Linux Debian 12 aarch64
- macOS 13 amd64
