### PR TITLE
Fix: DirectRename and ParRename support of nested file paths found in par files

### DIFF
--- a/daemon/nntp/ArticleWriter.h
+++ b/daemon/nntp/ArticleWriter.h
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2014-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -50,7 +50,8 @@ private:
 class ArticleWriter
 {
 public:
-	void SetInfoName(const char* infoName) { m_infoName = infoName; }
+	void SetInfoName(const char* infoName) { m_infoName = infoName ? infoName : ""; }
+	void SetInfoName(std::string infoName) { m_infoName = std::move(infoName); }
 	void SetFileInfo(FileInfo* fileInfo) { m_fileInfo = fileInfo; }
 	void SetArticleInfo(ArticleInfo* articleInfo) { m_articleInfo = articleInfo; }
 	void Prepare();
@@ -67,16 +68,16 @@ private:
 	FileInfo* m_fileInfo;
 	ArticleInfo* m_articleInfo;
 	DiskFile m_outFile;
-	CString m_tempFilename;
-	CString m_outputFilename;
-	const char* m_resultFilename = nullptr;
+	std::string m_tempFilename;
+	std::string m_outputFilename;
+	std::string m_resultFilename;
+	std::string m_infoName;
 	Decoder::EFormat m_format = Decoder::efUnknown;
 	CachedSegmentData m_articleData;
 	int64 m_articleOffset;
 	int m_articleSize;
 	int m_articlePtr;
 	bool m_duplicate = false;
-	CString m_infoName;
 
 	bool CreateOutputFile(int64 size);
 	void BuildOutputFilename();

--- a/daemon/queue/DirectRenamer.h
+++ b/daemon/queue/DirectRenamer.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,6 +22,7 @@
 #ifndef DIRECTRENAMER_H
 #define DIRECTRENAMER_H
 
+#include <string>
 #include "ArticleDownloader.h"
 
 class DirectRenamer
@@ -72,11 +74,13 @@ private:
 	void CheckState(DownloadQueue* downloadQueue, NzbInfo* nzbInfo);
 	void UnpausePars(NzbInfo* nzbInfo);
 	void RenameFiles(DownloadQueue* downloadQueue, NzbInfo* nzbInfo, FileHashList* parHashes);
-	bool RenameCompletedFile(NzbInfo* nzbInfo, const char* oldName, const char* newName);
+	bool RenameCompletedFile(NzbInfo* nzbInfo, const std::string& oldFullFilename, const std::string& newFullFilename);
 	bool NeedRenamePars(NzbInfo* nzbInfo);
 	void CollectPars(NzbInfo* nzbInfo, ParFileList* parFiles);
-	CString BuildNewRegularName(const char* oldName, FileHashList* parHashes, const char* hash16k);
-	CString BuildNewParName(const char* oldName, const char* destDir, const char* setId, int& vol);
+	std::string BuildNewRegularName(const char* oldName, FileHashList* parHashes, const char* hash16k);
+	std::string BuildNewParName(const char* oldName, const char* destDir, const char* setId, int& vol);
+	int RenameCompletedFiles(NzbInfo* nzbInfo, FileHashList* parHashes, bool needRenamePars, int& vol);
+	int RenameFilesInProgress(NzbInfo* nzbInfo, FileHashList* parHashes, bool needRenamePars, int& vol);
 
 	friend class DirectParLoader;
 };

--- a/daemon/queue/DiskState.cpp
+++ b/daemon/queue/DiskState.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -903,11 +903,15 @@ bool DiskState::LoadNzbInfo(NzbInfo* nzbInfo, Servers* servers, StateDiskFile& i
 			}
 		}
 
-		nzbInfo->GetCompletedFiles()->emplace_back(id, fileName,
-			Util::EmptyStr(origName) ? nullptr : origName,
-			(CompletedFile::EStatus)status, crc, (bool)parFile,
-			Util::EmptyStr(hash16k) ? nullptr : hash16k,
-			Util::EmptyStr(parSetId) ? nullptr : parSetId);
+		nzbInfo->GetCompletedFiles()->emplace_back(
+			id, 
+			Util::EmptyStr(fileName) ? "" : fileName,
+			Util::EmptyStr(origName) ? "" : origName,
+			static_cast<CompletedFile::EStatus>(status), 
+			crc, 
+			static_cast<bool>(parFile),
+			Util::EmptyStr(hash16k) ? "" : hash16k,
+			Util::EmptyStr(parSetId) ? "" : parSetId);
 	}
 
 	nzbInfo->GetParameters()->clear();

--- a/daemon/queue/DownloadInfo.cpp
+++ b/daemon/queue/DownloadInfo.cpp
@@ -839,10 +839,16 @@ void FileInfo::SetActiveDownloads(int activeDownloads)
 }
 
 
-CompletedFile::CompletedFile(int id, const char* filename, const char* origname, EStatus status,
-	uint32 crc, bool parFile, const char* hash16k, const char* parSetId) :
-	m_id(id), m_filename(filename), m_origname(origname), m_status(status),
-	m_crc(crc), m_parFile(parFile), m_hash16k(hash16k), m_parSetId(parSetId)
+CompletedFile::CompletedFile(int id, std::string filename, std::string origname, EStatus status,
+	uint32 crc, bool parFile, std::string hash16k, std::string parSetId) 
+	: m_id(id)
+	, m_filename(std::move(filename))
+	, m_origname(std::move(origname))
+	, m_status(status)
+	, m_crc(crc)
+	, m_parFile(parFile)
+	, m_hash16k(std::move(hash16k))
+	, m_parSetId(std::move(parSetId))
 {
 	if (FileInfo::m_idMax < m_id)
 	{

--- a/daemon/queue/DownloadInfo.h
+++ b/daemon/queue/DownloadInfo.h
@@ -3,7 +3,7 @@
  *
  *  Copyright (C) 2004 Sven Henkel <sidddy@users.sourceforge.net>
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -177,8 +177,9 @@ public:
 	bool GetParFile() { return m_parFile; }
 	void SetParFile(bool parFile) { m_parFile = parFile; }
 	Guard GuardOutputFile() { return Guard(m_outputFileMutex); }
-	const char* GetOutputFilename() { return m_outputFilename; }
-	void SetOutputFilename(const char* outputFilename) { m_outputFilename = outputFilename; }
+	const std::string& GetOutputFilename() const { return m_outputFilename; }
+	void SetOutputFilename(const char* outputFilename) { m_outputFilename = outputFilename ? outputFilename : ""; }
+	void SetOutputFilename(std::string outputFilename) { m_outputFilename = std::move(outputFilename); }
 	bool GetOutputInitialized() { return m_outputInitialized; }
 	void SetOutputInitialized(bool outputInitialized) { m_outputInitialized = outputInitialized; }
 	bool GetExtraPriority() { return m_extraPriority; }
@@ -231,7 +232,7 @@ private:
 	bool m_parFile = false;
 	int m_completedArticles = 0;
 	bool m_outputInitialized = false;
-	CString m_outputFilename;
+	std::string m_outputFilename;
 	std::unique_ptr<Mutex> m_outputFileMutex;
 	bool m_extraPriority = false;
 	int m_activeDownloads = 0;
@@ -265,30 +266,30 @@ public:
 		cfFailure
 	};
 
-	CompletedFile(int id, const char* filename, const char* oldname, EStatus status,
-		uint32 crc, bool parFile, const char* hash16k, const char* parSetId);
+	CompletedFile(int id, std::string filename, std::string oldname, EStatus status,
+		uint32 crc, bool parFile, std::string hash16k, std::string parSetId);
 	int GetId() { return m_id; }
-	void SetFilename(const char* filename) { m_filename = filename; }
-	const char* GetFilename() { return m_filename; }
-	void SetOrigname(const char* origname) { m_origname = origname; }
-	const char* GetOrigname() { return m_origname; }
+	void SetFilename(std::string filename) { m_filename = std::move(filename); }
+	const char* GetFilename() { return m_filename.c_str(); }
+	void SetOrigname(std::string origname) { m_origname = std::move(origname); }
+	const char* GetOrigname() { return m_origname.c_str(); }
 	bool GetParFile() { return m_parFile; }
 	EStatus GetStatus() { return m_status; }
 	uint32 GetCrc() { return m_crc; }
-	const char* GetHash16k() { return m_hash16k; }
-	void SetHash16k(const char* hash16k) { m_hash16k = hash16k; }
-	const char* GetParSetId() { return m_parSetId; }
-	void SetParSetId(const char* parSetId) { m_parSetId = parSetId; }
+	const char* GetHash16k() { return m_hash16k.c_str(); }
+	void SetHash16k(std::string hash16k) { m_hash16k = std::move(hash16k); }
+	const char* GetParSetId() { return m_parSetId.c_str(); }
+	void SetParSetId(std::string parSetId) { m_parSetId = std::move(parSetId); }
 
 private:
 	int m_id;
-	CString m_filename;
-	CString m_origname;
 	EStatus m_status;
 	uint32 m_crc;
 	bool m_parFile;
-	CString m_hash16k;
-	CString m_parSetId;
+	std::string m_filename;
+	std::string m_origname;
+	std::string m_hash16k;
+	std::string m_parSetId;
 };
 
 typedef std::deque<CompletedFile> CompletedFileList;

--- a/daemon/queue/HistoryCoordinator.cpp
+++ b/daemon/queue/HistoryCoordinator.cpp
@@ -130,9 +130,16 @@ void HistoryCoordinator::AddToHistory(DownloadQueue* downloadQueue, NzbInfo* nzb
 	for (FileInfo* fileInfo : nzbInfo->GetFileList())
 	{
 		nzbInfo->UpdateCompletedStats(fileInfo);
-		nzbInfo->GetCompletedFiles()->emplace_back(fileInfo->GetId(), fileInfo->GetFilename(),
-			fileInfo->GetOrigname(), CompletedFile::cfNone, 0, fileInfo->GetParFile(),
-			fileInfo->GetHash16k(), fileInfo->GetParSetId());
+		nzbInfo->GetCompletedFiles()->emplace_back(
+			fileInfo->GetId(),
+			fileInfo->GetFilename() ? fileInfo->GetFilename() : "",
+			fileInfo->GetOrigname() ? fileInfo->GetOrigname() : "",
+			CompletedFile::cfNone,
+			0,
+			fileInfo->GetParFile(),
+			fileInfo->GetHash16k() ? fileInfo->GetHash16k() : "",
+			fileInfo->GetParSetId() ? fileInfo->GetParSetId() : ""
+		);
 	}
 
 	// Cleaning up parked files if par-check was successful or unpack was successful or

--- a/daemon/queue/QueueCoordinator.cpp
+++ b/daemon/queue/QueueCoordinator.cpp
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 2005 Bo Cordes Petersen <placebodk@users.sourceforge.net>
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -861,13 +862,21 @@ void QueueCoordinator::DeleteFileInfo(DownloadQueue* downloadQueue, FileInfo* fi
 
 	if (completed || parking)
 	{
+		const std::string& outputFilename = fileInfo->GetOutputFilename();
+		std::string filename = (completed && !outputFilename.empty())
+			? FileSystem::BaseFileName(outputFilename.c_str())
+			: (fileInfo->GetFilename() ? fileInfo->GetFilename() : "");
+
 		fileInfo->GetNzbInfo()->GetCompletedFiles()->emplace_back(
 			fileInfo->GetId(),
-			completed && fileInfo->GetOutputFilename() ?
-			FileSystem::BaseFileName(fileInfo->GetOutputFilename()) : fileInfo->GetFilename(),
-			fileInfo->GetOrigname(), fileStatus,
+			std::move(filename),
+			fileInfo->GetOrigname() ? fileInfo->GetOrigname() : "", 
+			fileStatus,
 			fileStatus == CompletedFile::cfSuccess ? fileInfo->GetCrc() : 0,
-			fileInfo->GetParFile(), fileInfo->GetHash16k(), fileInfo->GetParSetId());
+			fileInfo->GetParFile(), 
+			fileInfo->GetHash16k() ? fileInfo->GetHash16k() : "", 
+			fileInfo->GetParSetId() ? fileInfo->GetParSetId() : ""
+		);
 	}
 
 	if (g_Options->GetDirectRename())
@@ -905,9 +914,10 @@ void QueueCoordinator::DiscardTempFiles(FileInfo* fileInfo)
 		}
 	}
 
-	if (g_Options->GetDirectWrite() && fileInfo->GetOutputFilename() && !fileInfo->GetForceDirectWrite())
+	const std::string& outputFilename = fileInfo->GetOutputFilename();
+	if (g_Options->GetDirectWrite() && !outputFilename.empty() && !fileInfo->GetForceDirectWrite())
 	{
-		FileSystem::DeleteFile(fileInfo->GetOutputFilename());
+		FileSystem::DeleteFile(outputFilename.c_str());
 	}
 }
 

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -414,6 +414,21 @@ char* FileSystem::BaseFileName(const char* filename)
 	}
 }
 
+std::pair<std::string, std::string> FileSystem::SplitPathAndFilename(const std::string& fullPath)
+{
+	size_t lastSlashPos = fullPath.find_last_of("/\\");
+
+	if (lastSlashPos == std::string::npos)
+	{
+		return std::make_pair(fullPath, "");
+	}
+
+	std::string path = fullPath.substr(0, lastSlashPos);
+	std::string filename = fullPath.substr(lastSlashPos + 1);
+
+	return std::make_pair(std::move(path), std::move(filename));
+}
+
 bool FileSystem::ReservedChar(char ch)
 {
 	if ((unsigned char)ch < 32)

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -38,6 +38,7 @@ class FileSystem
 public:
 	static CString GetLastErrorMessage();
 	static char* BaseFileName(const char* filename);
+	static std::pair<std::string, std::string> SplitPathAndFilename(const std::string& fullPath);
 	static bool SameFilename(const char* filename1, const char* filename2);
 	static void NormalizePathSeparators(char* path);
 	static std::optional<std::string> GetRealPath(const std::string& path);

--- a/tests/util/FileSystemTest.cpp
+++ b/tests/util/FileSystemTest.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -68,3 +68,82 @@ BOOST_AUTO_TEST_CASE(EscapePathForShellTest)
 
 #endif
 
+BOOST_AUTO_TEST_CASE(SplitPathAndFilenameTest)
+{
+	{
+		std::string fullPath = "/path/to/filename.txt";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "/path/to");
+		BOOST_TEST(result.second == "filename.txt");
+	}
+
+	{
+		std::string fullPath = "/path/to/";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "/path/to");
+		BOOST_TEST(result.second == "");
+	}
+
+	{
+		std::string fullPath = "C:\\path\\to\\filename.txt";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "C:\\path\\to");
+		BOOST_TEST(result.second == "filename.txt");
+	}
+
+	{
+		std::string fullPath = "C:\\path\\to\\";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "C:\\path\\to");
+		BOOST_TEST(result.second == "");
+	}
+
+	{
+		std::string fullPath = "/path\\to/filename.txt";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "/path\\to");
+		BOOST_TEST(result.second == "filename.txt");
+	}
+
+	{
+		std::string fullPath = "";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "");
+		BOOST_TEST(result.second == "");
+	}
+
+	{
+		std::string fullPath = "/filename.txt";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "");
+		BOOST_TEST(result.second == "filename.txt");
+	}
+
+	{
+		std::string fullPath = "\\filename.txt";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "");
+		BOOST_TEST(result.second == "filename.txt");
+	}
+
+	{
+		std::string fullPath = "/path/to\\a/b\\c/filename.txt";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "/path/to\\a/b\\c");
+		BOOST_TEST(result.second == "filename.txt");
+	}
+
+	{
+		std::string fullPath = "/";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "");
+		BOOST_TEST(result.second == "");
+	}
+
+	{
+		std::string fullPath = "\\";
+		std::pair<std::string, std::string> result = FileSystem::SplitPathAndFilename(fullPath);
+		BOOST_TEST(result.first == "");
+		BOOST_TEST(result.second == "");
+	}
+}


### PR DESCRIPTION
## Description

- DirectRename and ParRename now correctly handle nested file paths found in par files

## Testing

- Windows 11 AMD64
- Linux Debian 12 AMD64
