### PR TITLE
Fix: errors in par2 verification and completed file moving

### DIFF
--- a/cmake/par2-turbo.cmake
+++ b/cmake/par2-turbo.cmake
@@ -43,7 +43,7 @@ ExternalProject_add(
 	par2-turbo
 	PREFIX			par2-turbo
 	GIT_REPOSITORY	https://github.com/nzbgetcom/par2cmdline-turbo.git
-	GIT_TAG			v1.2.0-nzbget
+	GIT_TAG			v1.2.0-nzbget-20250213
 	TLS_VERIFY		TRUE
 	GIT_SHALLOW		TRUE
 	GIT_PROGRESS	TRUE

--- a/daemon/postprocess/ParChecker.cpp
+++ b/daemon/postprocess/ParChecker.cpp
@@ -851,6 +851,24 @@ void ParChecker::SortExtraFiles(std::vector<std::string>& extrafiles)
 	);
 }
 
+void ParChecker::FindExtraFiles(std::vector<std::string> extrafiles, const char* directory, bool externalDir)
+{
+	DirBrowser dir(directory);
+	while (const char* filename = dir.Next())
+	{
+		BString<1024> fullFilename("%s%c%s", directory, PATH_SEPARATOR, filename);
+
+		if (FileSystem::DirectoryExists(fullFilename))
+		{
+			FindExtraFiles(extrafiles, fullFilename, externalDir);
+		}
+		else if (externalDir || (!IsParredFile(filename) && !IsProcessedFile(filename)))
+		{
+			extrafiles.push_back(std::string(directory) + PATH_SEPARATOR + filename);
+		}
+	}
+}
+
 bool ParChecker::AddExtraFiles(bool onlyMissing, bool externalDir, const char* directory)
 {
 	if (externalDir)
@@ -864,14 +882,7 @@ bool ParChecker::AddExtraFiles(bool onlyMissing, bool externalDir, const char* d
 
 	std::vector<std::string> extrafiles;
 
-	DirBrowser dir(directory);
-	while (const char* filename = dir.Next())
-	{
-		if (externalDir || (!IsParredFile(filename) && !IsProcessedFile(filename)))
-		{
-			extrafiles.push_back(std::string(directory) + PATH_SEPARATOR + filename);
-		}
-	}
+	FindExtraFiles(extrafiles, directory, externalDir);
 
 	SortExtraFiles(extrafiles);
 

--- a/daemon/postprocess/ParChecker.h
+++ b/daemon/postprocess/ParChecker.h
@@ -230,6 +230,7 @@ private:
 	EFileStatus VerifyDataFile(Par2::DiskFile& diskFile, Par2::Par2RepairerSourceFile& sourceFile, int& availableBlocks);
 	bool VerifySuccessDataFile(Par2::DiskFile& diskFile, Par2::Par2RepairerSourceFile& sourceFile, uint32 downloadCrc);
 	bool VerifyPartialDataFile(Par2::DiskFile& diskFile, Par2::Par2RepairerSourceFile& sourceFile, SegmentList& segments, ValidBlocks& validBlocks);
+	void FindExtraFiles(std::vector<std::string> extrafiles, const char* directory, bool externalDir);
 	void SortExtraFiles(std::vector<std::string>& extrafiles);
 	bool SmartCalcFileRangeCrc(DiskFile& file, int64 start, int64 end, SegmentList& segments, uint32& downloadCrc);
 	bool DumbCalcFileRangeCrc(DiskFile& file, int64 start, int64 end, uint32& downloadCrc);

--- a/daemon/queue/DirectRenamer.h
+++ b/daemon/queue/DirectRenamer.h
@@ -74,7 +74,7 @@ private:
 	void CheckState(DownloadQueue* downloadQueue, NzbInfo* nzbInfo);
 	void UnpausePars(NzbInfo* nzbInfo);
 	void RenameFiles(DownloadQueue* downloadQueue, NzbInfo* nzbInfo, FileHashList* parHashes);
-	bool RenameCompletedFile(NzbInfo* nzbInfo, const std::string& oldFullFilename, const std::string& newFullFilename);
+	bool RenameFile(NzbInfo* nzbInfo, const std::string& oldFullFilename, const std::string& newFullFilename);
 	bool NeedRenamePars(NzbInfo* nzbInfo);
 	void CollectPars(NzbInfo* nzbInfo, ParFileList* parFiles);
 	std::string BuildNewRegularName(const char* oldName, FileHashList* parHashes, const char* hash16k);

--- a/daemon/queue/DiskState.cpp
+++ b/daemon/queue/DiskState.cpp
@@ -29,7 +29,7 @@
 
 static const char* FORMATVERSION_SIGNATURE = "nzbget diskstate file version ";
 const int DISKSTATE_QUEUE_VERSION = 62;
-const int DISKSTATE_FILE_VERSION = 6;
+const int DISKSTATE_FILE_VERSION = 7;
 const int DISKSTATE_STATS_VERSION = 3;
 const int DISKSTATE_FEEDS_VERSION = 3;
 
@@ -1067,6 +1067,7 @@ bool DiskState::SaveFileInfo(FileInfo* fileInfo, StateDiskFile& outfile, bool ar
 	outfile.PrintLine("%s", fileInfo->GetSubject());
 	outfile.PrintLine("%s", fileInfo->GetFilename());
 	outfile.PrintLine("%s", fileInfo->GetOrigname() ? fileInfo->GetOrigname() : "");
+	outfile.PrintLine("%s", fileInfo->GetOutputFilename().c_str());
 
 	outfile.PrintLine("%i,%i", (int)fileInfo->GetFilenameConfirmed(), (int)fileInfo->GetTime());
 
@@ -1134,6 +1135,15 @@ bool DiskState::LoadFileInfo(FileInfo* fileInfo, StateDiskFile& infile, int form
 	{
 		if (!infile.ReadLine(buf, sizeof(buf))) goto error;
 		if (fileSummary) fileInfo->SetOrigname(Util::EmptyStr(buf) ? nullptr : buf);
+	}
+
+	if (formatVersion >= 7)
+	{
+		if (!infile.ReadLine(buf, sizeof(buf))) goto error;
+		if (!Util::EmptyStr(buf))
+		{
+			fileInfo->SetOutputFilename(buf);
+		}
 	}
 
 	if (formatVersion >= 5)


### PR DESCRIPTION
## Description

- fixed errors in par2 verification and completed file moving caused by incorrect filenames and improper handling of nested files

## Lib changes

- updated par2-turbo library to the latest version, improving UNC path support and fixing build problems on RISC-V64 with GCC 13

## Testing

- Windows 11 AMD64
- Linux Debian 12 AMD64