### PR TITLE
Add filter to nzb upload dialog

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -2647,7 +2647,7 @@
 					<label class="control-label" for="AddDialog_Files">Add local files</label>
 					<div class="controls">
 						<div style="margin-top:6px; margin-bottom:10px;"><a href="#" class="btn btn-default" style="margin-top: -6px;" id="AddDialog_Select">Select files</a> or drop files here.</div>
-						<input multiple="multiple" type="file" id="AddDialog_Input" class="hidden-file-input">
+						<input multiple="multiple" type="file" accept=".nzb" id="AddDialog_Input" class="hidden-file-input">
 						<div class="dialog-add-files hide" id="AddDialog_Files"></div>
 						<div class="hide" style="margin-top:12px;" id="AddDialog_RenameTip">Tip: click on an item to rename or set password.</div>
 					</div>


### PR DESCRIPTION
## Description

Unfiltered dialog shows all files.  This change will start the dialog with a *.nzb filter applied, reducing the number of files shown in the dialog

## Lib changes

N/A

## Testing

Trivial change, works as expected in latest Chrome browser