### PR TITLE
Fix build with -DDISABLE_PARCHECK=yes by adding missing include

### DIFF
--- a/daemon/nntp/ArticleWriter.cpp
+++ b/daemon/nntp/ArticleWriter.cpp
@@ -22,6 +22,7 @@
 #include "nzbget.h"
 
 #include <sstream>
+#include <iomanip>
 #include "ArticleWriter.h"
 #include "DiskState.h"
 #include "Options.h"

--- a/daemon/queue/DirectRenamer.cpp
+++ b/daemon/queue/DirectRenamer.cpp
@@ -23,6 +23,7 @@
 
 #include <sstream>
 #include <iostream>
+#include <iomanip>
 #include "DirectRenamer.h"
 #include "Options.h"
 #include "FileSystem.h"


### PR DESCRIPTION
Otherwise, the build fails with `error: ‘setfill’ is not a member of ‘std’`.

## Description

Fixes the build when `-DDISABLE_PARCHECK=yes` is used.

## Lib changes

N/A

## Testing

Built nzbget and ran `ctest`.