### PR TITLE
Fix: cannot find Python on Windows

### DIFF
--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -707,7 +707,10 @@ void Options::InitOptions()
 	m_extCleanupDisk		= GetOption(OPTION_EXTCLEANUPDISK);
 	m_parIgnoreExt			= GetOption(OPTION_PARIGNOREEXT);
 	m_unpackIgnoreExt		= GetOption(OPTION_UNPACKIGNOREEXT);
-	m_shellOverride			= GetOption(OPTION_SHELLOVERRIDE);
+
+	const char* shellOverride = GetOption(OPTION_SHELLOVERRIDE);
+	m_shellOverride	= shellOverride ? shellOverride : "";
+
 	m_renameIgnoreExt 	    = GetOption(OPTION_RENAMEIGNOREEXT);
 
 	m_downloadRate			= ParseIntValue(OPTION_DOWNLOADRATE, 10) * 1024;

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -304,7 +304,7 @@ public:
 	int GetPropagationDelay() { return m_propagationDelay; }
 	int GetArticleCache() { return m_articleCache; }
 	int GetEventInterval() { return m_eventInterval; }
-	const char* GetShellOverride() { return m_shellOverride; }
+	const std::string& GetShellOverride() { return m_shellOverride; }
 	int GetMonthlyQuota() { return m_monthlyQuota; }
 	int GetQuotaStartDay() { return m_quotaStartDay; }
 	int GetDailyQuota() { return m_dailyQuota; }
@@ -441,7 +441,7 @@ private:
 	int m_propagationDelay = 0;
 	int m_articleCache = 0;
 	int m_eventInterval = 0;
-	CString m_shellOverride;
+	std::string m_shellOverride;
 	int m_monthlyQuota = 0;
 	int m_quotaStartDay = 0;
 	int m_dailyQuota = 0;


### PR DESCRIPTION
## Description

- fixed: installed Python on Windows could not be found, despite being accessible in the console

## Testing

- Windows 11 AMD64