### PR TITLE
Fix: rename output file after download

### DIFF
--- a/daemon/nntp/ArticleWriter.cpp
+++ b/daemon/nntp/ArticleWriter.cpp
@@ -360,7 +360,7 @@ void ArticleWriter::CompleteFileParts()
 		}
 	}
 
-	std::string infoFilename = nzbName + PATH_SEPARATOR + filename;
+	std::string infoFilename = nzbName + PATH_SEPARATOR + m_fileInfo->GetFilename();
 
 	bool cached = m_fileInfo->GetCachedArticles() > 0;
 
@@ -397,7 +397,7 @@ void ArticleWriter::CompleteFileParts()
 	}
 	else
 	{
-		ofn = FileSystem::MakeUniqueFilename(destDir.c_str(), filename.c_str());
+		ofn = FileSystem::MakeUniqueFilename(destDir.c_str(), filename.c_str()).Str();
 	}
 
 	DiskFile outfile;
@@ -582,7 +582,25 @@ void ArticleWriter::CompleteFileParts()
 	{
 		GuardedDownloadQueue guard = DownloadQueue::Guard();
 		m_fileInfo->SetCrc(crc);
+
+		RenameOutputFile(filename, destDir);
 	}
+}
+
+void ArticleWriter::RenameOutputFile(std::string_view filename, std::string_view destDir)
+{
+	if (filename == m_fileInfo->GetFilename())
+		return;
+
+	std::string ofn = FileSystem::MakeUniqueFilename(destDir.data(), m_fileInfo->GetFilename()).Str();
+	if (!FileSystem::MoveFile(m_outputFilename.c_str(), ofn.c_str()))
+	{
+		m_fileInfo->GetNzbInfo()->PrintMessage(Message::mkError,
+			"Could not rename file %s to %s: %s",
+			m_outputFilename.c_str(), ofn.c_str(), *FileSystem::GetLastErrorMessage()
+		);
+	}
+	m_fileInfo->SetOutputFilename(std::move(ofn));
 }
 
 void ArticleWriter::FlushCache()

--- a/daemon/nntp/ArticleWriter.h
+++ b/daemon/nntp/ArticleWriter.h
@@ -23,6 +23,7 @@
 #define ARTICLEWRITER_H
 
 #include <atomic>
+#include <string_view>
 #include "NString.h"
 #include "DownloadInfo.h"
 #include "Decoder.h"
@@ -65,6 +66,19 @@ public:
 
 private:
 	bool GetSkipDiskWrite();
+
+	/**
+	 *  @brief Renames the temporary `.out` output file to its original filename.
+	 *  
+	 * 	This is necessary when Direct/Par renaming is disabled or the download fails due to health checks.
+	 *  Or there are no par files at all.
+	 *  No action is taken if the filename matches the current filename.
+	 *
+	 * @param filename The desired final filename (without path).
+	 * @param destDir  The destination directory for the file.
+	 */
+	void RenameOutputFile(std::string_view filename, std::string_view destDir);
+
 	FileInfo* m_fileInfo;
 	ArticleInfo* m_articleInfo;
 	DiskFile m_outFile;

--- a/daemon/queue/Deobfuscation.cpp
+++ b/daemon/queue/Deobfuscation.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -49,14 +49,22 @@ namespace
 		return str.substr(0, endPos);
 	}
 
-	std::string ParseWtfNzb(const std::string& str) noexcept
+	std::string ParsePRiVATEnzb(const std::string& str) noexcept
 	{
-		const std::string begin = "[PRiVATE]-[WtFnZb]-";
-		size_t beginPos = str.find(begin);
-		if (beginPos == std::string::npos) return str;
-		beginPos += begin.size();
+		const std::string signature = "[PRiVATE]-[";
+		const std::string endOfSignature = "]-";
 
-		std::string end = " - \"\"";
+		size_t beginPos = str.find(signature);
+		if (beginPos == std::string::npos) return str;
+
+		beginPos += signature.size();
+
+		beginPos = str.find("]-[", beginPos);
+		if (beginPos == std::string::npos) return str;
+
+		beginPos += endOfSignature.size();
+
+		const std::string end = " - \"\"";
 		size_t endPos = str.rfind(end);
 		if (endPos == std::string::npos) return str;
 
@@ -65,7 +73,8 @@ namespace
 		// or
 		// [1/10]-[path/something[123].bin]
 		size_t distance = endPos - beginPos;
-		std::string middle = str.substr(beginPos, distance);
+		const std::string middle = str.substr(beginPos, distance);
+
 		std::string result;
 		result.reserve(middle.size());
 
@@ -139,7 +148,7 @@ namespace Deobfuscation
 		size_t distance = secondQuotPos - firstQuotPos;
 
 		if (distance == 0)
-			return ParseWtfNzb(str);
+			return ParsePRiVATEnzb(str);
 
 		if (distance > 0)
 			return str.substr(firstQuotPos, distance);

--- a/daemon/queue/DirectRenamer.cpp
+++ b/daemon/queue/DirectRenamer.cpp
@@ -425,7 +425,7 @@ int DirectRenamer::RenameFilesInProgress(NzbInfo* nzbInfo, FileHashList* parHash
 
 		nzbInfo->PrintMessage(Message::mkInfo,
 			"Renaming in-progress file %s to %s",
-			oldOutputFilename.c_str(), newOutputFilename.c_str()
+			fileInfo->GetFilename(), newOutputFilename.c_str()
 		);
 
 		bool renamed = (g_Options->GetDirectWrite() || fileInfo->GetForceDirectWrite())

--- a/tests/postprocess/ParCheckerTest.cpp
+++ b/tests/postprocess/ParCheckerTest.cpp
@@ -41,7 +41,7 @@ public:
 	~ParCheckerMock()
 	{
 		CString errmsg;
-		BOOST_CHECK(FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg));
+		FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg);
 	}
 
 protected:

--- a/tests/postprocess/ParRenamerTest.cpp
+++ b/tests/postprocess/ParRenamerTest.cpp
@@ -41,7 +41,7 @@ public:
 	~ParRenamerMock()
 	{
 		CString errmsg;
-		BOOST_CHECK(FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg));
+		FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg);
 	}
 private:
 	std::string m_workingDir;

--- a/tests/postprocess/RarRenamerTest.cpp
+++ b/tests/postprocess/RarRenamerTest.cpp
@@ -39,7 +39,8 @@ public:
 	~RarRenamerMock()
 	{
 		CString errmsg;
-		BOOST_CHECK(FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg));
+		BOOST_TEST_MESSAGE(m_workingDir);
+		FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg);
 	}
 private:
 	std::string m_workingDir;

--- a/tests/queue/DeobfuscationTest.cpp
+++ b/tests/queue/DeobfuscationTest.cpp
@@ -89,6 +89,11 @@ BOOST_AUTO_TEST_CASE(DeobfuscationTest)
 	);
 
 	BOOST_CHECK_EQUAL(
+		Deobfuscate("[N3wZ] _mC3M3U14246___[PRiVATE]-[EnCrYpTnZb]-[[SubsPlease].Some.file.name.-.20.(1080p).[64032D13].mkv]-[1_1] - \"\" yEnc  1454715270 (1/2030)"),
+		"[SubsPlease].Some.file.name.-.20.(1080p).[64032D13].mkv"
+	);
+
+	BOOST_CHECK_EQUAL(
 		Deobfuscate("\"2c0837e5fa42c8cfb5d5e583168a2af4.10\" yEnc (1/111)"),
 		"2c0837e5fa42c8cfb5d5e583168a2af4.10"
 	);


### PR DESCRIPTION
## Description

- fixed: renaming of the temporary `.out` output file to its original filename when Direct/Par renaming is disabled
- fixed: messages show downloaded files as out.tmp
- improved deobfuscation of `[PRiVATE]-...` groups

## Testing

- Windows 11 AMD64