### PR TITLE
Add: more tests in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,4 +155,4 @@ jobs:
 
     - name: Build
       run: |
-        brew install nzbget --head
+        brew install nzbget --formula --head --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
 
     - name: Install dependencies
-      run:
+      run: |
         brew install --formula boost sevenzip
         brew install --cask rar
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,6 +114,7 @@ jobs:
         retention-days: 5
 
   build-with-disabled-parcheck:
+    if: false
     runs-on: ubuntu-24.04
     steps:
 
@@ -131,3 +132,22 @@ jobs:
         cd build
         cmake .. -DDISABLE_PARCHECK=yes
         cmake --build . --config Release -j 4
+
+  build-openbsd:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: OpenBSD build
+      uses: cross-platform-actions/action@v0.27.0
+      with:
+        operating_system: openbsd
+        version: '7.6'
+        run: |
+          sudo pkg_add cmake libxml boost
+          mkdir build
+          cd build
+          cmake .. -DCURSES_INCLUDE_PATH=/usr/include
+          cmake --build . --config Release -j 4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ on:
 jobs:
 
   windows-tests:
-    if: false
     runs-on: windows-2022
     steps:
 
@@ -49,7 +48,6 @@ jobs:
         retention-days: 5
 
   linux-tests:
-    if: false
     runs-on: ubuntu-24.04
     steps:
 
@@ -82,7 +80,6 @@ jobs:
         retention-days: 5
 
   macos-tests:
-    if: false
     runs-on: macos-14
     steps:
 
@@ -114,7 +111,6 @@ jobs:
         retention-days: 5
 
   build-with-disabled-parcheck:
-    if: false
     runs-on: ubuntu-24.04
     steps:
 
@@ -151,3 +147,12 @@ jobs:
           cd build
           cmake .. -DCURSES_INCLUDE_PATH=/usr/include
           cmake --build . --config Release -j 4
+
+  build-macos-brew-head:
+    runs-on: macos-latest
+    if: github.ref_name == 'feature/more-tests'
+    steps:
+
+    - name: Build
+      run: |
+        brew install nzbget --head

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,7 @@ jobs:
         operating_system: openbsd
         version: '7.6'
         run: |
-          sudo pkg_add cmake libxml boost
+          sudo pkg_add git cmake libxml boost
           mkdir build
           cd build
           cmake .. -DCURSES_INCLUDE_PATH=/usr/include

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,7 @@ jobs:
           cd build
           cmake .. -DBUILD_ONLY_TESTS=ON -DCURSES_INCLUDE_PATH=/usr/include
           cmake --build . --config Release -j 4
-          ctest -C Release
+          ctest -C Release --repeat until-pass:5
 
     - name: Upload test artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ on:
 jobs:
 
   windows-tests:
+    if: false
     runs-on: windows-2022
     steps:
 
@@ -48,6 +49,7 @@ jobs:
         retention-days: 5
 
   linux-tests:
+    if: false
     runs-on: ubuntu-24.04
     steps:
 
@@ -80,6 +82,7 @@ jobs:
         retention-days: 5
 
   macos-tests:
+    if: false
     runs-on: macos-14
     steps:
 
@@ -109,3 +112,22 @@ jobs:
         name: nzbget-linux-test-log
         path: build/Testing/Temporary/LastTest.log
         retention-days: 5
+
+  build-with-disabled-parcheck:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Prepare environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DDISABLE_PARCHECK=yes
+        cmake --build . --config Release -j 4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Download and extract vcpkg cache
+    - name: Download and extract vcpkg cache and unpackers
       run: |
         $ProgressPreference = "SilentlyContinue"
         Invoke-WebRequest https://github.com/nzbgetcom/build-files/releases/download/v1.0/vcpkg-windows-tests.zip -OutFile "${{ github.workspace }}\vcpkg.zip"
         Expand-Archive -Path "${{ github.workspace }}\vcpkg.zip" -DestinationPath "${{ github.workspace }}"
+        Invoke-WebRequest https://github.com/nzbgetcom/build-files/releases/download/v1.0/nzbget-windows-tools.zip -OutFile "${{ github.workspace }}\tools.zip"
+        Expand-Archive -Path "${{ github.workspace }}\tools.zip" -DestinationPath C:\
+        Copy-Item "C:\nzbget\image\64\unrar.exe" -Destination "C:\Windows\System32"
+        Copy-Item "C:\nzbget\image\64\7za.exe" -Destination "C:\Windows\System32\7z.exe"
 
     - name: Build
       run: |
@@ -54,7 +58,7 @@ jobs:
     - name: Prepare environment
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev
+        sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev unrar 7zip
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -86,7 +90,7 @@ jobs:
     - name: Prepare environment
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev
+        sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev unrar 7zip
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -117,7 +121,8 @@ jobs:
 
     - name: Install dependencies
       run:
-        brew install --formula boost
+        brew install --formula boost sevenzip
+        brew install --cask rar
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -155,7 +160,7 @@ jobs:
         operating_system: openbsd
         version: '7.6'
         run: |
-          sudo pkg_add git cmake libxml boost
+          sudo pkg_add git cmake libxml boost unrar p7zip
           mkdir build
           cd build
           cmake .. -DBUILD_ONLY_TESTS=ON -DCURSES_INCLUDE_PATH=/usr/include
@@ -177,13 +182,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: OpenBSD build and test
+    - name: FreeBSD build and test
       uses: cross-platform-actions/action@v0.27.0
       with:
         operating_system: freebsd
         version: '14.2'
         run: |
-          sudo pkg install -y git cmake libxml2 boost-all
+          sudo pkg install -y git cmake libxml2 boost-all unrar 7-zip
           mkdir build
           cd build
           cmake .. -DBUILD_ONLY_TESTS=ON -DCURSES_INCLUDE_PATH=/usr/include

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
         retention-days: 5
 
   tests-macos:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
 
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,7 +150,7 @@ jobs:
 
   build-macos-brew-head:
     runs-on: macos-latest
-    if: github.ref_name == 'feature/more-tests'
+    if: github.ref_name == 'develop'
     steps:
 
     - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
 
-  windows-tests:
+  tests-windows:
     runs-on: windows-2022
     steps:
 
@@ -47,7 +47,7 @@ jobs:
         path: build/Testing/Temporary/LastTest.log
         retention-days: 5
 
-  linux-tests:
+  tests-linux:
     runs-on: ubuntu-24.04
     steps:
 
@@ -79,7 +79,39 @@ jobs:
         path: build/Testing/Temporary/LastTest.log
         retention-days: 5
 
-  macos-tests:
+  tests-linux-disabled-parcheck:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Prepare environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DBUILD_ONLY_TESTS=ON -DDISABLE_PARCHECK=yes
+        cmake --build . --config Release -j 4
+
+    - name: Test
+      run: |
+        cd build
+        ctest -C Release
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: nzbget-linux-test-log
+        path: build/Testing/Temporary/LastTest.log
+        retention-days: 5
+
+  tests-macos:
     runs-on: macos-14
     steps:
 
@@ -110,7 +142,63 @@ jobs:
         path: build/Testing/Temporary/LastTest.log
         retention-days: 5
 
-  build-with-disabled-parcheck:
+  tests-openbsd:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: OpenBSD build and test
+      uses: cross-platform-actions/action@v0.27.0
+      with:
+        operating_system: openbsd
+        version: '7.6'
+        run: |
+          sudo pkg_add git cmake libxml boost
+          mkdir build
+          cd build
+          cmake .. -DBUILD_ONLY_TESTS=ON -DCURSES_INCLUDE_PATH=/usr/include
+          cmake --build . --config Release -j 4
+          ctest -C Release
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: nzbget-openbsd-test-log
+        path: build/Testing/Temporary/LastTest.log
+        retention-days: 5
+
+  tests-freebsd:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: OpenBSD build and test
+      uses: cross-platform-actions/action@v0.27.0
+      with:
+        operating_system: freebsd
+        version: '14.2'
+        run: |
+          sudo pkg install -y git cmake libxml2 boost-all
+          mkdir build
+          cd build
+          cmake .. -DBUILD_ONLY_TESTS=ON -DCURSES_INCLUDE_PATH=/usr/include
+          cmake --build . --config Release -j 4
+          ctest -C Release
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: nzbget-freebsd-test-log
+        path: build/Testing/Temporary/LastTest.log
+        retention-days: 5
+
+  build-disabled-parcheck:
     runs-on: ubuntu-24.04
     steps:
 


### PR DESCRIPTION
## Description

- added next tests to tests workflow:
  - OpenBSD tests
  - FreeBSD tests
  - Linux tests with disabled parcheck
- added next test build:
  - Linux build with disabled parcheck
  - OpenBSD build
  - macOS brew install from head (develop branch only)
- added unpackers for every testing environments