### PR TITLE
Release v24.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,18 +14,22 @@ on:
 
 jobs:
 
-  windows-tests:
+  tests-windows:
     runs-on: windows-2022
     steps:
 
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Download and extract vcpkg cache
+    - name: Download and extract vcpkg cache and unpackers
       run: |
         $ProgressPreference = "SilentlyContinue"
         Invoke-WebRequest https://github.com/nzbgetcom/build-files/releases/download/v1.0/vcpkg-windows-tests.zip -OutFile "${{ github.workspace }}\vcpkg.zip"
         Expand-Archive -Path "${{ github.workspace }}\vcpkg.zip" -DestinationPath "${{ github.workspace }}"
+        Invoke-WebRequest https://github.com/nzbgetcom/build-files/releases/download/v1.0/nzbget-windows-tools.zip -OutFile "${{ github.workspace }}\tools.zip"
+        Expand-Archive -Path "${{ github.workspace }}\tools.zip" -DestinationPath C:\
+        Copy-Item "C:\nzbget\image\64\unrar.exe" -Destination "C:\Windows\System32"
+        Copy-Item "C:\nzbget\image\64\7za.exe" -Destination "C:\Windows\System32\7z.exe"
 
     - name: Build
       run: |
@@ -47,7 +51,159 @@ jobs:
         path: build/Testing/Temporary/LastTest.log
         retention-days: 5
 
-  linux-tests:
+  tests-linux:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Prepare environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev unrar 7zip
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DBUILD_ONLY_TESTS=ON
+        cmake --build . --config Release -j 4
+
+    - name: Test
+      run: |
+        cd build
+        ctest -C Release
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: nzbget-linux-test-log
+        path: build/Testing/Temporary/LastTest.log
+        retention-days: 5
+
+  tests-linux-disabled-parcheck:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Prepare environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev unrar 7zip
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DBUILD_ONLY_TESTS=ON -DDISABLE_PARCHECK=yes
+        cmake --build . --config Release -j 4
+
+    - name: Test
+      run: |
+        cd build
+        ctest -C Release
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: nzbget-linux-test-log
+        path: build/Testing/Temporary/LastTest.log
+        retention-days: 5
+
+  tests-macos:
+    runs-on: macos-latest
+    steps:
+
+    - name: Install dependencies
+      run: |
+        brew install --formula boost sevenzip
+        brew install --cask rar
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DBUILD_ONLY_TESTS=ON
+        cmake --build . --config Release -j 4
+
+    - name: Test
+      run: |
+        cd build
+        ctest -C Release
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: nzbget-linux-test-log
+        path: build/Testing/Temporary/LastTest.log
+        retention-days: 5
+
+  tests-openbsd:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: OpenBSD build and test
+      uses: cross-platform-actions/action@v0.27.0
+      with:
+        operating_system: openbsd
+        version: '7.6'
+        run: |
+          sudo pkg_add git cmake libxml boost unrar p7zip
+          mkdir build
+          cd build
+          cmake .. -DBUILD_ONLY_TESTS=ON -DCURSES_INCLUDE_PATH=/usr/include
+          cmake --build . --config Release -j 4
+          ctest -C Release --repeat until-pass:5
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: nzbget-openbsd-test-log
+        path: build/Testing/Temporary/LastTest.log
+        retention-days: 5
+
+  tests-freebsd:
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: FreeBSD build and test
+      uses: cross-platform-actions/action@v0.27.0
+      with:
+        operating_system: freebsd
+        version: '14.2'
+        run: |
+          sudo pkg install -y git cmake libxml2 boost-all unrar 7-zip
+          mkdir build
+          cd build
+          cmake .. -DBUILD_ONLY_TESTS=ON -DCURSES_INCLUDE_PATH=/usr/include
+          cmake --build . --config Release -j 4
+          ctest -C Release
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: nzbget-freebsd-test-log
+        path: build/Testing/Temporary/LastTest.log
+        retention-days: 5
+
+  build-disabled-parcheck:
     runs-on: ubuntu-24.04
     steps:
 
@@ -63,49 +219,33 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DBUILD_ONLY_TESTS=ON
+        cmake .. -DDISABLE_PARCHECK=yes
         cmake --build . --config Release -j 4
 
-    - name: Test
-      run: |
-        cd build
-        ctest -C Release
-
-    - name: Upload test artifacts
-      uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: nzbget-linux-test-log
-        path: build/Testing/Temporary/LastTest.log
-        retention-days: 5
-
-  macos-tests:
-    runs-on: macos-14
+  build-openbsd:
+    runs-on: ubuntu-24.04
     steps:
-
-    - name: Install dependencies
-      run:
-        brew install --formula boost
 
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: OpenBSD build
+      uses: cross-platform-actions/action@v0.27.0
+      with:
+        operating_system: openbsd
+        version: '7.6'
+        run: |
+          sudo pkg_add git cmake libxml boost
+          mkdir build
+          cd build
+          cmake .. -DCURSES_INCLUDE_PATH=/usr/include
+          cmake --build . --config Release -j 4
+
+  build-macos-brew-head:
+    runs-on: macos-latest
+    if: github.ref_name == 'develop'
+    steps:
+
     - name: Build
       run: |
-        mkdir build
-        cd build
-        cmake .. -DBUILD_ONLY_TESTS=ON
-        cmake --build . --config Release -j 4
-
-    - name: Test
-      run: |
-        cd build
-        ctest -C Release
-
-    - name: Upload test artifacts
-      uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: nzbget-linux-test-log
-        path: build/Testing/Temporary/LastTest.log
-        retention-days: 5
+        brew install nzbget --formula --head --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
 	message(FATAL_ERROR "In-source builds are not allowed. You should create separate directory for build files.")
 endif()
 
-set(VERSION "24.6")
+set(VERSION "24.7")
 set(PACKAGE "nzbget")
 set(LIBS "")
 set(INCLUDES ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,21 @@
+nzbget-24.7
+  - Bug fixes:
+    - Renaming of the temporary `*.out.tmp` output file to its original filename
+    - Improved deobfuscation of `[PRiVATE]-...` groups
+    [#516](https://github.com/nzbgetcom/nzbget/pull/516)
+    - Build with `-DDISABLE_PARCHECK=yes`
+    [#514](https://github.com/nzbgetcom/nzbget/pull/514)
+    - Installed Python on Windows could not be found, despite being accessible in the console
+    [#515](https://github.com/nzbgetcom/nzbget/pull/515)
+
+  - For developers:
+    - Added more test workflows
+        - OpenBSD build/tests
+        - FreeBSD tests
+        - Linux build/tests with disabled parcheck
+        - macOS brew install from head (develop branch only)
+    [#519](https://github.com/nzbgetcom/nzbget/pull/519)
+
 nzbget-24.6
   - Features:
     - Improved deobfuscation
@@ -37,8 +55,6 @@ nzbget-24.6
     [#481](https://github.com/nzbgetcom/nzbget/pull/481)
     - Added extra format string compiler security flags
     [#503](https://github.com/nzbgetcom/nzbget/pull/503)
-
-
 
 nzbget-24.5
   - Features:

--- a/README.md
+++ b/README.md
@@ -10,14 +10,12 @@
 ![GitHub release (by tag)](https://img.shields.io/github/downloads/nzbgetcom/nzbget/v24.4/total?label=v24.4)
 ![GitHub release (by tag)](https://img.shields.io/github/downloads/nzbgetcom/nzbget/v24.5/total?label=v24.5)
 ![GitHub release (by tag)](https://img.shields.io/github/downloads/nzbgetcom/nzbget/v24.6/total?label=v24.6)
+![GitHub release (by tag)](https://img.shields.io/github/downloads/nzbgetcom/nzbget/v24.7/total?label=v24.7)
 ![docker pulls](https://img.shields.io/docker/pulls/nzbgetcom/nzbget.svg)
 
-[![linux build](https://github.com/nzbgetcom/nzbget/actions/workflows/linux.yml/badge.svg?branch=main)](https://github.com/nzbgetcom/nzbget/actions/workflows/linux.yml)
-[![windows build](https://github.com/nzbgetcom/nzbget/actions/workflows/windows.yml/badge.svg?branch=main)](https://github.com/nzbgetcom/nzbget/actions/workflows/windows.yml)
-[![osx build](https://github.com/nzbgetcom/nzbget/actions/workflows/osx.yml/badge.svg)](https://github.com/nzbgetcom/nzbget/actions/workflows/osx.yml)
-[![Android build](https://github.com/nzbgetcom/nzbget/actions/workflows/android.yml/badge.svg)](https://github.com/nzbgetcom/nzbget/actions/workflows/android.yml)
-[![docker build](https://github.com/nzbgetcom/nzbget/actions/workflows/docker.yml/badge.svg)](https://github.com/nzbgetcom/nzbget/actions/workflows/docker.yml)
-[![qnap repack](https://github.com/nzbgetcom/nzbget/actions/workflows/qnap-repack.yml/badge.svg)](https://github.com/nzbgetcom/nzbget/actions/workflows/qnap-repack.yml)
+[![tests](https://github.com/nzbgetcom/nzbget/actions/workflows/tests.yml/badge.svg?branch=develop)](https://github.com/nzbgetcom/nzbget/actions/workflows/tests.yml)
+[![build](https://github.com/nzbgetcom/nzbget/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/nzbgetcom/nzbget/actions/workflows/build.yml)
+[![docker build](https://github.com/nzbgetcom/nzbget/actions/workflows/docker.yml/badge.svg?branch=develop)](https://github.com/nzbgetcom/nzbget/actions/workflows/docker.yml)
 
 
 ![Contributions welcome](https://img.shields.io/badge/contributions-welcome-blue.svg)

--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -707,7 +707,10 @@ void Options::InitOptions()
 	m_extCleanupDisk		= GetOption(OPTION_EXTCLEANUPDISK);
 	m_parIgnoreExt			= GetOption(OPTION_PARIGNOREEXT);
 	m_unpackIgnoreExt		= GetOption(OPTION_UNPACKIGNOREEXT);
-	m_shellOverride			= GetOption(OPTION_SHELLOVERRIDE);
+
+	const char* shellOverride = GetOption(OPTION_SHELLOVERRIDE);
+	m_shellOverride	= shellOverride ? shellOverride : "";
+
 	m_renameIgnoreExt 	    = GetOption(OPTION_RENAMEIGNOREEXT);
 
 	m_downloadRate			= ParseIntValue(OPTION_DOWNLOADRATE, 10) * 1024;

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -304,7 +304,7 @@ public:
 	int GetPropagationDelay() { return m_propagationDelay; }
 	int GetArticleCache() { return m_articleCache; }
 	int GetEventInterval() { return m_eventInterval; }
-	const char* GetShellOverride() { return m_shellOverride; }
+	const std::string& GetShellOverride() { return m_shellOverride; }
 	int GetMonthlyQuota() { return m_monthlyQuota; }
 	int GetQuotaStartDay() { return m_quotaStartDay; }
 	int GetDailyQuota() { return m_dailyQuota; }
@@ -441,7 +441,7 @@ private:
 	int m_propagationDelay = 0;
 	int m_articleCache = 0;
 	int m_eventInterval = 0;
-	CString m_shellOverride;
+	std::string m_shellOverride;
 	int m_monthlyQuota = 0;
 	int m_quotaStartDay = 0;
 	int m_dailyQuota = 0;

--- a/daemon/nntp/ArticleWriter.cpp
+++ b/daemon/nntp/ArticleWriter.cpp
@@ -22,6 +22,7 @@
 #include "nzbget.h"
 
 #include <sstream>
+#include <iomanip>
 #include "ArticleWriter.h"
 #include "DiskState.h"
 #include "Options.h"

--- a/daemon/nntp/ArticleWriter.cpp
+++ b/daemon/nntp/ArticleWriter.cpp
@@ -360,7 +360,7 @@ void ArticleWriter::CompleteFileParts()
 		}
 	}
 
-	std::string infoFilename = nzbName + PATH_SEPARATOR + filename;
+	std::string infoFilename = nzbName + PATH_SEPARATOR + m_fileInfo->GetFilename();
 
 	bool cached = m_fileInfo->GetCachedArticles() > 0;
 
@@ -397,7 +397,7 @@ void ArticleWriter::CompleteFileParts()
 	}
 	else
 	{
-		ofn = FileSystem::MakeUniqueFilename(destDir.c_str(), filename.c_str());
+		ofn = FileSystem::MakeUniqueFilename(destDir.c_str(), filename.c_str()).Str();
 	}
 
 	DiskFile outfile;
@@ -582,7 +582,25 @@ void ArticleWriter::CompleteFileParts()
 	{
 		GuardedDownloadQueue guard = DownloadQueue::Guard();
 		m_fileInfo->SetCrc(crc);
+
+		RenameOutputFile(filename, destDir);
 	}
+}
+
+void ArticleWriter::RenameOutputFile(std::string_view filename, std::string_view destDir)
+{
+	if (filename == m_fileInfo->GetFilename())
+		return;
+
+	std::string ofn = FileSystem::MakeUniqueFilename(destDir.data(), m_fileInfo->GetFilename()).Str();
+	if (!FileSystem::MoveFile(m_outputFilename.c_str(), ofn.c_str()))
+	{
+		m_fileInfo->GetNzbInfo()->PrintMessage(Message::mkError,
+			"Could not rename file %s to %s: %s",
+			m_outputFilename.c_str(), ofn.c_str(), *FileSystem::GetLastErrorMessage()
+		);
+	}
+	m_fileInfo->SetOutputFilename(std::move(ofn));
 }
 
 void ArticleWriter::FlushCache()

--- a/daemon/nntp/ArticleWriter.h
+++ b/daemon/nntp/ArticleWriter.h
@@ -23,6 +23,7 @@
 #define ARTICLEWRITER_H
 
 #include <atomic>
+#include <string_view>
 #include "NString.h"
 #include "DownloadInfo.h"
 #include "Decoder.h"
@@ -65,6 +66,19 @@ public:
 
 private:
 	bool GetSkipDiskWrite();
+
+	/**
+	 *  @brief Renames the temporary `.out` output file to its original filename.
+	 *  
+	 * 	This is necessary when Direct/Par renaming is disabled or the download fails due to health checks.
+	 *  Or there are no par files at all.
+	 *  No action is taken if the filename matches the current filename.
+	 *
+	 * @param filename The desired final filename (without path).
+	 * @param destDir  The destination directory for the file.
+	 */
+	void RenameOutputFile(std::string_view filename, std::string_view destDir);
+
 	FileInfo* m_fileInfo;
 	ArticleInfo* m_articleInfo;
 	DiskFile m_outFile;

--- a/daemon/queue/Deobfuscation.cpp
+++ b/daemon/queue/Deobfuscation.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -49,14 +49,22 @@ namespace
 		return str.substr(0, endPos);
 	}
 
-	std::string ParseWtfNzb(const std::string& str) noexcept
+	std::string ParsePRiVATEnzb(const std::string& str) noexcept
 	{
-		const std::string begin = "[PRiVATE]-[WtFnZb]-";
-		size_t beginPos = str.find(begin);
-		if (beginPos == std::string::npos) return str;
-		beginPos += begin.size();
+		const std::string signature = "[PRiVATE]-[";
+		const std::string endOfSignature = "]-";
 
-		std::string end = " - \"\"";
+		size_t beginPos = str.find(signature);
+		if (beginPos == std::string::npos) return str;
+
+		beginPos += signature.size();
+
+		beginPos = str.find("]-[", beginPos);
+		if (beginPos == std::string::npos) return str;
+
+		beginPos += endOfSignature.size();
+
+		const std::string end = " - \"\"";
 		size_t endPos = str.rfind(end);
 		if (endPos == std::string::npos) return str;
 
@@ -65,7 +73,8 @@ namespace
 		// or
 		// [1/10]-[path/something[123].bin]
 		size_t distance = endPos - beginPos;
-		std::string middle = str.substr(beginPos, distance);
+		const std::string middle = str.substr(beginPos, distance);
+
 		std::string result;
 		result.reserve(middle.size());
 
@@ -139,7 +148,7 @@ namespace Deobfuscation
 		size_t distance = secondQuotPos - firstQuotPos;
 
 		if (distance == 0)
-			return ParseWtfNzb(str);
+			return ParsePRiVATEnzb(str);
 
 		if (distance > 0)
 			return str.substr(firstQuotPos, distance);

--- a/daemon/queue/DirectRenamer.cpp
+++ b/daemon/queue/DirectRenamer.cpp
@@ -23,6 +23,7 @@
 
 #include <sstream>
 #include <iostream>
+#include <iomanip>
 #include "DirectRenamer.h"
 #include "Options.h"
 #include "FileSystem.h"

--- a/daemon/queue/DirectRenamer.cpp
+++ b/daemon/queue/DirectRenamer.cpp
@@ -425,7 +425,7 @@ int DirectRenamer::RenameFilesInProgress(NzbInfo* nzbInfo, FileHashList* parHash
 
 		nzbInfo->PrintMessage(Message::mkInfo,
 			"Renaming in-progress file %s to %s",
-			oldOutputFilename.c_str(), newOutputFilename.c_str()
+			fileInfo->GetFilename(), newOutputFilename.c_str()
 		);
 
 		bool renamed = (g_Options->GetDirectWrite() || fileInfo->GetForceDirectWrite())

--- a/osx/NZBGet-Info.plist
+++ b/osx/NZBGet-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>24.6</string>
+	<string>24.7</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 	<dict>

--- a/tests/postprocess/ParCheckerTest.cpp
+++ b/tests/postprocess/ParCheckerTest.cpp
@@ -41,7 +41,7 @@ public:
 	~ParCheckerMock()
 	{
 		CString errmsg;
-		BOOST_CHECK(FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg));
+		FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg);
 	}
 
 protected:

--- a/tests/postprocess/ParRenamerTest.cpp
+++ b/tests/postprocess/ParRenamerTest.cpp
@@ -41,7 +41,7 @@ public:
 	~ParRenamerMock()
 	{
 		CString errmsg;
-		BOOST_CHECK(FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg));
+		FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg);
 	}
 private:
 	std::string m_workingDir;

--- a/tests/postprocess/RarRenamerTest.cpp
+++ b/tests/postprocess/RarRenamerTest.cpp
@@ -39,7 +39,8 @@ public:
 	~RarRenamerMock()
 	{
 		CString errmsg;
-		BOOST_CHECK(FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg));
+		BOOST_TEST_MESSAGE(m_workingDir);
+		FileSystem::DeleteDirectoryWithContent(m_workingDir.c_str(), errmsg);
 	}
 private:
 	std::string m_workingDir;

--- a/tests/queue/DeobfuscationTest.cpp
+++ b/tests/queue/DeobfuscationTest.cpp
@@ -89,6 +89,11 @@ BOOST_AUTO_TEST_CASE(DeobfuscationTest)
 	);
 
 	BOOST_CHECK_EQUAL(
+		Deobfuscate("[N3wZ] _mC3M3U14246___[PRiVATE]-[EnCrYpTnZb]-[[SubsPlease].Some.file.name.-.20.(1080p).[64032D13].mkv]-[1_1] - \"\" yEnc  1454715270 (1/2030)"),
+		"[SubsPlease].Some.file.name.-.20.(1080p).[64032D13].mkv"
+	);
+
+	BOOST_CHECK_EQUAL(
 		Deobfuscate("\"2c0837e5fa42c8cfb5d5e583168a2af4.10\" yEnc (1/111)"),
 		"2c0837e5fa42c8cfb5d5e583168a2af4.10"
 	);


### PR DESCRIPTION
## Description

  - Bug fixes:
    - Renaming of the temporary `*.out.tmp` output file to its original filename
    - Improved deobfuscation of `[PRiVATE]-...` groups [#516](https://github.com/nzbgetcom/nzbget/pull/516)
    - Build with `-DDISABLE_PARCHECK=yes` [#514](https://github.com/nzbgetcom/nzbget/pull/514)
    - Installed Python on Windows could not be found, despite being accessible in the console [#515](https://github.com/nzbgetcom/nzbget/pull/515)

  - For developers:
    - Added more test workflows
        - OpenBSD build/tests
        - FreeBSD tests
        - Linux build/tests with disabled parcheck
        - macOS brew install from head (develop branch only) [#519](https://github.com/nzbgetcom/nzbget/pull/519)