### PR TITLE
Support running Docker image rootless

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,7 @@ if [ ! -d /downloads ]; then
     mkdir -p /downloads
 fi
 
-# delete lock file if found
+# delete lock file if found
 if [ -f /downloads/nzbget.lock ]; then
     rm /downloads/nzbget.lock
 fi
@@ -14,13 +14,16 @@ fi
 # change userid and groupid
 PUID=${PUID:-1000}
 PGID=${PGID:-1000}
-groupmod -o -g "$PGID" users >/dev/null
-usermod -o -u "$PUID" user >/dev/null
+if [ "$PGID" != "$(id -g user)" ]; then
+    groupmod -o -g "$PGID" users >/dev/null
+fi
+if [ "$PUID" != "$(id -u user)" ]; then
+    usermod -o -u "$PUID" user >/dev/null
+fi
 
 # create default config if not exist
 if [ ! -f /config/nzbget.conf ]; then
     cp /app/nzbget/share/nzbget/nzbget.conf /config/nzbget.conf
-    chown user:users /config/nzbget.conf
 fi
 
 # parse env vars to options
@@ -32,14 +35,20 @@ if [ ! -z "${NZBGET_PASS}" ]; then
     OPTIONS="${OPTIONS}-o ControlPassword=${NZBGET_PASS} "
 fi
 
-chown user:users /config || CONFIG_CHOWN_STATUS=$?
-if [ ! -z $CONFIG_CHOWN_STATUS ]; then
-    echo "*** Could not set permissions on /config ; this container may not work as expected ***"
-fi
+if [ "$(id -u)" -eq 0 ]; then
+    chown user:users /config/nzbget.conf
 
-chown user:users /downloads || DOWNLOADS_CHOWN_STATUS=$?
-if [ ! -z $DOWNLOADS_CHOWN_STATUS ]; then
-    echo "*** Could not set permissions on /downloads ; this container may not work as expected ***"
-fi
+    chown user:users /config || CONFIG_CHOWN_STATUS=$?
+    if [ ! -z $CONFIG_CHOWN_STATUS ]; then
+        echo "*** Could not set permissions on /config ; this container may not work as expected ***"
+    fi
 
-su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"
+    chown user:users /downloads || DOWNLOADS_CHOWN_STATUS=$?
+    if [ ! -z $DOWNLOADS_CHOWN_STATUS ]; then
+        echo "*** Could not set permissions on /downloads ; this container may not work as expected ***"
+    fi
+
+    su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"
+else
+    /app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}
+fi


### PR DESCRIPTION
## Description

I like to run all my Docker images rootless as an extra security measure. I understand the existing Docker image drops the user from root to a normal user when it run the nzbget executable but this PR updates the entrypoint script to support running the Docker image from the get-go as a non-root user. In those cases, there is no need to run `chmod` or `su`.

## Lib changes

No lib changes

## Testing

Ran this locally and it works fine