### PR TITLE
Add: completion and downloaded volumes statistics

### DIFF
--- a/daemon/nntp/ArticleDownloader.h
+++ b/daemon/nntp/ArticleDownloader.h
@@ -3,7 +3,7 @@
  *
  *  Copyright (C) 2004 Sven Henkel <sidddy@users.sourceforge.net>
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -105,7 +105,7 @@ private:
 	EStatus CheckResponse(const char* response, const char* comment);
 	void SetStatus(EStatus status) { m_status = status; }
 	bool Write(char* buffer, int len);
-	void AddServerData();
+	void AddServerStats();
 };
 
 #endif

--- a/docs/api/RESETSERVERVOLUME.md
+++ b/docs/api/RESETSERVERVOLUME.md
@@ -2,15 +2,18 @@
 
 ### Signature
 ``` c++
-bool resetservervolume(int ServerId, string Sounter);
+bool resetservervolume(int ServerId, string Counter);
 ```
 
 ### Description
-Reset download volume statistics for a specified news-server.
+Resets download volume statistics for a specified news-server. This method allows for selective resetting of counters.
 
 ### Arguments
 - **ServerId** `(int)` - Server ID to reset.
-- **Counter** `(string)` - The custom counter.
+- **Counter** `(string)` - Specifies which counter to reset. The behavior depends on the value of this argument:
+
+  - **"CUSTOM"** (case-sensitive) - Resets only the custom counter associated with the server. Use this option to clear custom statistics while preserving overall download volume data.
+  - **""** (empty string) - Resets all counters associated with the server, including the overall download volume and any custom counters.
 
 ### Return value
 `true` on success or `false` on failure.

--- a/docs/api/SERVERVOLUMES.md
+++ b/docs/api/SERVERVOLUMES.md
@@ -20,15 +20,17 @@ This method returns an array of structures with following fields:
 - **CustomSizeHi** `(int)` - Amount of downloaded data since last reset of custom counter, high 32-bits of 64-bit value.
 - **CustomSizeMB** `(int)` - Amount of downloaded data since last reset of custom counter, in MiB.
 - **CustomTime** `(int)` - Date/time of the last reset of custom counter (time is in C/Unix format).
+- **CountersResetTime** `(int)` - Date/time of the last reset of all counters (time is in C/Unix format).
 - **BytesPerSeconds** `(struct[])` - Per-second amount of data downloaded in last 60 seconds. See below.
 - **BytesPerMinutes** `(struct[])` - Per-minute amount of data downloaded in last 60 minutes. See below.
 - **BytesPerHours** `(struct[])` - Per-hour amount of data downloaded in last 24 hours. See below.
 - **BytesPerDays** `(struct[])` - Per-day amount of data downloaded since program installation. See below.
+- **ArticlesPerDays** `(struct[])` - Per-day amount of failed and success articles since program installation. See below.
 - **SecSlot** `(int)` - The current second slot of field `BytesPerSeconds` the program writes into.
 - **MinSlot** `(int)` - The current minute slot of field `BytesPerMinutes` the program writes into.
 - **HourSlot** `(int)` - The current hour slot of field `BytesPerHours` the program writes into.
 - **DaySlot** `(int)` - The current day slot of field `BytesPerDays` the program writes into.
-- **FirstDay** `(int)` - Indicates which calendar day the very first slot of `BytesPerDays` corresponds to. Details see below.
+- **FirstDay** `(int)` - Indicates which calendar day the very first slot of `BytesPerDays`, `ArticlesPerDay` correspond to. Details see below.
 
 **NOTE**: The first record (serverid=0) are totals for all servers.
 
@@ -38,6 +40,12 @@ Contains an array of structs with following fields:
 - **SizeLo** `(int)` - Amount of downloaded data, low 32-bits of 64-bit value.
 - **SizeHi** `(int)` - Amount of downloaded data, high 32-bits of 64-bit value.
 - **SizeMB** `(int)` - Amount of downloaded data, in MiB.
+
+### ArticlesPerDays
+Contains an array of structs with following fields:
+
+- **Failed** `(int)` - Amount of failed articles.
+- **Success** `(int)` - Amount of success articles.
 
 ### Seconds, minutes and hours slots
 These slots are arrays of fixed sizes (60, 60 and 24) which contain data for the last 60 seconds, 60 minutes and 24 hours. For example if current time “16:00:21” when the current slots would be:
@@ -53,6 +61,8 @@ Similarly for minutes `(BytesPerMinutes)` and hours `(BytesPerHours)` arrays.
 Daily slots are counted from the installation date, more precisely - from the date the program was used the first time after the installation. Or the first time it was used after deleting of statistics data, which is stored in directory pointed by option `QueueDir`.
 
 Therefore the first element of `BytesPerDays` array contains the amount of data downloaded at the first day of program usage. The second element - on the second day. The sub-sequential slots are created for each day, regardless of the fact if the program was running on this day or not.
+
+Similarly for `(ArticlesPerDays)` array.
 
 Field `DaySlot` shows into which day slot the data is currently being written.
 

--- a/tests/nntp/CMakeLists.txt
+++ b/tests/nntp/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(NNTPTestsSrc
+	main.cpp
 	ServerPoolTest.cpp
+	StatMeterTest.cpp
+	${CMAKE_SOURCE_DIR}/daemon/main/WorkState.cpp
 	${CMAKE_SOURCE_DIR}/daemon/nntp/ServerPool.cpp
+	${CMAKE_SOURCE_DIR}/daemon/nntp/StatMeter.cpp
 	${CMAKE_SOURCE_DIR}/daemon/main/Options.cpp
 	${CMAKE_SOURCE_DIR}/daemon/nntp/NewsServer.cpp
 	${CMAKE_SOURCE_DIR}/daemon/nntp/NntpConnection.cpp
@@ -10,6 +14,7 @@ set(NNTPTestsSrc
 	${CMAKE_SOURCE_DIR}/daemon/util/Log.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/NString.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/FileSystem.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/Observer.cpp
 	${CMAKE_SOURCE_DIR}/daemon/feed/FeedInfo.cpp
 	${CMAKE_SOURCE_DIR}/daemon/connect/Connection.cpp
 	${CMAKE_SOURCE_DIR}/daemon/connect/TlsSocket.cpp

--- a/tests/nntp/ServerPoolTest.cpp
+++ b/tests/nntp/ServerPoolTest.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,17 +21,16 @@
 
 #include "nzbget.h"
 
-#define BOOST_TEST_MODULE "NNTPTest" 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "ServerPool.h"
 #include "Log.h"
 #include "Options.h"
 #include "DiskState.h"
 
-Log* g_Log = new Log();
-Options* g_Options;
-DiskState* g_DiskState;
+extern Log* g_Log;
+extern Options* g_Options;
+extern DiskState* g_DiskState;
 
 void AddTestServer(ServerPool* pool, int id, bool active, int level, bool optional, int group, int connections)
 {
@@ -40,6 +40,7 @@ void AddTestServer(ServerPool* pool, int id, bool active, int level, bool option
 
 void TestBlockServers(int group)
 {
+	ServerVolume::VolumeArray arr;
 	ServerPool pool;
 	AddTestServer(&pool, 1, true, 0, false, group, 2);
 	AddTestServer(&pool, 2, true, 0, false, group, 2);

--- a/tests/nntp/StatMeterTest.cpp
+++ b/tests/nntp/StatMeterTest.cpp
@@ -1,0 +1,111 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include "StatMeter.h"
+#include "Log.h"
+#include "Options.h"
+#include "WorkState.h"
+#include "DiskState.h"
+#include "ServerPool.h"
+
+extern Log* g_Log;
+extern WorkState* g_WorkState;
+extern Options* g_Options;
+extern DiskState* g_DiskState;
+extern ServerPool* g_ServerPool;
+
+BOOST_AUTO_TEST_CASE(ServerVolumeTest)
+{
+	ServerVolume volume;
+
+	ServerVolume::Stats stats1 = { 100, {10, 20} };
+	ServerVolume::Stats stats2 = { 200, {30, 40} };
+
+	volume.AddStats(stats1);
+	volume.AddStats(stats2);
+
+	const ServerVolume::VolumeArray* bytesPerSeconds = volume.BytesPerSeconds();
+	const ServerVolume::VolumeArray* bytesPerMinutes = volume.BytesPerMinutes();
+	const ServerVolume::VolumeArray* bytesPerHours = volume.BytesPerHours();
+	const ServerVolume::VolumeArray* bytesPerDays = volume.BytesPerDays();
+	const ServerVolume::ArticlesArray& articlesPerDays = volume.GetArticlesPerDays();
+
+	size_t secSlot = static_cast<size_t>(volume.GetSecSlot());
+	size_t minSlot = static_cast<size_t>(volume.GetMinSlot());
+	size_t hourSlot = static_cast<size_t>(volume.GetHourSlot());
+	size_t daySlot = static_cast<size_t>(volume.GetDaySlot());
+
+	const ServerVolume::Articles& articlesPerDay = articlesPerDays.at(daySlot);
+
+	BOOST_CHECK_EQUAL(bytesPerDays->size(), 1);
+	BOOST_CHECK_EQUAL(articlesPerDay.failed, 40);
+	BOOST_CHECK_EQUAL(articlesPerDay.success, 60);
+	BOOST_CHECK_EQUAL(bytesPerSeconds->at(secSlot), 300);
+	BOOST_CHECK_EQUAL(bytesPerMinutes->at(minSlot), 300);
+	BOOST_CHECK_EQUAL(bytesPerHours->at(hourSlot), 300);
+	BOOST_CHECK_EQUAL(bytesPerDays->at(daySlot), 300);
+	BOOST_CHECK_EQUAL(volume.GetTotalBytes(), 300);
+	BOOST_CHECK_EQUAL(volume.GetCustomBytes(), 300);
+
+	int currentDay = volume.GetDaySlot();
+	time_t nextDay = Util::CurrentTime() + 86400;
+	volume.CalcSlots(nextDay);
+
+	const ServerVolume::VolumeArray* bytesPerSeconds2 = volume.BytesPerSeconds();
+	const ServerVolume::VolumeArray* bytesPerMinutes2 = volume.BytesPerMinutes();
+	const ServerVolume::VolumeArray* bytesPerHours2 = volume.BytesPerHours();
+	const ServerVolume::VolumeArray* bytesPerDays2 = volume.BytesPerDays();
+	const ServerVolume::ArticlesArray& articlesPerDays2 = volume.GetArticlesPerDays();
+
+	BOOST_CHECK_EQUAL(volume.GetDaySlot(), currentDay + 1);
+	BOOST_CHECK_EQUAL(bytesPerDays2->size(), 2);
+	BOOST_CHECK_EQUAL(articlesPerDays2.size(), 2);
+
+	size_t daySlot2 = static_cast<size_t>(volume.GetDaySlot());
+	const ServerVolume::Articles& articlesPerDay2 = articlesPerDays.at(daySlot);
+	const ServerVolume::Articles& articlesPerDay3 = articlesPerDays.at(daySlot2);
+
+	volume.ResetCustom();
+	BOOST_CHECK_EQUAL(volume.GetCustomBytes(), 0);
+
+	BOOST_CHECK_EQUAL(bytesPerSeconds2->at(secSlot), 300);
+	BOOST_CHECK_EQUAL(bytesPerMinutes2->at(minSlot), 300);
+	BOOST_CHECK_EQUAL(bytesPerHours2->at(hourSlot), 300);
+	BOOST_CHECK_EQUAL(bytesPerDays2->at(daySlot), 300);
+	BOOST_CHECK_EQUAL(bytesPerDays2->at(daySlot2), 0);
+	BOOST_CHECK_EQUAL(articlesPerDay2.failed, 40);
+	BOOST_CHECK_EQUAL(articlesPerDay2.success, 60);
+	BOOST_CHECK_EQUAL(articlesPerDay3.failed, 0);
+	BOOST_CHECK_EQUAL(articlesPerDay3.success, 0);
+	BOOST_CHECK_EQUAL(volume.GetTotalBytes(), 300);
+
+	volume.Reset();
+
+	BOOST_CHECK_EQUAL(bytesPerSeconds2->at(secSlot), 0);
+	BOOST_CHECK_EQUAL(bytesPerMinutes2->at(minSlot), 0);
+	BOOST_CHECK_EQUAL(bytesPerHours2->at(hourSlot), 0);
+	BOOST_CHECK_EQUAL(bytesPerDays2->at(daySlot), 0);
+	BOOST_CHECK_EQUAL(articlesPerDay2.failed, 0);
+	BOOST_CHECK_EQUAL(articlesPerDay2.success, 0);
+	BOOST_CHECK_EQUAL(volume.GetTotalBytes(), 0);
+}

--- a/tests/nntp/main.cpp
+++ b/tests/nntp/main.cpp
@@ -1,0 +1,57 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "nzbget.h"
+
+#define BOOST_TEST_MODULE "NNTPTest" 
+#include <boost/test/included/unit_test.hpp>
+
+#include "Log.h"
+#include "Options.h"
+#include "WorkState.h"
+#include "DiskState.h"
+#include "ServerPool.h"
+
+Log* g_Log;
+WorkState* g_WorkState;
+Options* g_Options;
+DiskState* g_DiskState;
+ServerPool* g_ServerPool;
+
+struct InitGlobals
+{
+	InitGlobals()
+	{
+		g_Log = new Log();
+		g_WorkState = new WorkState();
+		g_Options = new Options(nullptr, nullptr);
+		g_DiskState = new DiskState();
+		g_ServerPool = new ServerPool();
+	}
+
+	~InitGlobals()
+	{
+		delete g_WorkState;
+		delete g_DiskState;
+		delete g_ServerPool;
+		delete g_Log;
+	}
+};
+
+BOOST_GLOBAL_FIXTURE(InitGlobals);

--- a/webui/config.js
+++ b/webui/config.js
@@ -55,6 +55,7 @@ var Options = (new function($)
 	var loadConfigError;
 	var loadServerTemplateError;
 	var shortScriptNames = [];
+	var subs = [];
 
 	var HIDDEN_SECTIONS = ['DISPLAY (TERMINAL)', 'POSTPROCESSING-PARAMETERS', 'POST-PROCESSING-PARAMETERS', 'POST-PROCESSING PARAMETERS'];
 	var POSTPARAM_SECTIONS = ['POSTPROCESSING-PARAMETERS', 'POST-PROCESSING-PARAMETERS', 'POST-PROCESSING PARAMETERS'];
@@ -67,6 +68,7 @@ var Options = (new function($)
 			_this.options = _options;
 			initCategories();
 			_this.restricted = _this.option('ControlPort') === '***';
+			notifyAll(_options);
 			RPC.next();
 		});
 
@@ -102,12 +104,28 @@ var Options = (new function($)
 
 		server.id = id;
 		var serverId = 'Server' + id;
-		server.host = findOption(this.options, serverId + '.Host').Value;
+		var hostOpt = findOption(this.options, serverId + '.Host');
+		if (!hostOpt)
+			return null;
+
+		server.host = hostOpt.Value;
 		server.name = findOption(this.options, serverId + '.Name').Value;
 		server.port = findOption(this.options, serverId + '.Port').Value;
+		server.active = findOption(this.options, serverId + '.Active').Value == 'yes';
 		server.connections = findOption(this.options, serverId + '.Connections').Value;
 
 		return server;
+	}
+
+	this.subscribe = function(sub)
+	{
+		subs.push(sub);
+	}
+
+	function notifyAll(options) {
+		for (var i = 0; i < subs.length; ++i) {
+			subs[i].update(options);
+		}
 	}
 
 	function initCategories()
@@ -3430,7 +3448,7 @@ var ExecScriptDialog = (new function($)
 
 }(jQuery));
 
-/*** EXTENSION MANAGET *******************************************************/
+/*** EXTENSION MANAGER *******************************************************/
 
 function Extension()
 {

--- a/webui/config.js
+++ b/webui/config.js
@@ -56,6 +56,7 @@ var Options = (new function($)
 	var loadServerTemplateError;
 	var shortScriptNames = [];
 	var subs = [];
+	var onPageRenderedCallback;
 
 	var HIDDEN_SECTIONS = ['DISPLAY (TERMINAL)', 'POSTPROCESSING-PARAMETERS', 'POST-PROCESSING-PARAMETERS', 'POST-PROCESSING PARAMETERS'];
 	var POSTPARAM_SECTIONS = ['POSTPROCESSING-PARAMETERS', 'POST-PROCESSING-PARAMETERS', 'POST-PROCESSING PARAMETERS'];
@@ -84,6 +85,10 @@ var Options = (new function($)
 		{
 			_this.postParamConfig = initPostParamConfig(data);
 		});
+	}
+
+	this.setOnPageRenderedCallback = function(callback) {
+		onPageRenderedCallback = callback;
 	}
 
 	this.cleanup = function()
@@ -312,6 +317,11 @@ var Options = (new function($)
 
 		serverValues = null;
 		loadComplete(config);
+		if (onPageRenderedCallback)
+		{
+			onPageRenderedCallback();
+			onPageRenderedCallback = null;
+		}
 	}
 
 	function serverValuesLoaded(data)

--- a/webui/dark-theme.css
+++ b/webui/dark-theme.css
@@ -27,6 +27,10 @@ body {
 	color: #f5f5f5;
 }
 
+::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+}
+
 .btn-default {
 	color: #f5f5f5;
 	background-color: #414141;

--- a/webui/datetime.js
+++ b/webui/datetime.js
@@ -28,12 +28,17 @@ var DateTime = (function () {
 		var lastWeekDay = new Date();
 		lastWeekDay.setUTCDate(lastWeekDay.getUTCDate() + (6 - lastWeekDay.getUTCDay()));
 		
-		var now = new Date();
-		var firstMonthDay = new Date(Date.UTC(now.getFullYear(), now.getMonth(), 1));
-		var lastMonthDay = new Date(Date.UTC(now.getFullYear(), now.getMonth() + 1, 0));
+		this.currDay = new Date();
+
+		var firstMonthDay = new Date(Date.UTC(this.currDay.getFullYear(), this.currDay.getMonth(), 1));
+		var lastMonthDay = new Date(Date.UTC(this.currDay.getFullYear(), this.currDay.getMonth() + 1, 0));
 
 		this.week = this.getDateRange(firstWeekDay, lastWeekDay);
 		this.month = this.getDateRange(firstMonthDay, lastMonthDay);
+	};
+
+	DateTime.prototype.getCurrentDay = function () {
+		return this.currDay;
 	};
 
 	DateTime.prototype.getDateRange = function (startDate, endDate) {
@@ -48,15 +53,12 @@ var DateTime = (function () {
 		return dates;
 	};
 
-	DateTime.prototype.getWeekRange = function (date) {
-		const dayOfWeek = date.getUTCDay();
-		const startDate = new Date(date);
-		startDate.setUTCDate(date.getUTCDate() - dayOfWeek);
+	DateTime.prototype.getWeekRange = function () {
+		return this.getDateRange(this.week[0], this.week[this.week.length - 1]);
+	};
 
-		const endDate = new Date(date);
-		endDate.setUTCDate(date.getUTCDate() + (6 - dayOfWeek));
-
-		return this.getDateRange(startDate, endDate);
+	DateTime.prototype.getMonthRange = function () {
+		return this.getDateRange(this.month[0], this.month[this.month.length - 1]);
 	};
 
 	DateTime.prototype.getWeek = function () {

--- a/webui/datetime.js
+++ b/webui/datetime.js
@@ -1,0 +1,114 @@
+/*
+ * This file is part of nzbget. See <https://nzbget.com>.
+ *
+ * Copyright (C) 2025 Denis <denis@nzbget.com>
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+var DateTime = (function () {
+	function DateTime() {
+		this.recalculate();
+	}
+
+	DateTime.prototype.recalculate = function () {
+		var firstWeekDay = new Date();
+		firstWeekDay.setUTCDate(firstWeekDay.getUTCDate() - firstWeekDay.getUTCDay());
+		var lastWeekDay = new Date();
+		lastWeekDay.setUTCDate(lastWeekDay.getUTCDate() + (6 - lastWeekDay.getUTCDay()));
+		
+		var now = new Date();
+		var firstMonthDay = new Date(Date.UTC(now.getFullYear(), now.getMonth(), 1));
+		var lastMonthDay = new Date(Date.UTC(now.getFullYear(), now.getMonth() + 1, 0));
+
+		this.week = this.getDateRange(firstWeekDay, lastWeekDay);
+		this.month = this.getDateRange(firstMonthDay, lastMonthDay);
+	};
+
+	DateTime.prototype.getDateRange = function (startDate, endDate) {
+		var dates = [];
+		var currentDate = new Date(startDate);
+	
+		while (currentDate.getTime() <= endDate.getTime()) {
+			dates.push(new Date(currentDate));
+			currentDate.setUTCDate(currentDate.getUTCDate() + 1);
+		}
+	
+		return dates;
+	};
+
+	DateTime.prototype.getWeekRange = function (date) {
+		const dayOfWeek = date.getUTCDay();
+		const startDate = new Date(date);
+		startDate.setUTCDate(date.getUTCDate() - dayOfWeek);
+
+		const endDate = new Date(date);
+		endDate.setUTCDate(date.getUTCDate() + (6 - dayOfWeek));
+
+		return this.getDateRange(startDate, endDate);
+	};
+
+	DateTime.prototype.getWeek = function () {
+		return this.week;
+	};
+
+	DateTime.prototype.getMonth = function () {
+		return this.month;
+	};
+
+	DateTime.prototype.getFirstWeekDate = function () {
+		return this.week[0];
+	};
+
+	DateTime.prototype.getLastWeekDate = function () {
+		return this.week[6];
+	};
+
+	DateTime.prototype.getFirstMonthDate = function () {
+		return this.month[0];
+	};
+
+	DateTime.prototype.getLastMonthDate = function () {
+		return this.month[this.month.length - 1];
+	};
+
+	DateTime.prototype.getStartDate = function () {
+		return this.startDate;
+	};
+
+	DateTime.prototype.getEndDate = function () {
+		return this.endDate;
+	};
+
+	DateTime.prototype.getStartDateString = function () {
+		return this.startDateString;
+	};
+
+	DateTime.prototype.getEndDateString = function () {
+		return this.endDateString;
+	};
+
+	DateTime.prototype.formatDateForInput = function (date) {
+		var dateCopy = new Date(date);
+		if (isNaN(dateCopy)) {
+			return "";
+		}
+
+		dateCopy.setTime(dateCopy.getTime() - (dateCopy.getTimezoneOffset() * 60000));
+		var dateAsString = dateCopy.toISOString();
+		return dateAsString.slice(0, 10);
+	};
+
+	return DateTime;
+})();

--- a/webui/index.html
+++ b/webui/index.html
@@ -3,6 +3,7 @@
  * This file is part of nzbget. See <https://nzbget.com>.
  *
  * Copyright (C) 2012-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ * Copyright (C) 2023-2025 Denis <denis@nzbget.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,6 +43,7 @@
 
 	<!-- NZBGet -->
 	<!-- %if-debug%
+	<script language="javascript" type="text/javascript" src="datetime.js"></script>
 	<script language="javascript" type="text/javascript" src="fasttable.js"></script>
 	<script language="javascript" type="text/javascript" src="index.js"></script>
 	<script language="javascript" type="text/javascript" src="util.js"></script>
@@ -54,11 +56,12 @@
 	<script language="javascript" type="text/javascript" src="config.js"></script>
 	<script language="javascript" type="text/javascript" src="feed.js"></script>
 	<script language="javascript" type="text/javascript" src="system-info.js"></script>
+	<script language="javascript" type="text/javascript" src="statistics.js"></script>
 	%end% -->
 
 	<!-- Loading all javascript files from libraries and NZBGet in one request -->
 	<!-- %if-not-debug% -->
-	<script language="javascript" type="text/javascript" src="combined.js?lib/jquery.min.js+lib/bootstrap.min.js+lib/raphael.min.js+lib/elycharts.min.js+fasttable.js+index.js+util.js+downloads.js+edit.js+status.js+messages.js+history.js+upload.js+config.js+feed.js+system-info.js"></script>
+	<script language="javascript" type="text/javascript" src="combined.js?lib/jquery.min.js+lib/bootstrap.min.js+lib/raphael.min.js+lib/elycharts.min.js+datetime.js+fasttable.js+index.js+util.js+downloads.js+edit.js+status.js+messages.js+history.js+upload.js+config.js+feed.js+system-info.js+statistics.js"></script>
 	<!-- %end% -->
 
 	<style>.hide{display:none;}</style>
@@ -194,6 +197,9 @@
 
 					<input id="ConfigTable_filter" class="search-query" type="text" placeholder="Search settings" title="Search settings [Shift+F]">
 					<i id="ConfigTable_clearfilter" class="icon-remove-white search-clear" title="Clear [Shift+C]"></i>
+					
+					<input id="StatisticsTable_filter" class="search-query" disabled type="text" placeholder="Search statistics" title="Search">
+					<i id="StatisticsTable_clearfilter" class="icon-remove-white search-clear" title="Clear [Shift+C]"></i>
 				</div>
 			</div>
 
@@ -202,6 +208,7 @@
 				<ul class="nav">
 					<li class="active"><a data-toggle="tab" href="#DownloadsTab" id="DownloadsTabLink"><span class="phone-hide" title="Downloads [Shift+D]">Downloads </span><i class="material-icon phone-only inline">download</i><br class="phone-only"><span class="badge" id="DownloadsTabBadge" style="display: none;"></span><span class="badge badge-empty" id="DownloadsTabBadgeEmpty">&nbsp;</span></a></li>
 					<li><a data-toggle="tab" href="#HistoryTab" id="HistoryTabLink"><span class="phone-hide" title="History [Shift+H]">History </span><i class="material-icon phone-only inline">calendar_today</i><br class="phone-only"><span class="badge" id="HistoryTabBadge" style="display: none;"></span><span class="badge badge-empty" id="HistoryTabBadgeEmpty">&nbsp;</span></a></li>
+					<li><a data-toggle="tab" href="#StatisticsTab" id="StatisticsTabLink"><span class="phone-hide" title="Statistics [Shift+I]">Statistics </span><i class="material-icon phone-only inline">analytics</i><br class="phone-only"><span class="badge" id="StatisticsTabBadge" style="display: none;"></span><span class="phone-only"><span class="badge badge-empty" id="StatisticsabBadgeEmpty">&nbsp;</span></span></a></li>
 					<li><a data-toggle="tab" href="#MessagesTab" id="MessagesTabLink"><span class="phone-hide" title="Messages [Shift+M]">Messages </span><i class="material-icon phone-only inline">mail</i><br class="phone-only"><span class="badge" id="MessagesTabBadge" style="display: none;"></span><span class="badge badge-empty" id="MessagesTabBadgeEmpty">&nbsp;</span></a></li>
 					<li><a data-toggle="tab" href="#ConfigTab" id="ConfigTabLink"><span class="phone-hide" title="Settings [Shift+S]">Settings </span><i class="material-icon phone-only inline">settings</i><br class="phone-only"><span class="badge" id="ConfigTabBadge" style="display: none;"></span><span class="phone-only"><span class="badge badge-empty" id="ConfigTabBadgeEmpty">&nbsp;</span></span></a></li>
 				</ul>
@@ -1004,6 +1011,30 @@
 			</div>
 		</div>
 
+<!-- *** STATISTICS ************************************************************ -->
+		<div id="StatisticsTab" class="tab-pane fade">
+			<div id="StatisticsTabData" class="statistics">
+				<div id="Statistics_Spinner" class="statistics__spinner-container ">
+					<i class="material-icon spinner statistics__spinner ">progress_activity</i>
+				</div>
+				<div id="Statistics_Table" class="hide"></div>
+			</div>
+
+			<div id="Statistics_NoStatisticsAvailable" class="statistics__no-statistics hide">
+				<div class="statistics__no-servers-container">
+					<p class="text-large"><strong>Server stats are not available.</strong></p>
+					<p class="text-larger">No News Servers are currently configured.</p>
+					<p class="text-larger">Please go to Settings and add a News Server.</p>
+					<button id="Statistics_ConfigureServersBtn" class="btn btn-primary btn-large" 
+						title="News-Servers configuration"
+						onclick="Statistics.navigateToNewsServersConfiguration()"
+					>
+						Configure News Server
+					</button>
+				</div>
+			</div>
+		</div>
+
 	</div>
 </div>
 
@@ -1085,7 +1116,9 @@
 				</div>
 
 				<div id="StatDialog_Tooltip">Total</div>
-				<div id="StatDialog_ChartBlock"></div>
+				<div id="StatDialog_ChartBlock">
+					<div id="StatDialog_Chart"></div>
+				</div>
 
 				<hr>
 				<div id="StatDialog_CountersBlock">
@@ -2579,6 +2612,21 @@
 		</p>
 	</div>
 	<div id="StatDialogResetConfirmDialog_OK">Reset</div>
+</div>
+
+<!-- *** RESET VOLUME COUNTERS CONFIRMATION DIALOG DATA ******************************** -->
+
+<div class="hide" id="ServerStatResetConfirmDialog">
+	<div id="ServerStatResetConfirmDialog_Title">Reset counters</div>
+	<div id="ServerStatResetConfirmDialog_Text">
+		<p>
+			Reset counters for <strong id="ServerStatResetConfirmDialog_Server"></strong>?
+		</p>
+		<p class="confirm-help-block">
+			Last reset on <strong id="ServerStatResetConfirmDialog_Time"></strong>.
+		</p>
+	</div>
+	<div id="ServerStatResetConfirmDialog_OK">Reset</div>
 </div>
 
 <!-- *** START DANGEROUS SCRIPT CONFIRMATION DIALOG DATA ******************************** -->

--- a/webui/index.js
+++ b/webui/index.js
@@ -296,6 +296,7 @@ var Frontend = (new function($)
 		RestoreSettingsDialog.init();
 		LimitDialog.init();
 		SystemInfo.init();
+		Statistics.init();
 
 		DownloadsEditDialog.init();
 		DownloadsMultiDialog.init();
@@ -396,6 +397,8 @@ var Frontend = (new function($)
 			link = 'MessagesTabLink';
 		else if (location.indexOf('#settings') > -1)
 			link = 'ConfigTabLink';
+		else if (location.indexOf('#statistics') > -1)
+			link = 'StatisticsTabLink';
 		if (link)
 		{
 			$('#DownloadsTab').removeClass('fade');
@@ -482,7 +485,7 @@ var Frontend = (new function($)
 			return;
 		}
 
-		var filterBox = $('#DownloadsTable_filter, #HistoryTable_filter, #MessagesTable_filter, #ConfigTable_filter');
+		var filterBox = $('#DownloadsTable_filter, #HistoryTable_filter, #MessagesTable_filter, #ConfigTable_filter', '#StatisticsTable_filter');
 		if (filterBox.is(':focus') && (key === 'Escape' || key === 'Enter'))
 		{
 			filterBox.blur();
@@ -497,6 +500,7 @@ var Frontend = (new function($)
 				case 'History': if (History.processShortcut(key)) return false;
 				case 'Messages': if (Messages.processShortcut(key)) return false;
 				case 'Config': if (Config.processShortcut(key)) return false;
+				case 'Statistics': if (Config.processShortcut(key)) return false;
 			}
 			switch (key)
 			{
@@ -504,6 +508,7 @@ var Frontend = (new function($)
 				case 'Shift+H': $('#HistoryTabLink').click(); return false;
 				case 'Shift+M': $('#MessagesTabLink').click(); return false;
 				case 'Shift+S': $('#ConfigTabLink').click(); return false;
+				case 'Shift+I': $('#StatisticsTabLink').click(); return false;
 				case 'Shift+L': $('#StatusSpeed').click(); return false;
 				case 'Shift+A': $('#StatusTime').click(); return false;
 				case 'Shift+R': $('#RefreshButton').click(); return false;
@@ -869,6 +874,7 @@ var Refresher = (new function($)
 
 		loadQueue = 4;
 		Status.update();
+		Statistics.update();
 		Downloads.update();
 		Messages.update();
 		History.update();

--- a/webui/statistics.js
+++ b/webui/statistics.js
@@ -1,0 +1,1286 @@
+/*
+ * This file is part of nzbget. See <https://nzbget.com>.
+ *
+ * Copyright (C) 2025 Denis <denis@nzbget.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+var Statistics = new (function ($) {
+	"use strict";
+
+	var datetime = new DateTime();
+	var TEST_SERVER_HOST = "my.newsserver.com";
+
+	function Server() {
+		this.DOWNLOAD_SPEED_CHART = 0;
+		this.DOWMLOADED_VOLUME_CHART = 1;
+
+		this.id = 0;
+		this.connections = 0;
+		this.host = "";
+		this.name = "";
+		this.port = "";
+		this.active = false;
+		this.weekSizeMB = 0;
+		this.weekSizeLo = 0;
+		this.monthSizeMB = 0;
+		this.monthSizeLo = 0;
+		this.totalSizeMB = 0;
+		this.totalSizeLo = 0;
+		this.successArticles = [];
+		this.failedArticles = [];
+		this.startDate = datetime.getFirstMonthDate();
+		this.endDate = datetime.getLastMonthDate();
+		this.lastResetDate = null;
+		this.$details = null;
+		this.$downloadSpeedChart = null;
+		this.$downloadVolumeChart = null;
+		this.$spinner = null;
+		this.$chartToggleBtn = null;
+		this.$speedChartBtn = null;
+		this.$volumeChartBtn = null;
+		this.activeChart = this.DOWNLOAD_SPEED_CHART;
+		this.speedChartData = {
+			range: "MIN",
+			data: null,
+			dataMB: null,
+			curPoint: null,
+			units: null,
+			labels: null,
+			mouseOverIndex: -1
+		};
+
+		this.volumeChartData = {
+			range: "MONTH",
+			data: null,
+			dataMB: null,
+			dataLo: null,
+			units: null,
+			curPoint: null,
+			sumMB: null,
+			sumLo: null,
+			labels: null,
+			mouseOverIndex: -1
+		};
+
+		this.getChartData = function () {
+			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
+				return this.speedChartData;
+			}
+			return this.volumeChartData;
+		};
+
+		this.setChartData = function (data) {
+			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
+				var mouseOverIndex = this.speedChartData.mouseOverIndex;
+				this.speedChartData = data;
+				this.speedChartData.mouseOverIndex = mouseOverIndex;
+				return;
+			}
+			var mouseOverIndex = this.volumeChartData.mouseOverIndex;
+			this.volumeChartData = data;
+			this.volumeChartData.mouseOverIndex = mouseOverIndex;
+		};
+
+		this.showChart = function () {
+			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
+				this.$downloadSpeedChart.show();
+				this.$downloadVolumeChart.hide();
+			} else {
+				this.$downloadSpeedChart.hide();
+				this.$downloadVolumeChart.show();
+			}
+		};
+
+		this.hideChart = function () {
+			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
+				this.$downloadSpeedChart.hide();
+			} else {
+				this.$downloadVolumeChart.hide();
+			}
+		};
+
+		this.showDetails = function () {
+			this.$details.show();
+		};
+
+		this.hideSpinner = function () {
+			this.$spinner.hide();
+		};
+
+		this.showSpinner = function () {
+			this.$spinner.show();
+		};
+
+		this.toggleChart = function () {
+			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
+				this.activeChart = this.DOWMLOADED_VOLUME_CHART;
+				this.$downloadSpeedChart.hide();
+				this.$downloadVolumeChart.show();
+				this.$speedChartBtn.removeClass("btn-active");
+				this.$volumeChartBtn.addClass("btn-active");
+			} else {
+				this.activeChart = this.DOWNLOAD_SPEED_CHART;
+				this.$downloadSpeedChart.hide();
+				this.$downloadVolumeChart.show();
+				this.$speedChartBtn.addClass("btn-active");
+				this.$volumeChartBtn.removeClass("btn-active");
+			}
+		};
+	}
+
+	var $StatisticsSpinner;
+	var $StatisticsTable;
+	var $NoStatisticsAvailable;
+	var serverStats = {};
+	var options = null;
+	var servervolumes = null;
+	var serverVolumesLoaded = false;
+	var optionsHandler = {
+		update: function update(options_) {
+			if (options || !options_) return;
+			options = options_;
+
+			var id = 1;
+			var server = Options.getServerById(id);
+			while (server) {
+				var newServer = new Server();
+				newServer.id = id;
+				newServer.connections = server.connections;
+				newServer.host = server.host;
+				newServer.name = server.name;
+				newServer.port = server.port;
+				newServer.active = server.active;
+				serverStats[newServer.id] = newServer;
+				++id;
+				server = Options.getServerById(id);
+			}
+
+			if (noServers(serverStats) || testServerOnly(serverStats)) {
+				$StatisticsSpinner.hide();
+				$NoStatisticsAvailable.show();
+				return;
+			}
+
+			RPC.call("servervolumes", [], fistServervolumesLoaded);
+			renderServers(serverStats);
+		}
+	};
+
+	this.init = function () {
+		$("#StatisticsTable_filter").val("");
+		$StatisticsSpinner = $("#Statistics_Spinner");
+		$StatisticsTable = $("#Statistics_Table");
+		$NoStatisticsAvailable = $("#Statistics_NoStatisticsAvailable");
+		$StatisticsTable.fasttable({
+			filterInput: $("#StatisticsTable_filter"),
+			filterClearButton: $("#StatisticsTable_clearfilter"),
+			filterInputCallback: filterInput,
+			filterClearCallback: filterClear
+		});
+
+		Options.subscribe(optionsHandler);
+	};
+
+	this.update = function () {
+		if (serverVolumesLoaded) {
+			RPC.call("servervolumes", [], servervolumesLoaded);
+		}
+	};
+
+	function filterInput() { }
+	function filterClear() { }
+
+	function noServers(servers) {
+		return Util.emptyObject(servers);
+	}
+
+	function testServerOnly(servers) {
+		var amount = 0;
+		var hasTestServer = false;
+		for (const key in servers) {
+			if (Object.prototype.hasOwnProperty.call(servers, key)) {
+				++amount;
+				if (servers[key].host === TEST_SERVER_HOST) {
+					hasTestServer = true;
+				}
+			}
+		}
+
+		return amount == 1 && hasTestServer;
+	}
+
+	function fistServervolumesLoaded(volumes) {
+		if (serverVolumesLoaded) return;
+		servervolumes = volumes;
+		serverVolumesLoaded = true;
+		$StatisticsSpinner.hide();
+		$StatisticsTable.show();
+	}
+
+	function renderServers(servers) {
+		for (var key in servers) {
+			if (Object.prototype.hasOwnProperty.call(servers, key)) {
+				renderServer(servers[key]);
+			}
+		}
+	}
+
+	function renderServer(server) {
+		var $container = $("<div>", {
+			class: "flex-center"
+		})
+			.css("flex-wrap", "wrap")
+			.css("min-height", "300px");
+		server.$details = makeServerDetails(server);
+		server.$spinner = makeSpinner(server);
+		server.$downloadSpeedChart = makeDownloadSpeedChart(server);
+		server.$downloadVolumeChart = makeDownloadVolumeChart(server);
+		server.$details.css("flex-grow", "1").css("flex-basis", "400px");
+		server.$spinner.css("flex-grow", "3").css("flex-basis", "600px");
+		server.$downloadSpeedChart
+			.css("flex-grow", "3")
+			.css("flex-basis", "600px")
+			.css("overflow", "hidden");
+		server.$downloadVolumeChart
+			.css("flex-grow", "3")
+			.css("flex-basis", "600px")
+			.css("overflow", "hidden");
+		server.$details.hide();
+		server.$downloadSpeedChart.hide();
+		server.$downloadVolumeChart.hide();
+		$container.append(
+			server.$details,
+			server.$spinner,
+			server.$downloadSpeedChart,
+			server.$downloadVolumeChart
+		);
+		$StatisticsTable.append($container, "<hr>");
+	}
+
+	function makeResetButton(server) {
+		var $btn = $(
+			'<button class="btn btn-default" title="Reset counters">'
+			+ '<i class="material-icon">refresh</i>Reset'
+			+ '</button>'
+		);
+		$btn
+			.on("click", function () {
+				$("#ServerStatResetConfirmDialog_Server").text(server.name);
+				$("#ServerStatResetConfirmDialog_Time").text(server.lastResetDate);
+				ConfirmDialog.showModal("ServerStatResetConfirmDialog", function () {
+					RPC.call(
+						"resetservervolume",
+						[server.id === 0 ? -1 : server.id, ""],
+						function () {
+							PopupNotification.show("#Notif_StatReset");
+							Refresher.update();
+						}
+					);
+				});
+			});
+		return $btn;
+	}
+
+	function makeServerDetails(server) {
+		var html = '<div class="statistics__server-details">';
+		html += "<h4>Server Details</h4>";
+		html +=
+			'<table class="table table-condensed table-bordered table-fixed server-details__table">';
+		html += "<tr><th>Name:</th><td>".concat(server.name, "</td></tr>");
+		html += "<tr><th>Host:</th><td>".concat(server.host, "</td></tr>");
+		html += "<tr><th>Connections:</th><td>".concat(
+			server.connections,
+			"</td></tr>"
+		);
+		html += "<tr><th>Active:</th><td>".concat(
+			server.active ? "<span class='txt-success'>Yes</span>" : "<span class='txt-important'>No</span>",
+			"</td></tr>"
+		);
+		html += "</table>";
+		html += "<h4>Bandwidth Usage</h4>";
+		html +=
+			'<table class="table table-condensed table-bordered table-fixed server-details__table">';
+		html += '<tr><th>Today:</td><td id="'.concat(
+			server.id,
+			'_TodayDownloaded"></td></tr>'
+		);
+		html += '<tr><th>This Week:</th><td id="'.concat(
+			server.id,
+			'_WeekDownloaded"></td></tr>'
+		);
+		html += '<tr><th>This Month:</th><td id="'.concat(
+			server.id,
+			'_MonthDownloaded"></td></tr>'
+		);
+		html += '<tr><th>Total:</td><td id="'.concat(
+			server.id,
+			'_TotalDownloaded"></td></tr>'
+		);
+		html += "</table>";
+		html += "<h4>Article Statistics</h4>";
+		html += '<table class="table table-condensed table-bordered table-fixed">';
+		html += '<tr><th>Success/Failed:</th><td id="'.concat(
+			server.id,
+			'_Articles"></td></tr>'
+		);
+		html += '<tr><th>Completion:</td><td id="'.concat(
+			server.id,
+			'_Completion"></td></tr>'
+		);
+		html += "</table>";
+		html += "</div>";
+
+		var $controls = $("<div>", {
+			class: "btn-group"
+		}).css("padding", "5px 0");
+
+		var $serverConfigBtn = makeConfigServerBtn(server);
+		var $resetCountersBtn = makeResetButton(server);
+		$controls.append($serverConfigBtn, $resetCountersBtn);
+
+		return $(html).append($controls);
+	}
+
+	function updateServersDetails(servers) {
+		for (var key in servers) {
+			if (Object.prototype.hasOwnProperty.call(servers, key)) {
+				updateServerDetails(servers[key]);
+			}
+		}
+	}
+
+	function calculateSizePerDays(dates, bytesPerDays, firstDay, daySlot) {
+		var sizeMB = 0;
+		var sizeLo = 0;
+		for (var i = 0; i < dates.length; ++i) {
+			var date = dates[i];
+			var slot = Util.getDaySinceUnixEpoch(date);
+			if (slot >= firstDay) {
+				var idx = slot - firstDay;
+				if (!bytesPerDays[idx] || idx > daySlot)
+					break;
+
+				sizeMB += bytesPerDays[idx].SizeMB;
+				sizeLo += bytesPerDays[idx].SizeLo;
+			}
+		}
+		return {
+			sizeMB: sizeMB,
+			sizeLo: sizeLo
+		};
+	}
+
+	function updateServerDetails(server) {
+		if (!servervolumes[server.id])
+			return;
+
+		var serverVolume = servervolumes[server.id];
+		var daySlot = serverVolume.DaySlot;
+		var week = datetime.getWeek();
+		var month = datetime.getMonth();
+		var weekSizes = calculateSizePerDays(
+			week,
+			serverVolume.BytesPerDays,
+			serverVolume.FirstDay,
+			daySlot
+		);
+		server.weekSizeMB = weekSizes.sizeMB;
+		server.weekSizeLo = weekSizes.sizeLo;
+		var monthSizes = calculateSizePerDays(
+			month,
+			serverVolume.BytesPerDays,
+			serverVolume.FirstDay,
+			daySlot
+		);
+		server.monthSizeMB = monthSizes.sizeMB;
+		server.monthSizeLo = monthSizes.sizeLo;
+		server.todaySizeMB = serverVolume.BytesPerDays[daySlot].SizeMB;
+		server.todaySizeLo = serverVolume.BytesPerDays[daySlot].SizeLo;
+		server.totalSizeMB = serverVolume.TotalSizeMB;
+		server.totalSizeLo = serverVolume.TotalSizeLo;
+		server.lastResetDate = Util.formatDateTime(serverVolume.CountersResetTime);
+
+		var successSum = 0;
+		var failedSum = 0;
+		serverVolume.ArticlesPerDays.forEach(function (articles) {
+			successSum += articles.Success;
+			failedSum += articles.Failed;
+		});
+
+		var completion =
+			successSum + failedSum > 0
+				? Util.round0((successSum * 100.0) / (successSum + failedSum)) + "%"
+				: "--";
+
+		if (failedSum > 0 && completion === "100%") {
+			completion = "99.9%";
+		}
+
+		var $successArticles = $(
+			"<span>".concat(Util.formatNumber(successSum), "</span>")
+		);
+
+		$successArticles.addClass("txt-success");
+		var $failedArticles = $(
+			"<span>".concat(Util.formatNumber(failedSum), "</span>")
+		);
+
+		$failedArticles.addClass("txt-important");
+		var $articles = $("#".concat(server.id, "_Articles"));
+
+		$articles.empty();
+		$articles.append($successArticles, " / ", $failedArticles);
+
+		$("#".concat(server.id, "_TodayDownloaded")).text(
+			Util.formatSizeMB(server.todaySizeMB, server.todaySizeLo)
+		);
+		$("#".concat(server.id, "_WeekDownloaded")).text(
+			Util.formatSizeMB(server.weekSizeMB, server.weekSizeLo)
+		);
+		$("#".concat(server.id, "_MonthDownloaded")).text(
+			Util.formatSizeMB(server.monthSizeMB, server.monthSizeLo)
+		);
+		$("#".concat(server.id, "_TotalDownloaded")).text(
+			Util.formatSizeMB(server.totalSizeMB, server.totalSizeLo)
+		);
+		$("#".concat(server.id, "_Completion")).text(completion);
+		server.showDetails();
+	}
+
+	function makeSpinner(server) {
+		var html = '<div class="statistics__chart-block-spinner">';
+		html += '<i class="statistics__chart-block-spinner material-icon spinner"';
+		html += 'id="'
+			.concat(server.id, "_ChartSpinner-")
+			.concat(server.activeChart, '">progress_activity</i>');
+		html += "</div>";
+		return $(html);
+	}
+
+	function makeConfigServerBtn(server) {
+		var $btn = $(
+			'<button class="btn btn-default" title="News Server configuration">'
+			+ '<i class="material-icon">settings</i>Config'
+			+ '</button>'
+		)
+			.attr("data-optid", "S_Server" + server.id + "_Active")
+			.on("click", function (ev) {
+				$('#ConfigTabLink').click();
+				Options.loadConfig({
+					complete: function (config) {
+						Config.buildPage(config);
+						setTimeout(function () {
+							$("a[href$='#NEWS-SERVERS']").click();
+							Config.scrollToOption(ev, $btn);
+						}, 500);
+					},
+					configError: Config.loadConfigError,
+					serverTemplateError: Config.loadServerTemplateError
+				});
+			});
+
+		return $btn;
+	}
+
+	this.navigateToNewsServersConfiguration = function() {
+		$('#ConfigTabLink').click();
+		Options.loadConfig({
+			complete: function (config) {
+				Config.buildPage(config);
+				setTimeout(function () {
+					$("a[href$='#NEWS-SERVERS']").click();
+				}, 500);
+			},
+			configError: Config.loadConfigError,
+			serverTemplateError: Config.loadServerTemplateError
+		});
+	}
+
+	function makeToggleChartBtn(server) {
+		var $container = $("<div>", {
+			class: "btn-group"
+		}).css("padding-bottom", "5px");
+		var $speedChartBtn = $("<button>", {
+			class: "btn btn-default btn-active",
+			title: "Show the Download Speed chart",
+			text: "Speed"
+		}).on("click", function () {
+			server.toggleChart();
+			redrawChart(server);
+		});
+		var $volumeChartBtn = $("<button>", {
+			class: "btn btn-default",
+			title: "Show the Downloaded Volume chart",
+			text: "Volume"
+		}).on("click", function () {
+			server.toggleChart();
+			redrawChart(server);
+		});
+
+		server.$speedChartBtn = $speedChartBtn;
+		server.$volumeChartBtn = $volumeChartBtn;
+		$container.append($speedChartBtn, $volumeChartBtn);
+		return $container;
+	}
+
+	function makeDownloadSpeedChart(server) {
+		var $container = $("<div>", {
+			class: "statistics"
+		});
+		var $title = makeToggleChartBtn(server);
+		var $toolbar = $("<div>", {
+			class: "btn-toolbar form-inline section-toolbar",
+			id: "".concat(server.id, "_Toolbar-").concat(server.DOWNLOAD_SPEED_CHART)
+		}).css("margin-bottom", "0");
+		var $timeBlockTop = $("<div>", {
+			class: "btn-group phone-hide",
+			id: ""
+				.concat(server.id, "_TimeBlockTop-")
+				.concat(server.DOWNLOAD_SPEED_CHART)
+		});
+		var $minButton = $("<button>", {
+			class: "btn btn-default btn-active volume-range",
+			id: ""
+				.concat(server.id, "_Volume_MIN-")
+				.concat(server.DOWNLOAD_SPEED_CHART),
+			title: "Show last 60 seconds",
+			text: "60 Seconds"
+		}).on("click", function () {
+			chooseRange(server, "MIN");
+		});
+		var $5minButton = $("<button>", {
+			class: "btn btn-default volume-range",
+			id: ""
+				.concat(server.id, "_Volume_5MIN-")
+				.concat(server.DOWNLOAD_SPEED_CHART),
+			title: "Show last 5 minutes",
+			text: "5 Minutes"
+		}).on("click", function () {
+			chooseRange(server, "5MIN");
+		});
+		var $hourButton = $("<button>", {
+			class: "btn btn-default volume-range",
+			id: ""
+				.concat(server.id, "_Volume_HOUR-")
+				.concat(server.DOWNLOAD_SPEED_CHART),
+			title: "Show 60 minutes",
+			text: "60 Minutes"
+		}).on("click", function () {
+			chooseRange(server, "HOUR");
+		});
+		$timeBlockTop.append($minButton, $5minButton, $hourButton);
+		$toolbar.append($timeBlockTop);
+		var $phoneButtons = $("<div>", {
+			class: "btn-group phone-only inline"
+		}).append(
+			$("<button>", {
+				class: "btn btn-default btn-active volume-range",
+				id: ""
+					.concat(server.id, "_Volume_MIN2-")
+					.concat(server.DOWNLOAD_SPEED_CHART),
+				title: "Show last 60 seconds",
+				text: "60 s"
+			}).on("click", function () {
+				chooseRange(server, "MIN");
+			}),
+			$("<button>", {
+				class: "btn btn-default volume-range",
+				id: ""
+					.concat(server.id, "_Volume_5MIN2-")
+					.concat(server.DOWNLOAD_SPEED_CHART),
+				title: "Show last 5 minutes",
+				text: "5 m"
+			}).on("click", function () {
+				chooseRange(server, "5MIN");
+			}),
+			$("<button>", {
+				class: "btn btn-default volume-range",
+				id: ""
+					.concat(server.id, "_Volume_HOUR2-")
+					.concat(server.DOWNLOAD_SPEED_CHART),
+				title: "Show last 60 minutes",
+				text: "60 m"
+			}).on("click", function () {
+				chooseRange(server, "HOUR");
+			})
+		);
+		$toolbar.append($phoneButtons);
+		var $tooltip = $("<div>", {
+			class: "statistics__tooltip",
+			id: "".concat(server.id, "_Tooltip-").concat(server.DOWNLOAD_SPEED_CHART),
+			text: "--"
+		});
+		var $chartBlock = $("<div>", {
+			class: "statistics__chartblock"
+		});
+
+		var $chart = $("<div>", {
+			class: "statistics__chart",
+			id: ""
+				.concat(server.id, "_Chart-")
+				.concat(server.DOWNLOAD_SPEED_CHART)
+		});
+
+		$chartBlock.append($chart);
+		$container.append($title, $toolbar, $tooltip, $chartBlock);
+		return $container;
+	}
+
+	function makeDownloadVolumeChart(server) {
+		var $container = $("<div>", {
+			class: "statistics"
+		});
+		var $title = makeToggleChartBtn(server);
+		var $toolbar = $("<div>", {
+			class: "btn-toolbar form-inline section-toolbar",
+			id: ""
+				.concat(server.id, "_Toolbar-")
+				.concat(server.DOWMLOADED_VOLUME_CHART)
+		}).css("margin-bottom", "5px");
+		var $startDateInput = $("<input>", {
+			type: "date"
+		});
+		var $sep = $("<span> - </span>");
+		var $endDateInput = $("<input>", {
+			type: "date"
+		});
+		var startDateStr = datetime.formatDateForInput(server.startDate);
+		var endDateStr = datetime.formatDateForInput(server.endDate);
+		$startDateInput.val(startDateStr);
+		$endDateInput.val(endDateStr);
+		$startDateInput.attr("max", endDateStr);
+		$endDateInput.attr("min", startDateStr);
+		$startDateInput.on("change", function () {
+			var startDate = $(this).val();
+			server.startDate = new Date(startDate);
+			$endDateInput.attr("min", datetime.formatDateForInput(startDate));
+			redrawVolumeChart(server);
+		});
+		$endDateInput.on("change", function () {
+			var endDate = $(this).val();
+			server.endDate = new Date(endDate);
+			$startDateInput.attr("max", datetime.formatDateForInput(endDate));
+			redrawVolumeChart(server);
+		});
+		$toolbar.append($startDateInput, $sep, $endDateInput);
+		var $tooltip = $("<div>", {
+			class: "statistics__tooltip",
+			id: ""
+				.concat(server.id, "_Tooltip-")
+				.concat(server.DOWMLOADED_VOLUME_CHART),
+			text: "--"
+		});
+
+		var $chartBlock = $("<div>", {
+			class: "statistics__chartblock"
+		});
+
+		var $chart = $("<div>", {
+			class: "statistics__chart",
+			id: ""
+				.concat(server.id, "_Chart-")
+				.concat(server.DOWMLOADED_VOLUME_CHART)
+		});
+
+		$chartBlock.append($chart);
+		$container.append($title, $toolbar, $tooltip, $chartBlock);
+		return $container;
+	}
+
+	function servervolumesLoaded(volumes) {
+		var sameDay = servervolumes[0].DaySlot === volumes[0].DaySlot;
+		servervolumes = volumes;
+
+		if (!sameDay) {
+			datetime.recalculate();
+		}
+
+		updateServersDetails(serverStats);
+		redrawCharts(serverStats);
+	}
+
+	function redrawCharts(serverStats) {
+		for (var key in serverStats) {
+			if (Object.prototype.hasOwnProperty.call(serverStats, key)) {
+				var server = serverStats[key];
+				redrawChart(server);
+			}
+		}
+	}
+
+	function size64(size) {
+		return size.SizeMB < 2000 ? size.SizeLo / 1024.0 / 1024.0 : size.SizeMB;
+	}
+
+	function redrawSpeedChart(server) {
+		var serverData = server.getChartData();
+		var serverNo = server.id;
+		var curRange = serverData.range;
+		var lineLabels = [];
+		var dataLabels = [];
+		var chartSpeedTb = [];
+		var chartSpeedGb = [];
+		var chartSpeedMb = [];
+		var chartSpeedKb = [];
+		var chartSpeedB = [];
+		var curPoint = null;
+		var sumMb = 0;
+		var sumLo = 0;
+		var maxSizeMb = 0;
+		var maxSizeLo = 0;
+
+		function addData(data, dataLabel, timeIntervalSeconds) {
+			dataLabels.push(dataLabel);
+			var sizeMB = size64(data);
+			var speedMb = (sizeMB / timeIntervalSeconds) * 8;
+			var speedLoMb = (data.SizeLo / timeIntervalSeconds) * 8;
+			chartSpeedTb.push(speedMb / 1024.0 / 1024.0);
+			chartSpeedGb.push(speedMb / 1024.0);
+			chartSpeedMb.push(speedMb);
+			chartSpeedKb.push(speedMb * 1024.0);
+			chartSpeedB.push(speedMb * 1024.0 * 1024.0);
+			if (speedMb > maxSizeMb) {
+				maxSizeMb = speedMb;
+			}
+			if (speedLoMb > maxSizeLo) {
+				maxSizeLo = speedLoMb;
+			}
+			sumMb += speedMb;
+			sumLo += speedLoMb;
+		}
+
+		function rerangeCircularBuffer(buffer, currentSlot) {
+			var rearranged = [];
+			for (var i = currentSlot + 1; i < buffer.length; i++) {
+				rearranged.push(buffer[i]);
+			}
+			for (var i = 0; i <= currentSlot; i++) {
+				rearranged.push(buffer[i]);
+			}
+			return rearranged;
+		}
+
+		function drawMinuteGraph() {
+			var buffer = rerangeCircularBuffer(
+				servervolumes[serverNo].BytesPerSeconds,
+				servervolumes[serverNo].SecSlot
+			);
+			for (var i = 0; i < buffer.length; i++) {
+				// the current slot may be not fully filled yet,
+				// to make the chart smoother for current slot 
+				// we show the previous slot as current.
+				if (i === 59) {
+					addData(buffer[58], i + "s", 1);
+				}
+				else {
+					addData(buffer[i], i + "s", 1);
+				}
+			}
+			curPoint = 59;
+		}
+
+		function drawFiveMinuteGraph() {
+			var buffer = rerangeCircularBuffer(
+				servervolumes[serverNo].BytesPerMinutes,
+				servervolumes[serverNo].MinSlot
+			);
+			for (var i = 55; i < buffer.length; i++) {
+				addData(buffer[i], i - 55 + "m", 60);
+			}
+			curPoint = 4;
+		}
+
+		function drawHourGraph() {
+			var buffer = rerangeCircularBuffer(
+				servervolumes[serverNo].BytesPerMinutes,
+				servervolumes[serverNo].MinSlot
+			);
+			for (var i = 0; i < buffer.length; i++) {
+				addData(buffer[i], i + "m", 60);
+			}
+			curPoint = 59;
+		}
+
+		if (curRange === "MIN") {
+			drawMinuteGraph();
+		} else if (curRange === "5MIN") {
+			drawFiveMinuteGraph();
+		} else if (curRange === "HOUR") {
+			drawHourGraph();
+		}
+
+		var serieData =
+			maxSizeMb >= 1024 * 1024
+				? chartSpeedTb
+				: maxSizeMb >= 1024
+					? chartSpeedGb
+					: maxSizeMb >= 1
+						? chartSpeedMb
+						: chartSpeedKb;
+		var units =
+			maxSizeMb >= 1024 * 1024
+				? " Tbit/s"
+				: maxSizeMb >= 1024
+					? " Gbit/s"
+					: maxSizeMb >= 1
+						? " Mbit/s"
+						: " Kbit/s";
+		var curPointData = [];
+
+		for (var i = 0; i < serieData.length; ++i) {
+			curPointData.push(i === curPoint ? serieData[i] : null);
+		}
+
+		server.setChartData({
+			data: serieData,
+			dataMB: chartSpeedMb,
+			curPoint: curPoint,
+			units: units,
+			range: curRange,
+			labels: dataLabels
+		});
+
+		server.showChart();
+		server.hideSpinner();
+
+		var $chart = $("#".concat(server.id, "_Chart-").concat(server.activeChart));
+		if (!$chart) return;
+		if (!isParentContainerRendered($chart)) {
+			server.hideChart();
+			server.showSpinner();
+			return;
+		}
+
+		$chart
+			.chart('clear')
+			.width(getChartWidth($chart))
+			.chart(
+				makeChart(serieData, curPointData, lineLabels, units, {
+					type: "axis",
+					onMouseOver: function onMouseOver(env, serie, index, mouseAreaData) {
+						chartMouseOver(server, env, serie, index, mouseAreaData);
+					},
+					onMouseExit: function onMouseExit(env, serie, index, mouseAreaData) {
+						chartMouseExit(server, env, serie, index, mouseAreaData);
+					},
+					onMouseOut: function onMouseOut(env, serie, index, mouseAreaData) {
+						chartMouseExit(server, env, serie, index, mouseAreaData);
+					}
+				})
+			);
+
+		simulateMouseEvent(server, chartMouseExit);
+	}
+
+	function redrawVolumeChart(server) {
+		var serverNo = server.id;
+		var startDate = server.startDate;
+		var endDate = server.endDate;
+		var lineLabels = [];
+		var dataLabels = [];
+		var chartDataTB = [];
+		var chartDataGB = [];
+		var chartDataMB = [];
+		var chartDataKB = [];
+		var chartDataB = [];
+		var curPoint = null;
+		var sumMB = 0;
+		var sumLo = 0;
+		var maxSizeMB = 0;
+		var maxSizeLo = 0;
+		var dates = datetime.getDateRange(startDate, endDate);
+
+		function addData(bytes, dataLab, lineLab) {
+			dataLabels.push(dataLab);
+			lineLabels.push(lineLab);
+			if (bytes === null) {
+				chartDataTB.push(null);
+				chartDataGB.push(null);
+				chartDataMB.push(null);
+				chartDataKB.push(null);
+				chartDataB.push(null);
+				return;
+			}
+			chartDataTB.push(bytes.SizeMB / 1024.0 / 1024.0);
+			chartDataGB.push(bytes.SizeMB / 1024.0);
+			chartDataMB.push(size64(bytes));
+			chartDataKB.push(bytes.SizeLo / 1024.0);
+			chartDataB.push(bytes.SizeLo);
+			if (bytes.SizeMB > maxSizeMB) {
+				maxSizeMB = bytes.SizeMB;
+			}
+			if (bytes.SizeLo > maxSizeLo) {
+				maxSizeLo = bytes.SizeLo;
+			}
+			sumMB += bytes.SizeMB;
+			sumLo += bytes.SizeLo;
+		}
+
+		function drawGraph() {
+			var bytesPerDays = servervolumes[serverNo].BytesPerDays;
+			var firstDay = servervolumes[serverNo].FirstDay;
+			var daySlot = servervolumes[serverNo].DaySlot;
+			for (var i = 0; i < dates.length; ++i) {
+				var date = dates[i];
+				var label = date.toDateString();
+				var slot = Util.getDaySinceUnixEpoch(date);
+				if (slot >= firstDay) {
+					var idx = slot - firstDay;
+					if (idx <= daySlot)
+						addData(bytesPerDays[idx], label, "");
+					else
+						addData({ SizeMB: 0, SizeLo: 0 }, label, "");
+				} else {
+					addData({ SizeMB: 0, SizeLo: 0 }, label, "");
+				}
+			}
+		}
+
+		drawGraph();
+
+		var serieData =
+			maxSizeMB > 1024 * 1024
+				? chartDataTB
+				: maxSizeMB > 1024
+					? chartDataGB
+					: maxSizeMB > 1 || maxSizeLo == 0
+						? chartDataMB
+						: maxSizeLo > 1024
+							? chartDataKB
+							: chartDataB;
+
+		if (serieData.length === 0) return;
+
+		var units =
+			maxSizeMB > 1024 * 1024
+				? " TB"
+				: maxSizeMB > 1024
+					? " GB"
+					: maxSizeMB > 1 || maxSizeLo == 0
+						? " MB"
+						: maxSizeLo > 1024
+							? " KB"
+							: " B";
+
+		var curPointData = [];
+
+		for (var i = 0; i < serieData.length; i++) {
+			curPointData.push(i === curPoint ? serieData[i] : null);
+		}
+
+		server.setChartData({
+			data: serieData,
+			dataMB: chartDataMB,
+			dataLo: chartDataB,
+			units: units,
+			curPoint: curPoint,
+			labels: dataLabels,
+			sumMB: sumMB,
+			sumLo: sumLo
+		});
+
+		server.showChart();
+		server.hideSpinner();
+
+		var $chart = $("#".concat(server.id, "_Chart-").concat(server.activeChart));
+		if (!$chart) return;
+		if (!isParentContainerRendered($chart)) {
+			server.hideChart();
+			server.showSpinner();
+			return;
+		}
+
+		$chart
+			.chart('clear')
+			.width(getChartWidth($chart))
+			.chart(
+				makeChart(serieData, curPointData, lineLabels, units, {
+					type: "axis",
+					onMouseOver: function onMouseOver(env, serie, index, mouseAreaData) {
+						chartMouseOver2(server, env, serie, index, mouseAreaData);
+					},
+					onMouseExit: function onMouseExit(env, serie, index, mouseAreaData) {
+						chartMouseExit2(server, env, serie, index, mouseAreaData);
+					},
+					onMouseOut: function onMouseOut(env, serie, index, mouseAreaData) {
+						chartMouseExit2(server, env, serie, index, mouseAreaData);
+					}
+				})
+			);
+
+		simulateMouseEvent(server, chartMouseExit2);
+	}
+
+	function isParentContainerRendered($chart) {
+		var containerWidth = $chart.parent().width();
+		if (containerWidth > 0)
+			return true;
+		else
+			return false;
+	}
+
+	function getChartWidth($chart) {
+		var chartWidth = $chart.width();
+		var parentWidth = $chart.parent().width();
+		if (parentWidth !== 0 && chartWidth !== parentWidth) {
+			return parentWidth;
+		}
+
+		return chartWidth;
+	}
+
+	function redrawChart(server) {
+		if (!server) return;
+		if (server.activeChart === server.DOWNLOAD_SPEED_CHART) {
+			redrawSpeedChart(server);
+		} else {
+			redrawVolumeChart(server);
+		}
+	}
+
+	function chartMouseOver(server, env, serie, index, mouseAreaData) {
+		var data = server.getChartData();
+		if (data.mouseOverIndex > -1) {
+			var chart = $(
+				"#".concat(server.id, "_Chart-").concat(server.activeChart)
+			);
+			if (!chart) return;
+			var env = chart.data("elycharts_env");
+			if (env.mouseAreas[data.mouseOverIndex])
+				$.elycharts.mousemanager.onMouseOutArea(
+					env,
+					false,
+					data.mouseOverIndex,
+					env.mouseAreas[data.mouseOverIndex]
+				);
+		}
+
+		var tooltip = $(
+			"#".concat(server.id, "_Tooltip-").concat(server.activeChart)
+		);
+		if (!tooltip) return;
+		var data = server.getChartData();
+		var value = data.data[index];
+		if (value === undefined || value === null) {
+			value = "0.0";
+		} else {
+			value = value.toFixed(1);
+		}
+		var title = value + data.units;
+		tooltip.html('<span class="stat-size">' + title + "</span>");
+		tooltip.html(
+			data.labels[index] + ': <span class="stat-size">' + title + "</span>"
+		);
+	}
+
+	function chartMouseOver2(server, env, serie, index, mouseAreaData) {
+		var data = server.getChartData();
+		if (data.mouseOverIndex > -1) {
+			var chart = $(
+				"#".concat(server.id, "_Chart-").concat(server.activeChart)
+			);
+			if (!chart) return;
+			var env = chart.data("elycharts_env");
+			if (env.mouseAreas[data.mouseOverIndex])
+				$.elycharts.mousemanager.onMouseOutArea(
+					env,
+					false,
+					data.mouseOverIndex,
+					env.mouseAreas[data.mouseOverIndex]
+				);
+		}
+		data.mouseOverIndex = index;
+		var tooltip = $(
+			"#".concat(server.id, "_Tooltip-").concat(server.activeChart)
+		);
+
+		if (!tooltip) return;
+
+		var data = server.getChartData();
+		tooltip.html(
+			data.labels[index] +
+			': <span class="stat-size">' +
+			Util.formatSizeMB(data.dataMB[index], data.dataLo[index]) +
+			"</span>"
+		);
+	}
+
+	function chartMouseExit(server, env, serie, index, mouseAreaData) {
+		var tooltip = $(
+			"#".concat(server.id, "_Tooltip-").concat(server.activeChart)
+		);
+		if (!tooltip) return;
+		var data = server.getChartData();
+		data.mouseOverIndex = -1;
+		var value = data.data[data.curPoint];
+		if (value === undefined || value === null) {
+			value = "0.0";
+		} else {
+			value = value.toFixed(1);
+		}
+		var title = value + data.units;
+		tooltip.html('<span class="stat-size">' + title + "</span>");
+	}
+
+	function chartMouseExit2(server, env, serie, index, mouseAreaData) {
+		var tooltip = $(
+			"#".concat(server.id, "_Tooltip-").concat(server.activeChart)
+		);
+		if (!tooltip) return;
+		var data = server.getChartData();
+		if (data.sumMB === undefined || data.sumLo === undefined) return;
+
+		data.mouseOverIndex = -1;
+		var title = Util.formatSizeMB(data.sumMB, data.sumLo);
+		tooltip.html(
+			"Selected period:" + " " + '<span class="stat-size">' + title + "</span>"
+		);
+	}
+
+	function simulateMouseEvent(server, onExitFn) {
+		var data = server.getChartData();
+		if (data.mouseOverIndex > -1) {
+			var chart = $(
+				"#".concat(server.id, "_Chart-").concat(server.activeChart)
+			);
+			if (!chart) return;
+			var env = chart.data("elycharts_env");
+			if (env.mouseAreas[data.mouseOverIndex])
+				$.elycharts.mousemanager.onMouseOverArea(
+					env,
+					false,
+					data.mouseOverIndex,
+					env.mouseAreas[data.mouseOverIndex]
+				);
+		} else {
+			onExitFn(server);
+		}
+	}
+
+	function chooseRange(server, range) {
+		var data = server.getChartData();
+		updateRangeButtons(server, range, data.range);
+		data.range = range;
+		data.mouseOverIndex = -1;
+		redrawChart(server);
+	}
+
+	function updateRangeButtons(server, range, prevRange) {
+		var id = server.id;
+		var chartId = server.activeChart;
+		var prevTab = $(
+			"#"
+				.concat(id, "_Volume_")
+				.concat(prevRange, "-")
+				.concat(chartId, ", #")
+				.concat(id, "_Volume_")
+				.concat(prevRange, "2-")
+				.concat(chartId)
+		);
+		var newTab = $(
+			"#"
+				.concat(id, "_Volume_")
+				.concat(range, "-")
+				.concat(chartId, ", #")
+				.concat(id, "_Volume_")
+				.concat(range, "2-")
+				.concat(chartId)
+		);
+		prevTab.removeClass("btn-active");
+		newTab.addClass("btn-active");
+	}
+
+	function makeChart(serieData, curPointData, lineLabels, units, mousearea) {
+		return {
+			height: 250,
+			values: {
+				serie1: serieData,
+				serie2: curPointData
+			},
+			labels: lineLabels,
+			type: "line",
+			margins: [10, 15, 20, 70],
+			defaultSeries: {
+				rounded: 0.0,
+				fill: true,
+				plotProps: {
+					"stroke-width": 3.0
+				},
+				dot: true,
+				dotProps: {
+					stroke: "#FFF",
+					size: 3.0,
+					"stroke-width": 1.0,
+					fill: "#5AF"
+				},
+				highlight: {
+					scaleSpeed: 0,
+					scaleEasing: ">",
+					scale: 2.0
+				},
+				tooltip: {
+					active: false
+				},
+				color: "#5AF"
+			},
+			series: {
+				serie2: {
+					dotProps: {
+						stroke: "#F21860",
+						fill: "#F21860",
+						size: 3.5,
+						"stroke-width": 2.5
+					},
+					highlight: {
+						scale: 1.5
+					}
+				}
+			},
+			defaultAxis: {
+				labels: true,
+				labelsProps: {
+					"font-size": 13,
+					fill: "#3a87ad"
+				},
+				labelsDistance: 12
+			},
+			axis: {
+				l: {
+					labels: true,
+					suffix: units
+				}
+			},
+			features: {
+				grid: {
+					draw: [true, false],
+					forceBorder: true,
+					props: {
+						stroke: "#e0e0e0",
+						"stroke-width": 1
+					},
+					ticks: {
+						active: [true, false, false],
+						size: [6, 0],
+						props: {
+							stroke: "#e0e0e0"
+						}
+					}
+				},
+				mousearea: mousearea
+			}
+		};
+	}
+})(jQuery);

--- a/webui/statistics.js
+++ b/webui/statistics.js
@@ -483,35 +483,20 @@ var Statistics = new (function ($) {
 		)
 			.attr("data-optid", "S_Server" + server.id + "_Active")
 			.on("click", function (ev) {
-				$('#ConfigTabLink').click();
-				Options.loadConfig({
-					complete: function (config) {
-						Config.buildPage(config);
-						setTimeout(function () {
-							$("a[href$='#NEWS-SERVERS']").click();
-							Config.scrollToOption(ev, $btn);
-						}, 500);
-					},
-					configError: Config.loadConfigError,
-					serverTemplateError: Config.loadServerTemplateError
+				Options.setOnPageRenderedCallback(function() {
+					$("a[href$='#NEWS-SERVERS']").click();
 				});
+				$('#ConfigTabLink').click();
 			});
 
 		return $btn;
 	}
 
 	this.navigateToNewsServersConfiguration = function() {
-		$('#ConfigTabLink').click();
-		Options.loadConfig({
-			complete: function (config) {
-				Config.buildPage(config);
-				setTimeout(function () {
-					$("a[href$='#NEWS-SERVERS']").click();
-				}, 500);
-			},
-			configError: Config.loadConfigError,
-			serverTemplateError: Config.loadServerTemplateError
+		Options.setOnPageRenderedCallback(function() {
+			$("a[href$='#NEWS-SERVERS']").click();
 		});
+		$('#ConfigTabLink').click();
 	}
 
 	function makeToggleChartBtn(server) {

--- a/webui/statistics.js
+++ b/webui/statistics.js
@@ -24,8 +24,8 @@ var Statistics = new (function ($) {
 	var TEST_SERVER_HOST = "my.newsserver.com";
 
 	function Server() {
-		this.DOWNLOAD_SPEED_CHART = 0;
-		this.DOWMLOADED_VOLUME_CHART = 1;
+		this.SPEED_CHART = 0;
+		this.VOLUME_CHART = 1;
 
 		this.id = 0;
 		this.connections = 0;
@@ -41,17 +41,18 @@ var Statistics = new (function ($) {
 		this.totalSizeLo = 0;
 		this.successArticles = [];
 		this.failedArticles = [];
-		this.startDate = datetime.getFirstMonthDate();
-		this.endDate = datetime.getLastMonthDate();
+		this.startCustomDate = datetime.getFirstMonthDate();
+		this.endCustomDate = datetime.getLastMonthDate();
 		this.lastResetDate = null;
 		this.$details = null;
-		this.$downloadSpeedChart = null;
-		this.$downloadVolumeChart = null;
+		this.$speedChart = null;
+		this.$volumeChart = null;
 		this.$spinner = null;
 		this.$chartToggleBtn = null;
 		this.$speedChartBtn = null;
 		this.$volumeChartBtn = null;
-		this.activeChart = this.DOWNLOAD_SPEED_CHART;
+		this.activeChart = this.SPEED_CHART;
+
 		this.speedChartData = {
 			range: "MIN",
 			data: null,
@@ -75,15 +76,19 @@ var Statistics = new (function ($) {
 			mouseOverIndex: -1
 		};
 
+		this.makeId = function(suffix) {
+			return "Server_" + this.id + "_" + suffix;
+		}
+
 		this.getChartData = function () {
-			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
+			if (this.activeChart === this.SPEED_CHART) {
 				return this.speedChartData;
 			}
 			return this.volumeChartData;
 		};
 
 		this.setChartData = function (data) {
-			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
+			if (this.activeChart === this.SPEED_CHART) {
 				var mouseOverIndex = this.speedChartData.mouseOverIndex;
 				this.speedChartData = data;
 				this.speedChartData.mouseOverIndex = mouseOverIndex;
@@ -95,20 +100,20 @@ var Statistics = new (function ($) {
 		};
 
 		this.showChart = function () {
-			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
-				this.$downloadSpeedChart.show();
-				this.$downloadVolumeChart.hide();
+			if (this.activeChart === this.SPEED_CHART) {
+				this.$speedChart.show();
+				this.$volumeChart.hide();
 			} else {
-				this.$downloadSpeedChart.hide();
-				this.$downloadVolumeChart.show();
+				this.$speedChart.hide();
+				this.$volumeChart.show();
 			}
 		};
 
 		this.hideChart = function () {
-			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
-				this.$downloadSpeedChart.hide();
+			if (this.activeChart === this.SPEED_CHART) {
+				this.$speedChart.hide();
 			} else {
-				this.$downloadVolumeChart.hide();
+				this.$volumeChart.hide();
 			}
 		};
 
@@ -125,16 +130,16 @@ var Statistics = new (function ($) {
 		};
 
 		this.toggleChart = function () {
-			if (this.activeChart === this.DOWNLOAD_SPEED_CHART) {
-				this.activeChart = this.DOWMLOADED_VOLUME_CHART;
-				this.$downloadSpeedChart.hide();
-				this.$downloadVolumeChart.show();
+			if (this.activeChart === this.SPEED_CHART) {
+				this.activeChart = this.VOLUME_CHART;
+				this.$speedChart.hide();
+				this.$volumeChart.show();
 				this.$speedChartBtn.removeClass("btn-active");
 				this.$volumeChartBtn.addClass("btn-active");
 			} else {
-				this.activeChart = this.DOWNLOAD_SPEED_CHART;
-				this.$downloadSpeedChart.hide();
-				this.$downloadVolumeChart.show();
+				this.activeChart = this.SPEED_CHART;
+				this.$speedChart.hide();
+				this.$volumeChart.show();
 				this.$speedChartBtn.addClass("btn-active");
 				this.$volumeChartBtn.removeClass("btn-active");
 			}
@@ -246,26 +251,26 @@ var Statistics = new (function ($) {
 			.css("min-height", "300px");
 		server.$details = makeServerDetails(server);
 		server.$spinner = makeSpinner(server);
-		server.$downloadSpeedChart = makeDownloadSpeedChart(server);
-		server.$downloadVolumeChart = makeDownloadVolumeChart(server);
+		server.$speedChart = makeSpeedChart(server);
+		server.$volumeChart = makeVolumeChart(server);
 		server.$details.css("flex-grow", "1").css("flex-basis", "400px");
 		server.$spinner.css("flex-grow", "3").css("flex-basis", "600px");
-		server.$downloadSpeedChart
+		server.$speedChart
 			.css("flex-grow", "3")
 			.css("flex-basis", "600px")
 			.css("overflow", "hidden");
-		server.$downloadVolumeChart
+		server.$volumeChart
 			.css("flex-grow", "3")
 			.css("flex-basis", "600px")
 			.css("overflow", "hidden");
 		server.$details.hide();
-		server.$downloadSpeedChart.hide();
-		server.$downloadVolumeChart.hide();
+		server.$speedChart.hide();
+		server.$volumeChart.hide();
 		$container.append(
 			server.$details,
 			server.$spinner,
-			server.$downloadSpeedChart,
-			server.$downloadVolumeChart
+			server.$speedChart,
+			server.$volumeChart
 		);
 		$StatisticsTable.append($container, "<hr>");
 	}
@@ -536,26 +541,20 @@ var Statistics = new (function ($) {
 		return $container;
 	}
 
-	function makeDownloadSpeedChart(server) {
+	function makeSpeedChart(server) {
 		var $container = $("<div>", {
 			class: "statistics"
 		});
 		var $title = makeToggleChartBtn(server);
 		var $toolbar = $("<div>", {
 			class: "btn-toolbar form-inline section-toolbar",
-			id: "".concat(server.id, "_Toolbar-").concat(server.DOWNLOAD_SPEED_CHART)
 		}).css("margin-bottom", "0");
 		var $timeBlockTop = $("<div>", {
 			class: "btn-group phone-hide",
-			id: ""
-				.concat(server.id, "_TimeBlockTop-")
-				.concat(server.DOWNLOAD_SPEED_CHART)
 		});
 		var $minButton = $("<button>", {
 			class: "btn btn-default btn-active volume-range",
-			id: ""
-				.concat(server.id, "_Volume_MIN-")
-				.concat(server.DOWNLOAD_SPEED_CHART),
+			id: server.makeId(server.SPEED_CHART + "_MIN"),
 			title: "Show last 60 seconds",
 			text: "60 Seconds"
 		}).on("click", function () {
@@ -563,9 +562,7 @@ var Statistics = new (function ($) {
 		});
 		var $5minButton = $("<button>", {
 			class: "btn btn-default volume-range",
-			id: ""
-				.concat(server.id, "_Volume_5MIN-")
-				.concat(server.DOWNLOAD_SPEED_CHART),
+			id: server.makeId(server.SPEED_CHART + "_5MIN"),
 			title: "Show last 5 minutes",
 			text: "5 Minutes"
 		}).on("click", function () {
@@ -573,10 +570,8 @@ var Statistics = new (function ($) {
 		});
 		var $hourButton = $("<button>", {
 			class: "btn btn-default volume-range",
-			id: ""
-				.concat(server.id, "_Volume_HOUR-")
-				.concat(server.DOWNLOAD_SPEED_CHART),
-			title: "Show 60 minutes",
+			id: server.makeId(server.SPEED_CHART + "_HOUR"),
+			title: "Show last 60 minutes",
 			text: "60 Minutes"
 		}).on("click", function () {
 			chooseRange(server, "HOUR");
@@ -588,9 +583,7 @@ var Statistics = new (function ($) {
 		}).append(
 			$("<button>", {
 				class: "btn btn-default btn-active volume-range",
-				id: ""
-					.concat(server.id, "_Volume_MIN2-")
-					.concat(server.DOWNLOAD_SPEED_CHART),
+				id: server.makeId(server.SPEED_CHART + "_MIN2"),
 				title: "Show last 60 seconds",
 				text: "60 s"
 			}).on("click", function () {
@@ -598,9 +591,7 @@ var Statistics = new (function ($) {
 			}),
 			$("<button>", {
 				class: "btn btn-default volume-range",
-				id: ""
-					.concat(server.id, "_Volume_5MIN2-")
-					.concat(server.DOWNLOAD_SPEED_CHART),
+				id: server.makeId(server.SPEED_CHART + "_5MIN"),
 				title: "Show last 5 minutes",
 				text: "5 m"
 			}).on("click", function () {
@@ -608,9 +599,7 @@ var Statistics = new (function ($) {
 			}),
 			$("<button>", {
 				class: "btn btn-default volume-range",
-				id: ""
-					.concat(server.id, "_Volume_HOUR2-")
-					.concat(server.DOWNLOAD_SPEED_CHART),
+				id: server.makeId(server.SPEED_CHART + "_HOUR2"),
 				title: "Show last 60 minutes",
 				text: "60 m"
 			}).on("click", function () {
@@ -620,7 +609,7 @@ var Statistics = new (function ($) {
 		$toolbar.append($phoneButtons);
 		var $tooltip = $("<div>", {
 			class: "statistics__tooltip",
-			id: "".concat(server.id, "_Tooltip-").concat(server.DOWNLOAD_SPEED_CHART),
+			id: server.makeId(server.SPEED_CHART + "_TOOLTIP"),
 			text: "--"
 		});
 		var $chartBlock = $("<div>", {
@@ -629,9 +618,7 @@ var Statistics = new (function ($) {
 
 		var $chart = $("<div>", {
 			class: "statistics__chart",
-			id: ""
-				.concat(server.id, "_Chart-")
-				.concat(server.DOWNLOAD_SPEED_CHART)
+			id: server.makeId(server.SPEED_CHART + "_CHART"),
 		});
 
 		$chartBlock.append($chart);
@@ -639,48 +626,118 @@ var Statistics = new (function ($) {
 		return $container;
 	}
 
-	function makeDownloadVolumeChart(server) {
+	function makeVolumeChart(server) {
 		var $container = $("<div>", {
 			class: "statistics"
 		});
 		var $title = makeToggleChartBtn(server);
 		var $toolbar = $("<div>", {
 			class: "btn-toolbar form-inline section-toolbar",
-			id: ""
-				.concat(server.id, "_Toolbar-")
-				.concat(server.DOWMLOADED_VOLUME_CHART)
-		}).css("margin-bottom", "5px");
+		})
+			.css("margin-bottom", "5px")
+			.css("display", "flex")
+			.css("align-items", "center")
+			.css("flex-wrap", "wrap");
+		var $timeBlockTop = $("<div>", {
+			class: "btn-group phone-hide",
+		});
+		var $dayButton = $("<button>", {
+			class: "btn btn-default volume-range",
+			id: server.makeId(server.VOLUME_CHART + "_DAY"),
+			title: "Show day",
+			text: "Day"
+		}).on("click", function () {
+			chooseRange(server, "DAY");
+			redrawVolumeChart(server);
+		});
+		var $weekButton = $("<button>", {
+			class: "btn btn-default volume-range",
+			id: server.makeId(server.VOLUME_CHART + "_WEEK"),
+			title: "Show week",
+			text: "Week"
+		}).on("click", function () {
+			chooseRange(server, "WEEK");
+			redrawVolumeChart(server);
+		});
+		var $monthButton = $("<button>", {
+			class: "btn btn-default btn-active volume-range",
+			id: server.makeId(server.VOLUME_CHART + "_MONTH"),
+			title: "Show month",
+			text: "Month"
+		}).on("click", function () {
+			chooseRange(server, "MONTH");
+			redrawVolumeChart(server);
+		});
+		$timeBlockTop.append($dayButton, $weekButton, $monthButton);
+		$toolbar.append($timeBlockTop);
+		var $phoneButtons = $("<div>", {
+			class: "btn-group phone-only inline"
+		}).append(
+			$("<button>", {
+				class: "btn btn-default volume-range",
+				id: server.makeId(server.VOLUME_CHART + "_DAY2"),
+				title: "Show day",
+				text: "D"
+			}).on("click", function () {
+				chooseRange(server, "DAY");
+				redrawVolumeChart(server);
+			}),
+			$("<button>", {
+				class: "btn btn-default volume-range",
+				id: server.makeId(server.VOLUME_CHART + "_WEEK2"),
+				title: "Show week",
+				text: "W"
+			}).on("click", function () {
+				chooseRange(server, "WEEK");
+				redrawVolumeChart(server);
+			}),
+			$("<button>", {
+				class: "btn btn-default btn-active volume-range",
+				id: server.makeId(server.VOLUME_CHART + "_MONTH2"),
+				title: "Show month",
+				text: "M"
+			}).on("click", function () {
+				chooseRange(server, "MONTH");
+				redrawVolumeChart(server);
+			})
+		);
+		$toolbar.append($phoneButtons);
+
+		var $datePicker = $("<div>");
 		var $startDateInput = $("<input>", {
-			type: "date"
+			type: "date",
 		});
 		var $sep = $("<span> - </span>");
 		var $endDateInput = $("<input>", {
-			type: "date"
+			type: "date",
 		});
-		var startDateStr = datetime.formatDateForInput(server.startDate);
-		var endDateStr = datetime.formatDateForInput(server.endDate);
+		var startDateStr = datetime.formatDateForInput(server.startCustomDate);
+		var endDateStr = datetime.formatDateForInput(server.endCustomDate);
+
 		$startDateInput.val(startDateStr);
 		$endDateInput.val(endDateStr);
 		$startDateInput.attr("max", endDateStr);
 		$endDateInput.attr("min", startDateStr);
 		$startDateInput.on("change", function () {
 			var startDate = $(this).val();
-			server.startDate = new Date(startDate);
+			chooseRange(server, "CUSTOM");
+			server.startCustomDate = new Date(startDate);
 			$endDateInput.attr("min", datetime.formatDateForInput(startDate));
 			redrawVolumeChart(server);
 		});
 		$endDateInput.on("change", function () {
 			var endDate = $(this).val();
-			server.endDate = new Date(endDate);
+			chooseRange(server, "CUSTOM");
+			server.endCustomDate = new Date(endDate);
 			$startDateInput.attr("max", datetime.formatDateForInput(endDate));
 			redrawVolumeChart(server);
 		});
-		$toolbar.append($startDateInput, $sep, $endDateInput);
+
+		$datePicker.append($startDateInput, $sep, $endDateInput);
+		$toolbar.append($datePicker);
 		var $tooltip = $("<div>", {
 			class: "statistics__tooltip",
-			id: ""
-				.concat(server.id, "_Tooltip-")
-				.concat(server.DOWMLOADED_VOLUME_CHART),
+			id: server.makeId(server.VOLUME_CHART + "_TOOLTIP"),
 			text: "--"
 		});
 
@@ -690,9 +747,7 @@ var Statistics = new (function ($) {
 
 		var $chart = $("<div>", {
 			class: "statistics__chart",
-			id: ""
-				.concat(server.id, "_Chart-")
-				.concat(server.DOWMLOADED_VOLUME_CHART)
+			id: server.makeId(server.VOLUME_CHART + "_CHART"),
 		});
 
 		$chartBlock.append($chart);
@@ -856,7 +911,7 @@ var Statistics = new (function ($) {
 		server.showChart();
 		server.hideSpinner();
 
-		var $chart = $("#".concat(server.id, "_Chart-").concat(server.activeChart));
+		var $chart = $("#" + server.makeId(server.SPEED_CHART + "_CHART"));
 		if (!$chart) return;
 		if (!isParentContainerRendered($chart)) {
 			server.hideChart();
@@ -871,24 +926,26 @@ var Statistics = new (function ($) {
 				makeChart(serieData, curPointData, lineLabels, units, {
 					type: "axis",
 					onMouseOver: function onMouseOver(env, serie, index, mouseAreaData) {
-						chartMouseOver(server, env, serie, index, mouseAreaData);
+						speedChartMouseOver(server, env, serie, index, mouseAreaData);
 					},
 					onMouseExit: function onMouseExit(env, serie, index, mouseAreaData) {
-						chartMouseExit(server, env, serie, index, mouseAreaData);
+						speedChartMouseExit(server, env, serie, index, mouseAreaData);
 					},
 					onMouseOut: function onMouseOut(env, serie, index, mouseAreaData) {
-						chartMouseExit(server, env, serie, index, mouseAreaData);
+						speedChartMouseExit(server, env, serie, index, mouseAreaData);
 					}
 				})
 			);
 
-		simulateMouseEvent(server, chartMouseExit);
+		simulateMouseEvent(server, speedChartMouseExit);
 	}
 
 	function redrawVolumeChart(server) {
+		var serverData = server.getChartData();
 		var serverNo = server.id;
-		var startDate = server.startDate;
-		var endDate = server.endDate;
+		var startCustomDate = server.startCustomDate;
+		var endCustomDate = server.endCustomDate;
+		var curRange = serverData.range;
 		var lineLabels = [];
 		var dataLabels = [];
 		var chartDataTB = [];
@@ -901,7 +958,6 @@ var Statistics = new (function ($) {
 		var sumLo = 0;
 		var maxSizeMB = 0;
 		var maxSizeLo = 0;
-		var dates = datetime.getDateRange(startDate, endDate);
 
 		function addData(bytes, dataLab, lineLab) {
 			dataLabels.push(dataLab);
@@ -929,27 +985,60 @@ var Statistics = new (function ($) {
 			sumLo += bytes.SizeLo;
 		}
 
-		function drawGraph() {
+		function drawGraph(dates) {
 			var bytesPerDays = servervolumes[serverNo].BytesPerDays;
 			var firstDay = servervolumes[serverNo].FirstDay;
 			var daySlot = servervolumes[serverNo].DaySlot;
+			var currDaySlot = Util.getDaySinceUnixEpoch(datetime.getCurrentDay());
 			for (var i = 0; i < dates.length; ++i) {
 				var date = dates[i];
 				var label = date.toDateString();
 				var slot = Util.getDaySinceUnixEpoch(date);
 				if (slot >= firstDay) {
 					var idx = slot - firstDay;
-					if (idx <= daySlot)
+					if (idx <= daySlot) {
 						addData(bytesPerDays[idx], label, "");
-					else
+					}
+					else {
 						addData({ SizeMB: 0, SizeLo: 0 }, label, "");
+					}
 				} else {
 					addData({ SizeMB: 0, SizeLo: 0 }, label, "");
+				}
+
+				if (currDaySlot == slot) {
+					curPoint = i;
 				}
 			}
 		}
 
-		drawGraph();
+		function drawDayGraph() {
+			var bytesPerHours = servervolumes[serverNo].BytesPerHours;
+			for (var i = 0; i < 24; ++i) {
+				addData(bytesPerHours[i], i + "h", "");
+			}
+			curPoint = servervolumes[serverNo].HourSlot;
+		}
+
+		if (curRange == "DAY") {
+			drawDayGraph();
+		}
+		else if (curRange == "WEEK") {
+			var dates = datetime.getWeekRange();
+			drawGraph(dates);
+
+		}
+		else if (curRange == "MONTH") {
+			var dates = datetime.getMonthRange();
+			drawGraph(dates);
+		}
+		else if (curRange == "CUSTOM") {
+			var dates = datetime.getDateRange(startCustomDate, endCustomDate);
+			drawGraph(dates);
+		}
+		else {
+			return;
+		}
 
 		var serieData =
 			maxSizeMB > 1024 * 1024
@@ -985,6 +1074,7 @@ var Statistics = new (function ($) {
 			data: serieData,
 			dataMB: chartDataMB,
 			dataLo: chartDataB,
+			range: curRange,
 			units: units,
 			curPoint: curPoint,
 			labels: dataLabels,
@@ -995,7 +1085,7 @@ var Statistics = new (function ($) {
 		server.showChart();
 		server.hideSpinner();
 
-		var $chart = $("#".concat(server.id, "_Chart-").concat(server.activeChart));
+		var $chart = $("#" + server.makeId(server.VOLUME_CHART + "_CHART"));
 		if (!$chart) return;
 		if (!isParentContainerRendered($chart)) {
 			server.hideChart();
@@ -1010,18 +1100,18 @@ var Statistics = new (function ($) {
 				makeChart(serieData, curPointData, lineLabels, units, {
 					type: "axis",
 					onMouseOver: function onMouseOver(env, serie, index, mouseAreaData) {
-						chartMouseOver2(server, env, serie, index, mouseAreaData);
+						volumeChartMouseOver(server, env, serie, index, mouseAreaData);
 					},
 					onMouseExit: function onMouseExit(env, serie, index, mouseAreaData) {
-						chartMouseExit2(server, env, serie, index, mouseAreaData);
+						volumeChartMouseExit(server, env, serie, index, mouseAreaData);
 					},
 					onMouseOut: function onMouseOut(env, serie, index, mouseAreaData) {
-						chartMouseExit2(server, env, serie, index, mouseAreaData);
+						volumeChartMouseExit(server, env, serie, index, mouseAreaData);
 					}
 				})
 			);
 
-		simulateMouseEvent(server, chartMouseExit2);
+		simulateMouseEvent(server, volumeChartMouseExit);
 	}
 
 	function isParentContainerRendered($chart) {
@@ -1044,21 +1134,20 @@ var Statistics = new (function ($) {
 
 	function redrawChart(server) {
 		if (!server) return;
-		if (server.activeChart === server.DOWNLOAD_SPEED_CHART) {
+		if (server.activeChart === server.SPEED_CHART) {
 			redrawSpeedChart(server);
 		} else {
 			redrawVolumeChart(server);
 		}
 	}
 
-	function chartMouseOver(server, env, serie, index, mouseAreaData) {
+	function speedChartMouseOver(server, env, serie, index, mouseAreaData) {
 		var data = server.getChartData();
 		if (data.mouseOverIndex > -1) {
-			var chart = $(
-				"#".concat(server.id, "_Chart-").concat(server.activeChart)
-			);
-			if (!chart) return;
-			var env = chart.data("elycharts_env");
+			var $chart = $("#" + server.makeId(server.SPEED_CHART + "_CHART"));
+			if (!$chart) return;
+			var env = $chart.data("elycharts_env");
+			if (!env) return;
 			if (env.mouseAreas[data.mouseOverIndex])
 				$.elycharts.mousemanager.onMouseOutArea(
 					env,
@@ -1068,10 +1157,8 @@ var Statistics = new (function ($) {
 				);
 		}
 
-		var tooltip = $(
-			"#".concat(server.id, "_Tooltip-").concat(server.activeChart)
-		);
-		if (!tooltip) return;
+		var $tooltip = $("#" + server.makeId(server.SPEED_CHART + "_TOOLTIP"));
+		if (!$tooltip) return;
 		var data = server.getChartData();
 		var value = data.data[index];
 		if (value === undefined || value === null) {
@@ -1080,20 +1167,20 @@ var Statistics = new (function ($) {
 			value = value.toFixed(1);
 		}
 		var title = value + data.units;
-		tooltip.html('<span class="stat-size">' + title + "</span>");
-		tooltip.html(
+		$tooltip.html('<span class="stat-size">' + title + "</span>");
+		$tooltip.html(
 			data.labels[index] + ': <span class="stat-size">' + title + "</span>"
 		);
 	}
 
-	function chartMouseOver2(server, env, serie, index, mouseAreaData) {
+	function volumeChartMouseOver(server, env, serie, index, mouseAreaData) {
 		var data = server.getChartData();
 		if (data.mouseOverIndex > -1) {
-			var chart = $(
-				"#".concat(server.id, "_Chart-").concat(server.activeChart)
-			);
-			if (!chart) return;
-			var env = chart.data("elycharts_env");
+			var $chart = $("#" + server.makeId(server.VOLUME_CHART + "_CHART"));
+			if (!$chart) return;
+			var env = $chart.data("elycharts_env");
+			if (!env) return;
+
 			if (env.mouseAreas[data.mouseOverIndex])
 				$.elycharts.mousemanager.onMouseOutArea(
 					env,
@@ -1103,14 +1190,12 @@ var Statistics = new (function ($) {
 				);
 		}
 		data.mouseOverIndex = index;
-		var tooltip = $(
-			"#".concat(server.id, "_Tooltip-").concat(server.activeChart)
-		);
+		var $tooltip = $("#" + server.makeId(server.activeChart + "_TOOLTIP"));
 
-		if (!tooltip) return;
+		if (!$tooltip) return;
 
 		var data = server.getChartData();
-		tooltip.html(
+		$tooltip.html(
 			data.labels[index] +
 			': <span class="stat-size">' +
 			Util.formatSizeMB(data.dataMB[index], data.dataLo[index]) +
@@ -1118,11 +1203,9 @@ var Statistics = new (function ($) {
 		);
 	}
 
-	function chartMouseExit(server, env, serie, index, mouseAreaData) {
-		var tooltip = $(
-			"#".concat(server.id, "_Tooltip-").concat(server.activeChart)
-		);
-		if (!tooltip) return;
+	function speedChartMouseExit(server, env, serie, index, mouseAreaData) {
+		var $tooltip = $("#" + server.makeId(server.SPEED_CHART + "_TOOLTIP"));
+		if (!$tooltip) return;
 		var data = server.getChartData();
 		data.mouseOverIndex = -1;
 		var value = data.data[data.curPoint];
@@ -1132,20 +1215,18 @@ var Statistics = new (function ($) {
 			value = value.toFixed(1);
 		}
 		var title = value + data.units;
-		tooltip.html('<span class="stat-size">' + title + "</span>");
+		$tooltip.html('<span class="stat-size">' + title + "</span>");
 	}
 
-	function chartMouseExit2(server, env, serie, index, mouseAreaData) {
-		var tooltip = $(
-			"#".concat(server.id, "_Tooltip-").concat(server.activeChart)
-		);
-		if (!tooltip) return;
+	function volumeChartMouseExit(server, env, serie, index, mouseAreaData) {
+		var $tooltip = $("#" + server.makeId(server.VOLUME_CHART + "_TOOLTIP"));
+		if (!$tooltip) return;
 		var data = server.getChartData();
 		if (data.sumMB === undefined || data.sumLo === undefined) return;
 
 		data.mouseOverIndex = -1;
 		var title = Util.formatSizeMB(data.sumMB, data.sumLo);
-		tooltip.html(
+		$tooltip.html(
 			"Selected period:" + " " + '<span class="stat-size">' + title + "</span>"
 		);
 	}
@@ -1153,11 +1234,11 @@ var Statistics = new (function ($) {
 	function simulateMouseEvent(server, onExitFn) {
 		var data = server.getChartData();
 		if (data.mouseOverIndex > -1) {
-			var chart = $(
-				"#".concat(server.id, "_Chart-").concat(server.activeChart)
-			);
-			if (!chart) return;
-			var env = chart.data("elycharts_env");
+			var $chart = $("#" + server.makeId(server.activeChart + "_CHART"));
+			if (!$chart) return;
+			var env = $chart.data("elycharts_env");
+			if (!env) return;
+
 			if (env.mouseAreas[data.mouseOverIndex])
 				$.elycharts.mousemanager.onMouseOverArea(
 					env,
@@ -1179,25 +1260,14 @@ var Statistics = new (function ($) {
 	}
 
 	function updateRangeButtons(server, range, prevRange) {
-		var id = server.id;
 		var chartId = server.activeChart;
 		var prevTab = $(
-			"#"
-				.concat(id, "_Volume_")
-				.concat(prevRange, "-")
-				.concat(chartId, ", #")
-				.concat(id, "_Volume_")
-				.concat(prevRange, "2-")
-				.concat(chartId)
+			"#" + server.makeId(chartId + "_" + prevRange) + "," +
+			"#" + server.makeId(chartId + "_" + prevRange) + "2"
 		);
 		var newTab = $(
-			"#"
-				.concat(id, "_Volume_")
-				.concat(range, "-")
-				.concat(chartId, ", #")
-				.concat(id, "_Volume_")
-				.concat(range, "2-")
-				.concat(chartId)
+			"#" + server.makeId(chartId + "_" + range) + "," +
+			"#" + server.makeId(chartId + "_" + range) + "2"
 		);
 		prevTab.removeClass("btn-active");
 		newTab.addClass("btn-active");

--- a/webui/status.js
+++ b/webui/status.js
@@ -542,7 +542,6 @@ var StatDialog = (new function($)
 	var $StatDialog_DataSpeedLimit;
 	var $StatDialog_ArticleCache;
 	var $StatDialog_QueueScripts;
-	var $StatDialog_ChartBlock;
 	var $StatRangeDialog;
 	var $StatRangeDialog_PeriodInput;
 	var $StatDialog_Tooltip;
@@ -590,7 +589,6 @@ var StatDialog = (new function($)
 		$StatDialog_DataSpeedLimit = $('#StatDialog_DataSpeedLimit');
 		$StatDialog_ArticleCache = $('#StatDialog_ArticleCache');
 		$StatDialog_QueueScripts = $('#StatDialog_QueueScripts');
-		$StatDialog_ChartBlock = $('#StatDialog_ChartBlock');
 		$StatRangeDialog = $('#StatRangeDialog');
 		$StatRangeDialog_PeriodInput = $('#StatRangeDialog_PeriodInput');
 		$StatDialog_Tooltip = $('#StatDialog_Tooltip');
@@ -610,7 +608,6 @@ var StatDialog = (new function($)
 			lastTab = null;
 			servervolumes = null;
 			prevServervolumes = null;
-			$StatDialog_ChartBlock.empty();
 			visible = false;
 		});
 
@@ -1032,15 +1029,16 @@ var StatDialog = (new function($)
 			dataLabels: dataLabels
 		};
 
-		$StatDialog_ChartBlock.empty();
-		$StatDialog_ChartBlock.html('<div id="StatDialog_Chart"></div>');
-		$('#StatDialog_Chart').chart({
+		var $chart = $("#StatDialog_Chart");
+		if (!$chart) return;
+
+		$chart.chart('clear').chart({
 			values: { serie1 : serieData, serie2: curPointData },
 			labels: lineLabels,
 			type: 'line',
 			margins: [10, 15, 20, 60],
 			defaultSeries: {
-				rounded: 0.5,
+				rounded: 0.0,
 				fill: true,
 				plotProps: {
 					'stroke-width': 3.0

--- a/webui/style.css
+++ b/webui/style.css
@@ -51,6 +51,14 @@ body {
 	padding-right: 0;
 }
 
+.txt-success {
+	color: #5bb75b;
+}
+
+.txt-important {
+	color: #b94a48;
+}
+
 .flex-center {
 	display: flex;
 	align-items: center;
@@ -89,13 +97,22 @@ body {
 	font-style: italic;
 }
 
+.statistics__spinner-container,
 .system-info__spinner-container {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+}
+
+.system-info__spinner-container {
 	height: 60vh;
 }
 
+.statistics__spinner-container {
+	height: 90vh;
+}
+
+.statistics__spinner,
 .system-info__spinner {
 	font-size: 128px;
 }
@@ -1448,10 +1465,46 @@ ul.help > li {
 	margin-top: 0;
 }
 
-/*** STATISTICS DIALOG */
+/*** STATISTICS */
 
-#StatisticsTab table {
+.statistics__no-statistics {
+	width: 100%;
+	text-align: center;
+}
+
+.statistics__no-servers-container {
+	display: inline-block;
+	vertical-align: middle;
+	text-align: left;
+	width: auto;
+	max-width: 500px;
+	padding: 15px;
+	border: 1px solid #ccc;
+	border-radius: 5px;
+	margin: 0 auto;
+}
+
+.text-large {
+	font-size: large;
+}
+
+.text-larger {
+	font-size: larger;
+}
+
+#StatisticsTab {
+	max-width: 1280px;
+	padding: 5px;
+	margin: auto;
+}
+
+.statistics__server-details {
+	height: 100%;
 	width: 350px;
+}
+
+.server-details__table {
+	margin-bottom: 15px;
 }
 
 #StatDialog_VolumesBlock {
@@ -1465,18 +1518,38 @@ ul.help > li {
 	margin-bottom: 15px;
 }
 
+.statistics__chartblock {
+	height: 250px;
+	margin-bottom: 10px;
+}
+
 #StatDialog_Chart {
 	height: 100%;
 	width: 670px;
 	width: 100%;
 }
 
-#StatDialog_Tooltip {
+.statistics__chart {
+	width: 100%;
+	height: 100%;
+}
+
+#StatDialog_Tooltip, .statistics__tooltip {
 	float: right;
 	margin-top: -3px;
 	margin-bottom: -6px;
 	padding-right: 15px;
 	font-style: italic;
+}
+
+.statistics__chart-block-spinner {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.statistics__chart-block-spinner .spinner {
+	font-size: 100px;
 }
 
 .stat-size {
@@ -1487,16 +1560,17 @@ ul.help > li {
 	font-weight: bold;
 }
 
-#StatDialog_CountersBlock {
+#StatDialog_CountersBlock, .statistics__counter-block {
 	padding-right: 20px;
 }
 
-#StatDialog_Counters {
+#StatDialog_Counters, .statistics__counters {
 	margin-top: 8px;
 	text-align: center;
 }
 
-#StatDialog_Counters .span3 {
+#StatDialog_Counters .span3,
+.statistics__counters .span3 {
 	min-height: 0;
 }
 
@@ -2379,6 +2453,10 @@ body.phone,
 
 .phone #StatDialog hr {
 	margin-top: 30px;
+}
+
+input[type="date"] {
+	width: auto;
 }
 
 /* MEDIA SMALL SCREENS */

--- a/webui/style.css
+++ b/webui/style.css
@@ -1519,9 +1519,14 @@ ul.help > li {
 }
 
 .statistics__chartblock {
-	height: 250px;
 	margin-bottom: 10px;
 }
+
+.statistics__chartblock,
+.statistics__chart-block-spinner .spinner {
+	height: 250px;
+}
+
 
 #StatDialog_Chart {
 	height: 100%;
@@ -1550,6 +1555,7 @@ ul.help > li {
 
 .statistics__chart-block-spinner .spinner {
 	font-size: 100px;
+	height: 250px;
 }
 
 .stat-size {

--- a/webui/system-info.js
+++ b/webui/system-info.js
@@ -840,7 +840,7 @@ var SystemInfo = (new function($)
 
 		speedContainer.attr('title', Util.formatSpeedWithCustomUnit(bytesPerSec, 'Bytes') 
 		+ '\nApprox. ' 
-		+  '≈' + Util.formatSpeedWithCustomUnit(bitsPerSec, 'bits'));
+		+  '≈' + Util.formatSpeedWithCustomUnit(bitsPerSec, 'bit'));
 
 		return speedContainer;
 	}

--- a/webui/util.js
+++ b/webui/util.js
@@ -2,7 +2,7 @@
  * This file is part of nzbget. See <https://nzbget.com>.
  *
  * Copyright (C) 2012-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- * Copyright (C) 2024 Denis <denis@nzbget.com>
+ * Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,6 +30,12 @@
 var Util = (new function($)
 {
 	'use strict';
+
+	this.emptyObject = function(obj) {
+		if (!obj) return true;
+		if (Object.keys(obj).length == 0) return true;
+		return false;
+	}
 
 	this.saveToLocalStorage = function(key, val)
 	{
@@ -107,6 +113,23 @@ var Util = (new function($)
 	this.isNumber = function(value)
 	{
 		return typeof value === 'number';
+	}
+
+	this.getDaySinceUnixEpoch = function (date) 
+	{
+		var utcDate = new Date(Date.UTC(
+			date.getFullYear(),
+			date.getMonth(),
+			date.getDate()
+		));
+
+		// Get the number of milliseconds since the Unix epoch (UTC).
+		var utcTime = utcDate.getTime();
+
+		// Divide by the number of milliseconds in a day to get the number of days.
+		var daysSinceEpoch = Math.floor(utcTime / (1000 * 60 * 60 * 24));
+
+		return daysSinceEpoch;
 	}
 
 	this.formatDateTime = function(unixTime)
@@ -264,6 +287,31 @@ var Util = (new function($)
 		else
 		{
 			return this.round0(diff / (60))  +'&nbsp;m';
+		}
+	}
+
+	this.formatNumber = function (num) 
+	{
+		var formattedNum;
+
+		if (num >= 1000000000) 
+		{
+			formattedNum = (num / 1000000000).toFixed(0);
+			return formattedNum + 'B';
+		}
+		else if (num >= 1000000) 
+		{
+			formattedNum = (num / 1000000).toFixed(0);
+			return formattedNum + 'M';
+		}
+		else if (num >= 1000) 
+		{
+			formattedNum = (num / 1000).toFixed(0);
+			return formattedNum + 'K';
+		}
+		else 
+		{
+			return num.toFixed(0);
 		}
 	}
 


### PR DESCRIPTION
## Description

- added a new "Statistics" page to display completion and download volume analytics for news-servers.
- the API method "resetservervolumes" now allows for selective resetting of counters. Arguments:
  - **ServerId** `(int)` - Server ID to reset.
  - **Counter** `(string)` - Specifies which counter to reset. The behavior depends on the value of this argument:
    - **"CUSTOM"** (case-sensitive) - Resets only the custom counter associated with the server. Use this option to clear custom statistics while preserving overall download volume data.
    - **""** (empty string) - Resets all counters associated with the server, including the overall download volume and any custom counters.
- the API method "servervolumes" now returns 2 additional properties:
    - **CountersResetTime** `(int)` - Date/time of the last reset of all counters (time is in C/Unix format).
    - **ArticlesPerDays** `(struct[])` - Per-day amount of failed and success articles since program installation. Contains an array of structs with following fields:
        - **Failed** `(int)` - Amount of failed articles.
        - **Success** `(int)` - Amount of success articles.
  
## Testing

- Windows 7 / Firefox 115
- Windows 11 / Chrome 135
- macOS 13 / Chrome 135, Safari 18