### PR TITLE
Fix: direct unpack failures when processing non-archive files

### DIFF
--- a/daemon/postprocess/DirectUnpack.cpp
+++ b/daemon/postprocess/DirectUnpack.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -394,7 +395,7 @@ void DirectUnpack::AddMessage(Message::EKind kind, const char* text)
 
 void DirectUnpack::Stop(DownloadQueue* downloadQueue, NzbInfo* nzbInfo)
 {
-	debug("Stopping direct unpack for %s", *m_infoName);
+	debug("Stopping %s", *m_infoName);
 	if (m_processed)
 	{
 		if (nzbInfo)
@@ -458,7 +459,7 @@ void DirectUnpack::FileDownloaded(DownloadQueue* downloadQueue, FileInfo* fileIn
 {
 	debug("FileDownloaded for %s/%s", fileInfo->GetNzbInfo()->GetName(), fileInfo->GetFilename());
 
-	if (fileInfo->GetNzbInfo()->GetFailedArticles() > 0)
+	if (!CanProceed(fileInfo))
 	{
 		Stop(downloadQueue, fileInfo->GetNzbInfo());
 		return;
@@ -475,6 +476,14 @@ void DirectUnpack::FileDownloaded(DownloadQueue* downloadQueue, FileInfo* fileIn
 	{
 		m_archives.emplace_back(fileInfo->GetFilename());
 	}
+}
+
+bool DirectUnpack::CanProceed(FileInfo* fileInfo) const
+{
+	if (!IsArchiveFilename(fileInfo->GetFilename())) 
+		return true;
+
+	return fileInfo->GetFailedArticles() == 0;
 }
 
 void DirectUnpack::NzbDownloaded(DownloadQueue* downloadQueue, NzbInfo* nzbInfo)

--- a/daemon/postprocess/DirectUnpack.h
+++ b/daemon/postprocess/DirectUnpack.h
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
 #include "DownloadInfo.h"
 #include "ScriptController.h"
 
-class DirectUnpack : public Thread, public ScriptController
+class DirectUnpack final : public Thread, public ScriptController
 {
 public:
 	virtual void Run();
@@ -49,6 +49,14 @@ private:
 	public:
 		bool Exists(const char* param) { return std::find(begin(), end(), param) != end(); }
 	};
+
+	/**
+	 *  @brief Checks if Direct unpack can proceed.
+	 *
+	 *  @return True if direct unpack is permitted (either the file is not an
+ 	 *          archive or the archive contains no failed articles), false otherwise.
+	 */
+	bool CanProceed(FileInfo* fileInfo) const;
 
 	typedef std::deque<CString> ArchiveList;
 

--- a/daemon/util/ScriptController.cpp
+++ b/daemon/util/ScriptController.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -85,6 +86,9 @@ void EnvironmentStrings::Clear()
 
 void EnvironmentStrings::InitFromCurrentProcess()
 {
+	if (!g_EnvironmentVariables)
+		return;
+
 	for (int i = 0; (*g_EnvironmentVariables)[i]; i++)
 	{
 		char* var = (*g_EnvironmentVariables)[i];

--- a/tests/postprocess/CMakeLists.txt
+++ b/tests/postprocess/CMakeLists.txt
@@ -1,12 +1,12 @@
 set(PostprocessTestsSrc
 	main.cpp
-	# DirectUnpackTest.cpp
+	DirectUnpackTest.cpp
 	# DupeMatcherTest.cpp
 	RarReaderTest.cpp
 	RarRenamerTest.cpp
 	../suite/TestUtil.cpp
-	# ${CMAKE_SOURCE_DIR}/daemon/postprocess/DirectUnpack.cpp
-	# ${CMAKE_SOURCE_DIR}/daemon/postprocess/DupeMatcher.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/DirectUnpack.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/DupeMatcher.cpp
 	${CMAKE_SOURCE_DIR}/daemon/postprocess/RarReader.cpp
 	${CMAKE_SOURCE_DIR}/daemon/postprocess/RarRenamer.cpp
 	${CMAKE_SOURCE_DIR}/daemon/main/Options.cpp
@@ -14,7 +14,7 @@ set(PostprocessTestsSrc
 	${CMAKE_SOURCE_DIR}/daemon/util/Util.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/Thread.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/Log.cpp
-	#${CMAKE_SOURCE_DIR}/daemon/util/ScriptController.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/ScriptController.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/FileSystem.cpp
 	${CMAKE_SOURCE_DIR}/daemon/queue/DownloadInfo.cpp
 	${CMAKE_SOURCE_DIR}/daemon/queue/DiskState.cpp

--- a/tests/postprocess/main.cpp
+++ b/tests/postprocess/main.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "nzbget.h"
@@ -27,9 +27,7 @@
 #include "WorkState.h"
 #include "DiskState.h"
 
-char* envVars[] = {"NZBXX_YYYY", 0};
-char* (*g_EnvironmentVariables)[2] = &envVars;
-char* (*g_Arguments)[] = nullptr;
+char* (*g_EnvironmentVariables)[] = nullptr;
 Log* g_Log;
 WorkState* g_WorkState;
 Options* g_Options;


### PR DESCRIPTION
## Description

Direct unpack fails for even non-archives files if at least one article has failed.
- Fixed DirectUnpack unit tests.

## Testing

- macOS 12 Ventura
- Windows 11