### PR TITLE
Fix: Correctly decode Unicode escape sequences in JsonDecode

### DIFF
--- a/daemon/util/Util.cpp
+++ b/daemon/util/Util.cpp
@@ -1360,8 +1360,13 @@ void WebUtil::JsonDecode(char* raw)
 							*output++ = '\t';
 							break;
 						case 'u':
-							*output++ = (char)strtol(p + 1, nullptr, 16);
-							p += 4;
+							{
+								char hex[5] = {0};
+								strncpy(hex, p + 1, 4);
+								unsigned int code = strtoul(hex, nullptr, 16);
+								*output++ = (char)code;
+								p += 4;
+							}
 							break;
 						default:
 							// unknown escape-sequence, should never occur

--- a/tests/util/JsonTest.cpp
+++ b/tests/util/JsonTest.cpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <string>
 #include "Json.h"
+#include "Util.h"
 
 BOOST_AUTO_TEST_CASE(JsonDeserializeTest)
 {
@@ -58,4 +59,44 @@ BOOST_AUTO_TEST_CASE(JsonDeserializeTest)
 			BOOST_CHECK(!res.has_value());
 		}
 	}
+}
+
+BOOST_AUTO_TEST_CASE(JsonDecodeTest)
+{
+    {
+        const char* json = "Test \\\"quoted\\\" text";
+        const char* expected = "Test \"quoted\" text";
+        char* testString = strdup(json);
+        WebUtil::JsonDecode(testString);
+        BOOST_CHECK(strcmp(testString, expected) == 0);
+        free(testString);
+    }
+
+    {
+        const char* json = "Test \\u0026 ampersand";
+        const char* expected = "Test & ampersand";
+        char* testString = strdup(json);
+        WebUtil::JsonDecode(testString);
+        BOOST_CHECK(strcmp(testString, expected) == 0);
+        free(testString);
+    }
+
+
+    {
+        const char* json = "Test \\u0026 \\u0026 \\u0026";
+        const char* expected = "Test & & &";
+        char* testString = strdup(json);
+        WebUtil::JsonDecode(testString);
+        BOOST_CHECK(strcmp(testString, expected) == 0);
+        free(testString);
+    }
+
+    {
+        const char* json = "Test \\\"quote\\\" \\u0026 \\n newline";
+        const char* expected = "Test \"quote\" & \n newline";
+        char* testString = strdup(json);
+        WebUtil::JsonDecode(testString);
+        BOOST_CHECK(strcmp(testString, expected) == 0);
+        free(testString);
+    }
 }


### PR DESCRIPTION
## Description

The JsonDecode function in WebUtil incorrectly handled Unicode escape sequences like \u0026. This could lead to malformed data when decoding JSON, particularly URLs containing ampersands passed via the API.

This commit modifies the JsonDecode logic to correctly parse \uXXXX sequences into their corresponding characters using strtoul.

## Lib changes

NA

## Testing

Unit tests have been added in JsonDecodeTest to verify the fix and cover various standard and Unicode escape sequence scenarios.