### PR TITLE
Suppress some "-Wunused-parameter" compiler warnings

### DIFF
--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -179,13 +179,13 @@ public:
 			bool tls, const char* cipher, int maxConnections, int retention,
 			int level, int group, bool optional, unsigned int certVerificationfLevel) = 0;
 		virtual void AddFeed([[maybe_unused]] int id, [[maybe_unused]] const char* name,
-                        [[maybe_unused]] const char* url, [[maybe_unused]] int interval,
-                        [[maybe_unused]] const char* filter, [[maybe_unused]] bool backlog,
-                        [[maybe_unused]] bool pauseNzb, [[maybe_unused]] const char* category,
+			[[maybe_unused]] const char* url, [[maybe_unused]] int interval,
+			[[maybe_unused]] const char* filter, [[maybe_unused]] bool backlog,
+			[[maybe_unused]] bool pauseNzb, [[maybe_unused]] const char* category,
 			[[maybe_unused]] int priority, [[maybe_unused]] const char* extensions) {}
 		virtual void AddTask([[maybe_unused]] int id, [[maybe_unused]] int hours, [[maybe_unused]] int minutes,
-                        [[maybe_unused]] int weekDaysBits, [[maybe_unused]] ESchedulerCommand command,
-                        [[maybe_unused]] const char* param) {}
+			[[maybe_unused]] int weekDaysBits, [[maybe_unused]] ESchedulerCommand command,
+			[[maybe_unused]] const char* param) {}
 		virtual void SetupFirstStart() {}
 	};
 

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -178,11 +178,14 @@ public:
 			int port, int ipVersion, const char* user, const char* pass, bool joinGroup,
 			bool tls, const char* cipher, int maxConnections, int retention,
 			int level, int group, bool optional, unsigned int certVerificationfLevel) = 0;
-		virtual void AddFeed(int id, const char* name, const char* url, int interval,
-			const char* filter, bool backlog, bool pauseNzb, const char* category,
-			int priority, const char* extensions) {}
-		virtual void AddTask(int id, int hours, int minutes, int weekDaysBits, ESchedulerCommand command,
-			const char* param) {}
+		virtual void AddFeed([[maybe_unused]] int id, [[maybe_unused]] const char* name,
+                        [[maybe_unused]] const char* url, [[maybe_unused]] int interval,
+                        [[maybe_unused]] const char* filter, [[maybe_unused]] bool backlog,
+                        [[maybe_unused]] bool pauseNzb, [[maybe_unused]] const char* category,
+			[[maybe_unused]] int priority, [[maybe_unused]] const char* extensions) {}
+		virtual void AddTask([[maybe_unused]] int id, [[maybe_unused]] int hours, [[maybe_unused]] int minutes,
+                        [[maybe_unused]] int weekDaysBits, [[maybe_unused]] ESchedulerCommand command,
+                        [[maybe_unused]] const char* param) {}
 		virtual void SetupFirstStart() {}
 	};
 

--- a/daemon/postprocess/DupeMatcher.h
+++ b/daemon/postprocess/DupeMatcher.h
@@ -34,8 +34,8 @@ public:
 	static bool SizeDiffOK(int64 size1, int64 size2, int maxDiffPercent);
 
 protected:
-	virtual void PrintMessage([[maybe_unused]] Message::EKind kind, [[maybe_unused]] const char* format,
-                     ...) PRINTF_SYNTAX(3) {}
+	virtual void PrintMessage([[maybe_unused]] Message::EKind kind,
+		[[maybe_unused]] const char* format, ...) PRINTF_SYNTAX(3) {}
 
 private:
 	CString m_destDir;

--- a/daemon/postprocess/DupeMatcher.h
+++ b/daemon/postprocess/DupeMatcher.h
@@ -34,7 +34,8 @@ public:
 	static bool SizeDiffOK(int64 size1, int64 size2, int maxDiffPercent);
 
 protected:
-	virtual void PrintMessage(Message::EKind kind, const char* format, ...) PRINTF_SYNTAX(3) {}
+	virtual void PrintMessage([[maybe_unused]] Message::EKind kind, [[maybe_unused]] const char* format,
+                     ...) PRINTF_SYNTAX(3) {}
 
 private:
 	CString m_destDir;

--- a/daemon/postprocess/ParChecker.h
+++ b/daemon/postprocess/ParChecker.h
@@ -142,13 +142,15 @@ protected:
 	virtual void UpdateProgress() {}
 	virtual bool IsStopped() { return false; };
 	virtual void Completed() {}
-	virtual void PrintMessage(Message::EKind kind, const char* format, ...) PRINTF_SYNTAX(3) {}
-	virtual void RegisterParredFile(const char* filename) {}
-	virtual bool IsParredFile(const char* filename) { return false; }
-	virtual EFileStatus FindFileCrc(const char* filename, uint32* crc, SegmentList* segments) { return fsUnknown; }
-	virtual const char* FindFileOrigname(const char* filename) { return nullptr; }
-	virtual void RequestDupeSources(DupeSourceList* dupeSourceList) {}
-	virtual void StatDupeSources(DupeSourceList* dupeSourceList) {}
+	virtual void PrintMessage([[maybe_unused]] Message::EKind kind, [[maybe_unused]] const char* format,
+                     ...) PRINTF_SYNTAX(3) {}
+	virtual void RegisterParredFile([[maybe_unused]] const char* filename) {}
+	virtual bool IsParredFile([[maybe_unused]] const char* filename) { return false; }
+	virtual EFileStatus FindFileCrc([[maybe_unused]] const char* filename, [[maybe_unused]] uint32* crc,
+                            [[maybe_unused]] SegmentList* segments) { return fsUnknown; }
+	virtual const char* FindFileOrigname([[maybe_unused]] const char* filename) { return nullptr; }
+	virtual void RequestDupeSources([[maybe_unused]] DupeSourceList* dupeSourceList) {}
+	virtual void StatDupeSources([[maybe_unused]] DupeSourceList* dupeSourceList) {}
 	EStage GetStage() { return m_stage; }
 	const char* GetProgressLabel() { return m_progressLabel.c_str(); }
 	int GetFileProgress() { return m_fileProgress; }

--- a/daemon/postprocess/ParChecker.h
+++ b/daemon/postprocess/ParChecker.h
@@ -142,12 +142,12 @@ protected:
 	virtual void UpdateProgress() {}
 	virtual bool IsStopped() { return false; };
 	virtual void Completed() {}
-	virtual void PrintMessage([[maybe_unused]] Message::EKind kind, [[maybe_unused]] const char* format,
-                     ...) PRINTF_SYNTAX(3) {}
+	virtual void PrintMessage([[maybe_unused]] Message::EKind kind,
+		[[maybe_unused]] const char* format, ...) PRINTF_SYNTAX(3) {}
 	virtual void RegisterParredFile([[maybe_unused]] const char* filename) {}
 	virtual bool IsParredFile([[maybe_unused]] const char* filename) { return false; }
 	virtual EFileStatus FindFileCrc([[maybe_unused]] const char* filename, [[maybe_unused]] uint32* crc,
-                            [[maybe_unused]] SegmentList* segments) { return fsUnknown; }
+		[[maybe_unused]] SegmentList* segments) { return fsUnknown; }
 	virtual const char* FindFileOrigname([[maybe_unused]] const char* filename) { return nullptr; }
 	virtual void RequestDupeSources([[maybe_unused]] DupeSourceList* dupeSourceList) {}
 	virtual void StatDupeSources([[maybe_unused]] DupeSourceList* dupeSourceList) {}

--- a/daemon/postprocess/ParRenamer.h
+++ b/daemon/postprocess/ParRenamer.h
@@ -42,10 +42,10 @@ protected:
 	virtual void UpdateProgress() {}
 	virtual bool IsStopped() { return false; };
 	virtual void PrintMessage([[maybe_unused]] Message::EKind kind, [[maybe_unused]] const char* format,
-                     ...) PRINTF_SYNTAX(3) {}
+		...) PRINTF_SYNTAX(3) {}
 	virtual void RegisterParredFile([[maybe_unused]] const char* filename) {}
 	virtual void RegisterRenamedFile([[maybe_unused]] const char* oldFilename,
-                     [[maybe_unused]] const char* newFileName) {}
+		[[maybe_unused]] const char* newFileName) {}
 	const char* GetProgressLabel() { return m_progressLabel; }
 	int GetStageProgress() { return m_stageProgress; }
 

--- a/daemon/postprocess/ParRenamer.h
+++ b/daemon/postprocess/ParRenamer.h
@@ -41,9 +41,11 @@ public:
 protected:
 	virtual void UpdateProgress() {}
 	virtual bool IsStopped() { return false; };
-	virtual void PrintMessage(Message::EKind kind, const char* format, ...) PRINTF_SYNTAX(3) {}
-	virtual void RegisterParredFile(const char* filename) {}
-	virtual void RegisterRenamedFile(const char* oldFilename, const char* newFileName) {}
+	virtual void PrintMessage([[maybe_unused]] Message::EKind kind, [[maybe_unused]] const char* format,
+                     ...) PRINTF_SYNTAX(3) {}
+	virtual void RegisterParredFile([[maybe_unused]] const char* filename) {}
+	virtual void RegisterRenamedFile([[maybe_unused]] const char* oldFilename,
+                     [[maybe_unused]] const char* newFileName) {}
 	const char* GetProgressLabel() { return m_progressLabel; }
 	int GetStageProgress() { return m_stageProgress; }
 

--- a/daemon/postprocess/PrePostProcessor.h
+++ b/daemon/postprocess/PrePostProcessor.h
@@ -39,7 +39,7 @@ public:
 	void NzbDownloaded(DownloadQueue* downloadQueue, NzbInfo* nzbInfo);
 
 protected:
-	virtual void Update(Subject* caller, void* aspect) { DownloadQueueUpdate(aspect); }
+	virtual void Update([[maybe_unused]] Subject* caller, void* aspect) { DownloadQueueUpdate(aspect); }
 
 private:
 	int m_queuedJobs = 0;

--- a/daemon/postprocess/RarRenamer.h
+++ b/daemon/postprocess/RarRenamer.h
@@ -41,9 +41,9 @@ protected:
 	virtual void UpdateProgress() {}
 	virtual bool IsStopped() { return false; };
 	virtual void PrintMessage([[maybe_unused]] Message::EKind kind, [[maybe_unused]] const char* format,
-                     ...) PRINTF_SYNTAX(3) {}
+		...) PRINTF_SYNTAX(3) {}
 	virtual void RegisterRenamedFile([[maybe_unused]] const char* oldFilename,
-                     [[maybe_unused]] const char* newFileName) {}
+		[[maybe_unused]] const char* newFileName) {}
 	const char* GetProgressLabel() { return m_progressLabel; }
 	int GetStageProgress() { return m_stageProgress; }
 

--- a/daemon/postprocess/RarRenamer.h
+++ b/daemon/postprocess/RarRenamer.h
@@ -40,8 +40,10 @@ public:
 protected:
 	virtual void UpdateProgress() {}
 	virtual bool IsStopped() { return false; };
-	virtual void PrintMessage(Message::EKind kind, const char* format, ...) PRINTF_SYNTAX(3) {}
-	virtual void RegisterRenamedFile(const char* oldFilename, const char* newFileName) {}
+	virtual void PrintMessage([[maybe_unused]] Message::EKind kind, [[maybe_unused]] const char* format,
+                     ...) PRINTF_SYNTAX(3) {}
+	virtual void RegisterRenamedFile([[maybe_unused]] const char* oldFilename,
+                     [[maybe_unused]] const char* newFileName) {}
 	const char* GetProgressLabel() { return m_progressLabel; }
 	int GetStageProgress() { return m_stageProgress; }
 

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -300,7 +300,7 @@ bool FileSystem::SaveBufferIntoFile(const char* filename, const char* buffer, in
 	return writtenBytes == bufLen;
 }
 
-bool FileSystem::AllocateFile(const char* filename, int64 size, bool sparse, CString& errmsg)
+bool FileSystem::AllocateFile(const char* filename, int64 size, [[maybe_unused]] bool sparse, CString& errmsg)
 {
 	errmsg.Clear();
 	bool ok = false;
@@ -1168,7 +1168,7 @@ bool FileSystem::NeedLongPath(const char* path)
 }
 #endif
 
-CString FileSystem::MakeExtendedPath(const char* path, bool force)
+CString FileSystem::MakeExtendedPath(const char* path, [[maybe_unused]] bool force)
 {
 #ifdef WIN32
 	if (force || NeedLongPath(path))

--- a/daemon/util/ScriptController.h
+++ b/daemon/util/ScriptController.h
@@ -79,7 +79,7 @@ protected:
 	void ResetEnv();
 	void PrepareEnvOptions(const char* stripPrefix);
 	void PrepareArgs();
-	virtual const char* GetOptValue(const char* name, const char* value) { return value; }
+	virtual const char* GetOptValue([[maybe_unused]] const char* name, const char* value) { return value; }
 	void StartProcess(int* pipein, int* pipeout);
 	int WaitProcess();
 	void SetNeedWrite(bool needWrite) { m_needWrite = needWrite; }

--- a/daemon/util/Util.cpp
+++ b/daemon/util/Util.cpp
@@ -852,7 +852,7 @@ bool Util::StrCaseCmp(const std::string& a, const std::string& b)
 }
 
 // prevent PC from going to sleep
-void Util::SetStandByMode(bool standBy)
+void Util::SetStandByMode([[maybe_unused]] bool standBy)
 {
 #ifdef WIN32
 	SetThreadExecutionState((standBy ? 0 : ES_SYSTEM_REQUIRED) | ES_CONTINUOUS);


### PR DESCRIPTION
## Description

This PR adds the attribute `[[maybe_unused]]` ([available since C++17](https://en.cppreference.com/w/cpp/language/attributes/maybe_unused)) to parameters of virtual functions and parameters that are used only for WIN32.

Here are some compiler warning examples:

```
==== Util.cpp ====

/home/boechat/Code/Opensource/nzbget/daemon/util/Util.cpp: In static member function ‘static void Util::SetStandByMode(bool)’:
/home/boechat/Code/Opensource/nzbget/daemon/util/Util.cpp:855:32: warning: unused parameter ‘standBy’ [-Wunused-parameter]
  855 | void Util::SetStandByMode(bool standBy)
      |                           ~~~~~^~~~~~~

==== FileSystem.cpp & ScriptController.h ====

/home/boechat/Code/Opensource/nzbget/daemon/util/FileSystem.cpp: In static member function ‘static bool FileSystem::AllocateFile(const char*, int64, bool, CString&)’:
/home/boechat/Code/Opensource/nzbget/daemon/util/FileSystem.cpp:303:70: warning: unused parameter ‘sparse’ [-Wunused-parameter]
  303 | bool FileSystem::AllocateFile(const char* filename, int64 size, bool sparse, CString& errmsg)
      |                                                                 ~~~~~^~~~~~
In file included from /home/boechat/Code/Opensource/nzbget/daemon/main/Maintenance.h:25,
                 from /home/boechat/Code/Opensource/nzbget/daemon/remote/XmlRpc.cpp:32:
/home/boechat/Code/Opensource/nzbget/daemon/util/ScriptController.h: In member function ‘virtual const char* ScriptController::GetOptValue(const char*, const char*)’:
/home/boechat/Code/Opensource/nzbget/daemon/util/ScriptController.h:82:53: warning: unused parameter ‘name’ [-Wunused-parameter]
   82 |         virtual const char* GetOptValue(const char* name, const char* value) { return value; }
      |                                         ~~~~~~~~~~~~^~~~
/home/boechat/Code/Opensource/nzbget/daemon/util/FileSystem.cpp: In static member function ‘static CString FileSystem::MakeExtendedPath(const char*, bool)’:
/home/boechat/Code/Opensource/nzbget/daemon/util/FileSystem.cpp:1171:61: warning: unused parameter ‘force’ [-Wunused-parameter]
 1171 | CString FileSystem::MakeExtendedPath(const char* path, bool force)
      |                                                        ~~~~~^~~~~

==== Options.h ====

/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h: In member function ‘virtual void Options::Extender::AddFeed(int, const char*, const char*, int, const char*, bool, bool, const char*, int, const char*)’:
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:181:42: warning: unused parameter ‘id’ [-Wunused-parameter]
  181 |                 virtual void AddFeed(int id, const char* name, const char* url, int interval,
      |                                      ~~~~^~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:181:58: warning: unused parameter ‘name’ [-Wunused-parameter]
  181 |                 virtual void AddFeed(int id, const char* name, const char* url, int interval,
      |                                              ~~~~~~~~~~~~^~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:181:76: warning: unused parameter ‘url’ [-Wunused-parameter]
  181 |                 virtual void AddFeed(int id, const char* name, const char* url, int interval,
      |                                                                ~~~~~~~~~~~~^~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:181:85: warning: unused parameter ‘interval’ [-Wunused-parameter]
  181 |                 virtual void AddFeed(int id, const char* name, const char* url, int interval,
      |                                                                                 ~~~~^~~~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:182:37: warning: unused parameter ‘filter’ [-Wunused-parameter]
  182 |                         const char* filter, bool backlog, bool pauseNzb, const char* category,
      |                         ~~~~~~~~~~~~^~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:182:50: warning: unused parameter ‘backlog’ [-Wunused-parameter]
  182 |                         const char* filter, bool backlog, bool pauseNzb, const char* category,
      |                                             ~~~~~^~~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:182:64: warning: unused parameter ‘pauseNzb’ [-Wunused-parameter]
  182 |                         const char* filter, bool backlog, bool pauseNzb, const char* category,
      |                                                           ~~~~~^~~~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:182:86: warning: unused parameter ‘category’ [-Wunused-parameter]
  182 |                         const char* filter, bool backlog, bool pauseNzb, const char* category,
      |                                                                          ~~~~~~~~~~~~^~~~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:183:29: warning: unused parameter ‘priority’ [-Wunused-parameter]
  183 |                         int priority, const char* extensions) {}
      |                         ~~~~^~~~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:183:51: warning: unused parameter ‘extensions’ [-Wunused-parameter]
  183 |                         int priority, const char* extensions) {}
      |                                       ~~~~~~~~~~~~^~~~~~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h: In member function ‘virtual void Options::Extender::AddTask(int, int, int, int, Options::ESchedulerCommand, const char*)’:
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:184:42: warning: unused parameter ‘id’ [-Wunused-parameter]
  184 |                 virtual void AddTask(int id, int hours, int minutes, int weekDaysBits, ESchedulerCommand command,
      |                                      ~~~~^~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:184:50: warning: unused parameter ‘hours’ [-Wunused-parameter]
  184 |                 virtual void AddTask(int id, int hours, int minutes, int weekDaysBits, ESchedulerCommand command,
      |                                              ~~~~^~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:184:61: warning: unused parameter ‘minutes’ [-Wunused-parameter]
  184 |                 virtual void AddTask(int id, int hours, int minutes, int weekDaysBits, ESchedulerCommand command,
      |                                                         ~~~~^~~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:184:74: warning: unused parameter ‘weekDaysBits’ [-Wunused-parameter]
  184 |                 virtual void AddTask(int id, int hours, int minutes, int weekDaysBits, ESchedulerCommand command,
      |                                                                      ~~~~^~~~~~~~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:184:106: warning: unused parameter ‘command’ [-Wunused-parameter]
  184 |                 virtual void AddTask(int id, int hours, int minutes, int weekDaysBits, ESchedulerCommand command,
      |                                                                                        ~~~~~~~~~~~~~~~~~~^~~~~~~
/home/boechat/Code/Opensource/nzbget/daemon/main/Options.h:185:37: warning: unused parameter ‘param’ [-Wunused-parameter]
  185 |                         const char* param) {}
      |                         ~~~~~~~~~~~~^~~~~
```