### PR TITLE
Fix: non native atomics support

### DIFF
--- a/cmake/posix.cmake
+++ b/cmake/posix.cmake
@@ -359,7 +359,7 @@ check_cxx_source_compiles("
 	}
 " HAVE_NATIVE_ATOMICS_SUPPORT)
 
-if(NOT HAVE_NATIVE_ATOMICS_SUPPORT AND NOT ENABLE_STATIC)
+if(NOT HAVE_NATIVE_ATOMICS_SUPPORT)
 	message(STATUS "Compiler lacks native support for C++ atomics. Linking against libatomic.")
 	set(LIBS ${LIBS} -latomic)
 endif()

--- a/cmake/posix.cmake
+++ b/cmake/posix.cmake
@@ -333,19 +333,21 @@ if(HAVE_VARIADIC_MACROS)
 	set(DHAVE_VARIADIC_MACROS 1)
 endif()
 
-check_cxx_source_compiles("
-	#include <execinfo.h>
-	#include <stdio.h>
-	#include <stdlib.h>
-	int main() 
-	{ 
-		void* array[100];
-		size_t size; 
-		char** strings; 
-		size = backtrace(array, 100);
-		strings = backtrace_symbols(array, size);
-		return 0; 
-	}" HAVE_BACKTRACE)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+	check_cxx_source_compiles("
+		#include <execinfo.h>
+		#include <stdio.h>
+		#include <stdlib.h>
+		int main() 
+		{ 
+			void* array[100];
+			size_t size; 
+			char** strings; 
+			size = backtrace(array, 100);
+			strings = backtrace_symbols(array, size);
+			return 0; 
+		}" HAVE_BACKTRACE)
+endif()
 
 check_cxx_source_compiles("
 	#include <atomic>

--- a/cmake/posix.cmake
+++ b/cmake/posix.cmake
@@ -357,7 +357,7 @@ check_cxx_source_compiles("
 	}
 " HAVE_NATIVE_ATOMICS_SUPPORT)
 
-if(NOT HAVE_NATIVE_ATOMICS_SUPPORT)
+if(NOT HAVE_NATIVE_ATOMICS_SUPPORT AND NOT ENABLE_STATIC)
 	message(STATUS "Compiler lacks native support for C++ atomics. Linking against libatomic.")
 	set(LIBS ${LIBS} -latomic)
 endif()

--- a/cmake/posix.cmake
+++ b/cmake/posix.cmake
@@ -346,3 +346,18 @@ check_cxx_source_compiles("
 		strings = backtrace_symbols(array, size);
 		return 0; 
 	}" HAVE_BACKTRACE)
+
+check_cxx_source_compiles("
+	#include <atomic>
+	int main()
+	{
+		std::atomic<uint64_t> x{ 0 };
+		x.load(std::memory_order_acquire);
+		return 0;
+	}
+" HAVE_NATIVE_ATOMICS_SUPPORT)
+
+if(NOT HAVE_NATIVE_ATOMICS_SUPPORT)
+	message(STATUS "Compiler lacks native support for C++ atomics. Linking against libatomic.")
+	set(LIBS ${LIBS} -latomic)
+endif()

--- a/linux/build-nzbget.sh
+++ b/linux/build-nzbget.sh
@@ -650,10 +650,10 @@ build_bin()
             CMAKE_EXTRA_ARGS="-DCOMPILER=clang -DTOOLCHAIN_PREFIX=$TOOLCHAIN_PREFIX"
             ;;
         freebsd)
-            export LIBS="$LDFLAGS -lxml2 -lboost_json -lssl -lcrypto -lz -lncursesw -lc++ -Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
+            export LIBS="$LDFLAGS -lxml2 -lboost_json -lssl -lcrypto -lz -lncursesw -lc++ -lexecinfo -lelf -Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
             export INCLUDES="$NZBGET_INCLUDES;$FREEBSD_SYSROOT/usr/include/c++/v1"
             CMAKE_SYSTEM_NAME="FreeBSD"
-            CMAKE_EXTRA_ARGS="-DCMAKE_SYSROOT=$FREEBSD_SYSROOT"
+            CMAKE_EXTRA_ARGS="-DCMAKE_SYSROOT=$FREEBSD_SYSROOT -DCMAKE_CXX_FLAGS=-I$FREEBSD_SYSROOT/usr/include/c++/v1"
             ;;
         *)
             if [ "$ARCH" != "ppc500" ]; then


### PR DESCRIPTION
## Description

Added checks for native atomics support and links against libatomic if missing.

## Testing

- FreeBSD 14 AMD65
- ppc500 (QEMU)