### PR TITLE
Add support for libxml2 2.14 dataBlock() callback (#572)

### DIFF
--- a/daemon/feed/FeedFile.h
+++ b/daemon/feed/FeedFile.h
@@ -47,7 +47,7 @@ private:
 
 	static void SAX_StartElement(FeedFile* file, const char *name, const char **atts);
 	static void SAX_EndElement(FeedFile* file, const char *name);
-	static void SAX_characters(FeedFile* file, const char *  xmlstr, int len);
+	static void SAX_textHandler(FeedFile* file, const char *  xmlstr, int len);
 	static xmlEntityPtr SAX_getEntity(FeedFile* file, const xmlChar*  name);
 	static void SAX_error(FeedFile* file, const char *msg, ...);
 	void Parse_StartElement(const char *name, const char **atts);


### PR DESCRIPTION
On libxml2 2.13, cdataBlock is ignored (NULL), and all text + CDATA come through characters().  On libxml2 2.14+, CDATA arrives through cdataBlock, normal text through characters(), both appended to the same buffer. At element end, you get the complete merged text content — exactly like libxml2 ≤ 2.13 behavior.