### PR TITLE
Fix: data race that could cause application crashes

### DIFF
--- a/daemon/extension/CommandScript.cpp
+++ b/daemon/extension/CommandScript.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -41,14 +42,13 @@ bool CommandScriptController::StartScript(const char* scriptName, const char* co
 
 	scriptController->Start();
 
-	for (const auto script : g_ExtensionManager->GetExtensions())
-	{
-		if (strcmp(scriptName, script->GetName()) == 0)
+	auto found = g_ExtensionManager->FindIf([&](auto script)
 		{
-			return true;
+			return strcmp(scriptName, script->GetName()) == 0;
 		}
-	}
-	return false;
+	);
+	
+	return found.has_value();
 }
 
 void CommandScriptController::Run()

--- a/daemon/extension/ExtensionManager.h
+++ b/daemon/extension/ExtensionManager.h
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,13 +25,15 @@
 #include <memory>
 #include <shared_mutex>
 #include <optional>
+#include <functional>
 #include "WebDownloader.h"
 #include "Options.h"
 #include "Extension.h"
 
 namespace ExtensionManager
 {
-	using Extensions = std::vector<std::shared_ptr<const Extension::Script>>;
+	using ExtensionPtr = std::shared_ptr<const Extension::Script>;
+	using Extensions = std::vector<ExtensionPtr>;
 
 	class Manager final
 	{
@@ -59,8 +61,11 @@ namespace ExtensionManager
 
 		std::pair<WebDownloader::EStatus, std::string>
 		DownloadExtension(const std::string& url, const std::string& info);
-		
-		const Extensions& GetExtensions() const &;
+
+		void ForEach(std::function<void(const ExtensionPtr)> callback) const;
+
+		std::optional<ExtensionPtr> 
+		FindIf(std::function<bool(ExtensionPtr)> comparator) const;
 
 	private:
 		void LoadExtensionDir(const char* directory, bool isSubDir, const char* rootDir);

--- a/daemon/extension/NzbScript.cpp
+++ b/daemon/extension/NzbScript.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -67,9 +68,12 @@ void NzbScriptController::PrepareEnvScript(NzbParameterList* parameters, const c
 
 void NzbScriptController::ExecuteScriptList(const char* scriptList)
 {
-	for (const auto script : g_ExtensionManager->GetExtensions())
+	if (Util::EmptyStr(scriptList))
 	{
-		if (scriptList && *scriptList)
+		return;
+	}
+
+	g_ExtensionManager->ForEach([&](auto script)
 		{
 			// split szScriptList into tokens
 			Tokenizer tok(scriptList, ",;");
@@ -82,5 +86,5 @@ void NzbScriptController::ExecuteScriptList(const char* scriptList)
 				}
 			}
 		}
-	}
+	);
 }

--- a/daemon/queue/Scanner.cpp
+++ b/daemon/queue/Scanner.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -379,10 +379,11 @@ void Scanner::InitPPParameters(const char* category, NzbParameterList* parameter
 
 	if (reset)
 	{
-		for (const auto script : g_ExtensionManager->GetExtensions())
-		{
-			parameters->SetParameter(BString<1024>("%s:", script->GetName()), nullptr);
-		}
+		g_ExtensionManager->ForEach([&parameters](auto script)
+			{
+				parameters->SetParameter(BString<1024>("%s:", script->GetName()), nullptr);
+			}
+		);
 	}
 
 	if (!parameters->Find("*Unpack:"))
@@ -396,16 +397,17 @@ void Scanner::InitPPParameters(const char* category, NzbParameterList* parameter
 		Tokenizer tok(extensions, ",;");
 		while (const char* scriptName = tok.Next())
 		{
-			for (const auto script : g_ExtensionManager->GetExtensions())
-			{
-				BString<1024> paramName("%s:", scriptName);
-				if ((script->GetPostScript() || script->GetQueueScript()) &&
-					!parameters->Find(paramName) &&
-					strcmp(scriptName, script->GetName()) == 0)
+			g_ExtensionManager->ForEach([&](auto script)
 				{
-					parameters->SetParameter(paramName, "yes");
+					BString<1024> paramName("%s:", scriptName);
+					if ((script->GetPostScript() || script->GetQueueScript()) &&
+						!parameters->Find(paramName) &&
+						strcmp(scriptName, script->GetName()) == 0)
+					{
+						parameters->SetParameter(paramName, "yes");
+					}
 				}
-			}
+			);
 		}
 	}
 }

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -2948,15 +2948,16 @@ void LoadExtensionsXmlCommand::Execute()
 
 	int index = 0;
 
-	for (const auto extension : g_ExtensionManager->GetExtensions())
-	{
-		std::string response = isJson
-			? Extension::ToJsonStr(*extension)
-			: Extension::ToXmlStr(*extension);
+	g_ExtensionManager->ForEach([&](auto extension)
+		{
+			const std::string response = isJson
+				? Extension::ToJsonStr(*extension)
+				: Extension::ToXmlStr(*extension);
 
-		AppendCondResponse(",\n", isJson && index++ > 0);
-		AppendResponse(response.c_str());
-	}
+			AppendCondResponse(",\n", isJson && index++ > 0);
+			AppendResponse(response.c_str());
+		}
+	);
 
 	AppendResponse(isJson ? "\n]" : "</data></array>\n");
 }

--- a/tests/extension/CMakeLists.txt
+++ b/tests/extension/CMakeLists.txt
@@ -4,6 +4,7 @@ set(ExtensionSrc
 	ExtensionLoaderTest.cpp
 	ExtensionTest.cpp
 	ExtensionManagerTest.cpp
+	../suite/TestUtil.cpp
 	${CMAKE_SOURCE_DIR}/daemon/extension/ManifestFile.cpp
 	${CMAKE_SOURCE_DIR}/daemon/extension/ExtensionLoader.cpp
 	${CMAKE_SOURCE_DIR}/daemon/extension/Extension.cpp
@@ -37,7 +38,7 @@ endif()
 
 add_executable(ExtensionTests ${ExtensionSrc})
 target_link_libraries(ExtensionTests PRIVATE ${LIBS})
-target_include_directories(ExtensionTests PRIVATE ${INCLUDES})
+target_include_directories(ExtensionTests PRIVATE ${INCLUDES} ../suite)
 
 file(COPY ../testdata/extension/manifest DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ../testdata/extension/V1 DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/extension/ExtensionManagerTest.cpp
+++ b/tests/extension/ExtensionManagerTest.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -29,18 +29,20 @@
 #include "ExtensionManager.h"
 #include "FileSystem.h"
 #include "Options.h"
+#include "TestUtil.h"
 
-const std::string currentPath = FileSystem::GetCurrentDirectory().Str();
-const std::string testDir = "ScriptDir=" + currentPath + "/scripts";
-const std::string extensions = std::string("Extensions=") + "Extension2, Extension1, email; Extension1; Extension1";
-const std::string scriptOrder = std::string("ScriptOrder=") + "Extension2, Extension1, email; Extension1; Extension1";
+const std::string CURRENT_PATH = FileSystem::GetCurrentDirectory().Str();
+const std::string SCRIPTS_DIR = CURRENT_PATH + "/scripts";
+const std::string SCRIPTS_DIR_OPT = "ScriptDir=" + SCRIPTS_DIR;
+const std::string EXTENSIONS = std::string("Extensions=") + "Extension2, Extension1, email; Extension1; Extension1";
+const std::string ORDER = std::string("ScriptOrder=") + "Extension2, Extension1, email; Extension1; Extension1";
 
-BOOST_AUTO_TEST_CASE(LoadExtesionsTest)
+BOOST_AUTO_TEST_CASE(LoadExtensionsTest)
 {
 	Options::CmdOptList cmdOpts;
-	cmdOpts.push_back(testDir.c_str());
-	cmdOpts.push_back(extensions.c_str());
-	cmdOpts.push_back(scriptOrder.c_str());
+	cmdOpts.push_back(SCRIPTS_DIR_OPT.c_str());
+	cmdOpts.push_back(EXTENSIONS.c_str());
+	cmdOpts.push_back(ORDER.c_str());
 	cmdOpts.push_back("NzbLog=no");
 	Options options(&cmdOpts, nullptr);
 	g_Options = &options;
@@ -49,23 +51,25 @@ BOOST_AUTO_TEST_CASE(LoadExtesionsTest)
 	ExtensionManager::Manager manager;
 
 	BOOST_REQUIRE(manager.LoadExtensions() == std::nullopt);
-	BOOST_REQUIRE(manager.GetExtensions().size() == 4);
-
-	for (size_t i = 0; i < manager.GetExtensions().size(); ++i)
-	{
-		if (i < correctOrder.size())
+	size_t idx = 0;
+	manager.ForEach([&](auto script)
 		{
-			BOOST_CHECK(correctOrder[i] == manager.GetExtensions()[i]->GetName());
+			if (idx < correctOrder.size())
+			{
+				BOOST_CHECK_EQUAL(correctOrder[idx], script->GetName());
+			}
+			++idx;
 		}
-	}
+	);
+	BOOST_CHECK_EQUAL(idx, 4);
 }
 
 BOOST_AUTO_TEST_CASE(ShouldNotDeleteExtensionIfExtensionIsBusyTest)
 {
 	Options::CmdOptList cmdOpts;
-	cmdOpts.push_back(testDir.c_str());
-	cmdOpts.push_back(extensions.c_str());
-	cmdOpts.push_back(scriptOrder.c_str());
+	cmdOpts.push_back(SCRIPTS_DIR_OPT.c_str());
+	cmdOpts.push_back(EXTENSIONS.c_str());
+	cmdOpts.push_back(ORDER.c_str());
 	cmdOpts.push_back("NzbLog=no");
 	Options options(&cmdOpts, nullptr);
 	g_Options = &options;
@@ -73,10 +77,43 @@ BOOST_AUTO_TEST_CASE(ShouldNotDeleteExtensionIfExtensionIsBusyTest)
 
 	BOOST_REQUIRE(manager.LoadExtensions() == std::nullopt);
 
-	const auto busyExt = manager.GetExtensions()[0];
+	const auto busyExt = manager.FindIf([](auto script) { return true; });
+	auto error = manager.DeleteExtension((*busyExt)->GetName());
 
-	auto error = manager.DeleteExtension(busyExt->GetName());
+	BOOST_CHECK_EQUAL(error.has_value(), true);
+	BOOST_CHECK_EQUAL(error.value(), std::string("Failed to delete: ") + (*busyExt)->GetName() + " is executing");
+}
 
-	BOOST_CHECK(error.has_value() == true);
-	BOOST_CHECK(error.value() == "Failed to delete: " + std::string(busyExt->GetName()) + " is executing");
+BOOST_AUTO_TEST_CASE(DeleteExtensionTest)
+{
+	const std::string workingDir = CURRENT_PATH + "/DeleteExtensionTest_dir";
+	const std::string scriptDirOpt = "ScriptDir=" + workingDir;
+
+	BOOST_REQUIRE(FileSystem::CreateDirectory(workingDir.c_str()));
+	TestUtil::CopyAllFiles(workingDir.c_str(), SCRIPTS_DIR.c_str());
+
+	Options::CmdOptList cmdOpts;
+	cmdOpts.push_back(scriptDirOpt.c_str());
+	cmdOpts.push_back(EXTENSIONS.c_str());
+	cmdOpts.push_back(ORDER.c_str());
+	cmdOpts.push_back("NzbLog=no");
+	Options options(&cmdOpts, nullptr);
+	g_Options = &options;
+	ExtensionManager::Manager manager;
+
+	BOOST_REQUIRE(manager.LoadExtensions() == std::nullopt);
+
+	auto res = manager.DeleteExtension("email");
+	const auto found = manager.FindIf([](auto script) 
+		{ 
+			return std::string("email") == script->GetName(); 
+		}
+	);
+
+	BOOST_CHECK_EQUAL(res.has_value(), false);
+	BOOST_CHECK_EQUAL(found.has_value(), false);
+	BOOST_CHECK_EQUAL(FileSystem::DirectoryExists("Email"), false);
+
+	CString errmsg;
+	FileSystem::DeleteDirectoryWithContent(workingDir.c_str(), errmsg);
 }

--- a/tests/suite/TestUtil.cpp
+++ b/tests/suite/TestUtil.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2015-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -116,6 +117,14 @@ void TestUtil::CopyAllFiles(const std::string destDir, const std::string srcDir)
 	{
 		std::string srcFile(srcDir + "/" + filename);
 		std::string dstFile(destDir + "/" + filename);
+
+		if (FileSystem::DirectoryExists(srcFile.c_str()))
+		{
+			FileSystem::CreateDirectory(dstFile.c_str());
+			CopyAllFiles(dstFile.c_str(), srcFile.c_str());
+			continue;
+		}
+
 		FileSystem::CopyFile(srcFile.c_str(), dstFile.c_str());
 	}
 }


### PR DESCRIPTION
## Description

- fixed a data race in the ExtensionManager that could cause application crashes
- suppressed several compiler warnings
- added more unit tests

## Testing

- Windows 11 amd64
- macOS Ventura amd64
- Linux Debian 12 amd64
- Docker arm32