### PR TITLE
Refactor: StrToNum by improving performance, safety and minimizing memory usage

### DIFF
--- a/daemon/extension/ExtensionLoader.cpp
+++ b/daemon/extension/ExtensionLoader.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2023-2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2023-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -335,7 +335,7 @@ namespace ExtensionLoader
 				return ManifestFile::SelectOption(val);
 			}
 
-			auto result = Util::StrToNum(val);
+			auto result = Util::StrToNum<double>(val);
 			if (result.has_value())
 			{
 				return ManifestFile::SelectOption(result.value());

--- a/daemon/util/Util.cpp
+++ b/daemon/util/Util.cpp
@@ -238,25 +238,6 @@ void Util::SplitInt64(int64 Int64, uint32* Hi, uint32* Lo)
 	*Lo = (uint32)(Int64 & 0xFFFFFFFF);
 }
 
-std::optional<double> 
-Util::StrToNum(const std::string& str)
-{
-	std::istringstream ss(str);
-	double num;
-
-	if (ss >> num)
-	{
-		if (!ss.eof()) 
-		{
-			return std::nullopt;
-		}
-
-		return { num };
-	}
-
-	return std::nullopt;
-}
-
 /* Base64 decryption is taken from
 *  Article "BASE 64 Decoding and Encoding Class 2003" by Jan Raddatz
 *  http://www.codeguru.com/cpp/cpp/algorithms/article.php/c5099/

--- a/tests/util/UtilTest.cpp
+++ b/tests/util/UtilTest.cpp
@@ -122,11 +122,20 @@ BOOST_AUTO_TEST_CASE(RegExTest)
 
 BOOST_AUTO_TEST_CASE(StrToNumTest)
 {
-	BOOST_CHECK(Util::StrToNum("3.14").value() == 3.14);
-	BOOST_CHECK(Util::StrToNum("3.").value() == 3.0);
-	BOOST_CHECK(Util::StrToNum("3").value() == 3);
-	BOOST_CHECK(Util::StrToNum("3 not a number").has_value() == false);
-	BOOST_CHECK(Util::StrToNum("not a number").has_value() == false);
+	BOOST_CHECK_LT(Util::StrToNum<float>("3.14").value() - 3.14f, std::numeric_limits<float>::epsilon());
+	BOOST_CHECK_LT(Util::StrToNum<float>("3.14 abc").value() - 3.14f, std::numeric_limits<float>::epsilon());
+	BOOST_CHECK_EQUAL(Util::StrToNum<double>("3.").value(), 3.0);
+	BOOST_CHECK_EQUAL(Util::StrToNum<int>("3.").value(), 3);
+	BOOST_CHECK_EQUAL(Util::StrToNum<int>("3").value(), 3);
+	BOOST_CHECK_EQUAL(Util::StrToNum<int>("-3").value(), -3);
+	BOOST_CHECK_EQUAL(Util::StrToNum<int>("+3").value(), 3);
+	BOOST_CHECK_EQUAL(Util::StrToNum<int>("   3").value(), 3);
+	BOOST_CHECK_EQUAL(Util::StrToNum<int>("3   ").value(), 3);
+	BOOST_CHECK_EQUAL(Util::StrToNum<int>("3 not a number").value(), 3);
+	BOOST_CHECK_EQUAL(Util::StrToNum<uint8_t>("256").has_value(), false);
+	BOOST_CHECK_EQUAL(Util::StrToNum<int>("not a number").has_value(), false);
+	BOOST_CHECK_EQUAL(Util::StrToNum<float>("").has_value(), false);
+	BOOST_CHECK_EQUAL(Util::StrToNum<float>("  ").has_value(), false);
 }
 
 BOOST_AUTO_TEST_CASE(StrCaseCmpTest)
@@ -138,7 +147,7 @@ BOOST_AUTO_TEST_CASE(StrCaseCmpTest)
 	BOOST_CHECK(Util::StrCaseCmp("3.14", "3.12") == false);
 }
 
-BOOST_AUTO_TEST_CASE(SplintInt64Test)
+BOOST_AUTO_TEST_CASE(SplitInt64Test)
 {
 	{
 		uint32 hi, lo;


### PR DESCRIPTION
## Description

- refactored Util::StrToNum to improve efficiency, safety and reduce memory allocations.
- added more unit tests.

## Testing

- macOS Ventura 13