### PR TITLE
Fix: prevent showing of negative age caused by incorrect dates in NZB file

### DIFF
--- a/webui/util.js
+++ b/webui/util.js
@@ -270,9 +270,9 @@ var Util = (new function($)
 
 	this.formatAge = function(time)
 	{
-		if (time == 0)
+		if (time <= 0)
 		{
-			return '';
+			return '--';
 		}
 
 		var diff = new Date().getTime() / 1000 - time;
@@ -283,6 +283,10 @@ var Util = (new function($)
 		else if (diff > 60*60)
 		{
 			return this.round0(diff / (60*60))  +'&nbsp;h';
+		}
+		else if (diff <= 0)
+		{
+			return '--';
 		}
 		else
 		{


### PR DESCRIPTION
## Description

- Fixed negative age values showing caused by incorrect dates in NZB files

## Testing

- macOS Ventura / Chrome 137