### PR TITLE
Fix: deobfuscation of yEnc subjects without quotes

### DIFF
--- a/daemon/queue/Deobfuscation.h
+++ b/daemon/queue/Deobfuscation.h
@@ -44,8 +44,8 @@ namespace Deobfuscation
 		std::regex{ "^[0-9]{6}_[0-9]{2}$" },
 	};
 
-	bool IsExcessivelyObfuscated(const std::string& str) noexcept;
-	std::string Deobfuscate(const std::string& str) noexcept;
+	bool IsExcessivelyObfuscated(const std::string& str);
+	std::string Deobfuscate(const std::string& str);
 }
 
 #endif

--- a/daemon/queue/NzbFile.cpp
+++ b/daemon/queue/NzbFile.cpp
@@ -128,11 +128,11 @@ void NzbFile::ParseSubject(FileInfo* fileInfo, bool TryQuotes)
 
 	detail("Extracting a filename from Subject %s", fileInfo->GetSubject());
 
-	std::string subject = Deobfuscation::Deobfuscate(fileInfo->GetSubject());
+	std::string filename = Deobfuscation::Deobfuscate(fileInfo->GetSubject());
 
-	detail("Extracted Filename: %s", subject.c_str());
+	detail("Extracted Filename: %s", filename.c_str());
 
-	fileInfo->SetFilename(std::move(subject));
+	fileInfo->SetFilename(std::move(filename));
 }
 
 bool NzbFile::HasDuplicateFilenames()

--- a/tests/queue/DeobfuscationTest.cpp
+++ b/tests/queue/DeobfuscationTest.cpp
@@ -113,5 +113,6 @@ BOOST_AUTO_TEST_CASE(DeobfuscationTest)
 	);
 
 	BOOST_CHECK_EQUAL(Deobfuscate("Re: A (2/3)"), "A");
-	BOOST_CHECK_EQUAL(Deobfuscate("Re: A"), "Re: A");
+	BOOST_CHECK_EQUAL(Deobfuscate("Re: A"), "A");
+	BOOST_CHECK_EQUAL(Deobfuscate("[34/44] - id.bdmv yEnc (1/1) 104"), "id.bdmv");
 }


### PR DESCRIPTION
## Description

- Improved parsing of yEnc subjects without surrounding quotes, e.g. "[34/44] - id.bdmv yEnc (1/1)"

## Testing

- macOS Ventura amd64