### PR TITLE
Build: upgrade par2-turbo to v1.3.0

### DIFF
--- a/cmake/par2-turbo.cmake
+++ b/cmake/par2-turbo.cmake
@@ -52,7 +52,7 @@ ExternalProject_add(
 	par2-turbo
 	PREFIX			par2-turbo
 	GIT_REPOSITORY	https://github.com/nzbgetcom/par2cmdline-turbo.git
-	GIT_TAG			v1.2.0-nzbget-20250213
+	GIT_TAG			v1.3.0
 	TLS_VERIFY		TRUE
 	GIT_SHALLOW		TRUE
 	GIT_PROGRESS	TRUE


### PR DESCRIPTION
## Lib changes

Upgraded par2-turbo from v1.2.0 to v1.3.0

## Testing

- macOS 13 Ventura