### PR TITLE
Fix: OpenSSL memory leaks and vulnerabilities associated with older SSL/TLS protocols

### DIFF
--- a/daemon/connect/HttpClient.cpp
+++ b/daemon/connect/HttpClient.cpp
@@ -56,6 +56,9 @@ namespace Network
 				Connect(socket, endpoints, host);
 				Write(socket, "GET", host);
 
+#ifndef DISABLE_TLS
+				OpenSSL::StopSSLThread();
+#endif
 				return MakeResponse(socket);
 			}
 		);

--- a/daemon/connect/TlsSocket.cpp
+++ b/daemon/connect/TlsSocket.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2008-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -30,81 +30,16 @@
 #include "FileSystem.h"
 #include "Options.h"
 
-std::string TlsSocket::m_certStore;
-X509_STORE* TlsSocket::m_X509Store = nullptr;
-
-#ifndef CRYPTO_set_locking_callback
-#define NEED_CRYPTO_LOCKING
-#endif
-
-#ifdef NEED_CRYPTO_LOCKING
-
-/**
- * Mutexes for OpenSSL
- */
-
-std::vector<std::unique_ptr<Mutex>> g_OpenSSLMutexes;
-
-static void openssl_locking(int mode, int n, const char* file, int line)
-{
-	Mutex* mutex = g_OpenSSLMutexes[n].get();
-	if (mode & CRYPTO_LOCK)
-	{
-		mutex->Lock();
-	}
-	else
-	{
-		mutex->Unlock();
-	}
-}
-
-static struct CRYPTO_dynlock_value* openssl_dynlock_create(const char *file, int line)
-{
-	return (CRYPTO_dynlock_value*)new Mutex();
-}
-
-static void openssl_dynlock_destroy(struct CRYPTO_dynlock_value *l, const char *file, int line)
-{
-	Mutex* mutex = (Mutex*)l;
-	delete mutex;
-}
-
-static void openssl_dynlock_lock(int mode, struct CRYPTO_dynlock_value *l, const char *file, int line)
-{
-	Mutex* mutex = (Mutex*)l;
-	if (mode & CRYPTO_LOCK)
-	{
-		mutex->Lock();
-	}
-	else
-	{
-		mutex->Unlock();
-	}
-}
-
-#endif /* NEED_CRYPTO_LOCKING */
-
+OpenSSL::X509StorePtr TlsSocket::m_X509Store{ nullptr, &X509_STORE_free };
 
 void TlsSocket::Init()
 {
 	debug("Initializing TLS library");
 
-
-#ifdef NEED_CRYPTO_LOCKING
-	for (int i = 0, num = CRYPTO_num_locks(); i < num; i++)
+	if (OPENSSL_init_ssl(0, nullptr) == 0)
 	{
-		g_OpenSSLMutexes.emplace_back(std::make_unique<Mutex>());
+		error("Could not initialize the OpenSSL library");
 	}
-
-	CRYPTO_set_locking_callback(openssl_locking);
-	CRYPTO_set_dynlock_create_callback(openssl_dynlock_create);
-	CRYPTO_set_dynlock_destroy_callback(openssl_dynlock_destroy);
-	CRYPTO_set_dynlock_lock_callback(openssl_dynlock_lock);
-#endif /* NEED_CRYPTO_LOCKING */
-
-	SSL_load_error_strings();
-	SSL_library_init();
-	OpenSSL_add_all_algorithms();
 }
 
 void TlsSocket::InitOptions(const char* certStore)
@@ -112,89 +47,46 @@ void TlsSocket::InitOptions(const char* certStore)
 	if (Util::EmptyStr(certStore)) 
 		return;
 
-	m_certStore = certStore;
-
-	InitX509Store(m_certStore);
+	InitX509Store(certStore);
 }
 
-void TlsSocket::InitX509Store(const std::string& certStore)
+void TlsSocket::InitX509Store(std::string_view certStore)
 {
-	if (m_X509Store) 
-	{
-		FreeX509Store(m_X509Store);
-	}
+	m_X509Store.reset(X509_STORE_new());
 
-	m_X509Store = X509_STORE_new();
 	if (!m_X509Store)
 	{
 		error("Could not create certificate store");
 		return;
 	}
 
-	if (!X509_STORE_load_locations(m_X509Store, certStore.c_str(), nullptr))
+	if (!X509_STORE_load_locations(m_X509Store.get(), certStore.data(), nullptr))
 	{
-		FreeX509Store(m_X509Store);
-		error("Could not load certificate store location");
+		error("Could not load certificate store location from %s", certStore.data());
 		return;
 	}
 }
 
-void TlsSocket::FreeX509Store(X509_STORE* store)
-{
-	X509_STORE_free(m_X509Store);
-	m_X509Store = nullptr;
-}
-
 void TlsSocket::Final()
 {
-
-	X509_STORE_free(m_X509Store);
-
-#ifndef LIBRESSL_VERSION_NUMBER
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
-	FIPS_mode_set(0);
-#else
-	EVP_default_properties_enable_fips(nullptr, 0);
-#endif
-#endif
-#ifdef NEED_CRYPTO_LOCKING
-	CRYPTO_set_locking_callback(nullptr);
-	CRYPTO_set_id_callback(nullptr);
-#endif
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	ERR_remove_state(0);
-#endif
-#if	OPENSSL_VERSION_NUMBER >= 0x10002000L && ! defined (LIBRESSL_VERSION_NUMBER)
-	SSL_COMP_free_compression_methods();
-#endif
-	//ENGINE_cleanup();
-	CONF_modules_free();
-	CONF_modules_unload(1);
-#ifndef OPENSSL_NO_COMP
-	COMP_zlib_cleanup();
-#endif
-	ERR_free_strings();
-	EVP_cleanup();
-	CRYPTO_cleanup_all_ex_data();
+	m_X509Store.reset();
+	OPENSSL_cleanup();
 }
 
 TlsSocket::~TlsSocket()
 {
 	Close();
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	ERR_remove_state(0);
-#endif
+	ERR_clear_error();
 }
 
 void TlsSocket::ReportError(const char* errMsg, bool suppressable)
 {
-	int errcode = ERR_get_error();
+	auto errcode = ERR_get_error();
 	do
 	{
 		char errstr[1024];
 		ERR_error_string_n(errcode, errstr, sizeof(errstr));
-		errstr[1024-1] = '\0';
+		errstr[1024 - 1] = '\0';
 
 		if (suppressable && m_suppressErrors)
 		{
@@ -220,7 +112,7 @@ void TlsSocket::PrintError(const char* errMsg)
 
 bool TlsSocket::Start()
 {
-	m_context = SSL_CTX_new(SSLv23_method());
+	m_context.reset(SSL_CTX_new(TLS_method()));
 
 	if (!m_context)
 	{
@@ -230,65 +122,35 @@ bool TlsSocket::Start()
 
 	if (!m_certFile.empty() && !m_keyFile.empty())
 	{
-		if (SSL_CTX_use_certificate_chain_file((SSL_CTX*)m_context, m_certFile.c_str()) != 1)
+		if (!SSL_CTX_use_certificate_chain_file(m_context.get(), m_certFile.c_str()))
 		{
 			ReportError("Could not load certificate file", false);
 			Close();
 			return false;
 		}
-		if (SSL_CTX_use_PrivateKey_file((SSL_CTX*)m_context, m_keyFile.c_str(), SSL_FILETYPE_PEM) != 1)
+		if (!SSL_CTX_use_PrivateKey_file(m_context.get(), m_keyFile.c_str(), SSL_FILETYPE_PEM))
 		{
 			ReportError("Could not load key file", false);
 			Close();
 			return false;
 		}
-		if (!SSL_CTX_set_options((SSL_CTX*)m_context, SSL_OP_NO_SSLv3))
-		{
-			ReportError("Could not select minimum protocol version for TLS", false);
-			Close();
-			return false;
-		}
-
-		// For ECC certificates
-		EC_KEY* ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
-		if (!ecdh)
-		{
-			ReportError("Could not generate ecdh parameters for TLS", false);
-			Close();
-			return false;
-		}
-		if (!SSL_CTX_set_tmp_ecdh((SSL_CTX*)m_context, ecdh))
-		{
-			ReportError("Could not set ecdh parameters for TLS", false);
-			EC_KEY_free(ecdh);
-			Close();
-			return false;
-		}
-		EC_KEY_free(ecdh);
 	}
 
-	if (m_isClient && !m_certStore.empty())
+	if (m_isClient && m_X509Store)
 	{
-		if (!m_X509Store)
-		{
-			error("Could not set certificate store location. Make sure the CertPath option is correct.");
-			Close();
-			return false;
-		}
-
-		SSL_CTX_set1_cert_store((SSL_CTX*)m_context, m_X509Store);
+		SSL_CTX_set1_cert_store(m_context.get(), m_X509Store.get());
 
 		if (m_certVerifLevel > Options::ECertVerifLevel::cvNone)
 		{
-			SSL_CTX_set_verify((SSL_CTX*)m_context, SSL_VERIFY_PEER, nullptr);
+			SSL_CTX_set_verify(m_context.get(), SSL_VERIFY_PEER, nullptr);
 		}
 		else
 		{
-			SSL_CTX_set_verify((SSL_CTX*)m_context, SSL_VERIFY_NONE, nullptr);
+			SSL_CTX_set_verify(m_context.get(), SSL_VERIFY_NONE, nullptr);
 		}
 	}
 
-	m_session = SSL_new((SSL_CTX*)m_context);
+	m_session.reset(SSL_new(m_context.get()));
 	if (!m_session)
 	{
 		ReportError("Could not create TLS session", false);
@@ -296,31 +158,37 @@ bool TlsSocket::Start()
 		return false;
 	}
 
-	if (!m_cipher.empty() && !SSL_set_cipher_list((SSL*)m_session, m_cipher.c_str()))
+	if (!m_cipher.empty() && !SSL_set_cipher_list(m_session.get(), m_cipher.c_str()))
 	{
 		ReportError("Could not select cipher for TLS", false);
 		Close();
 		return false;
 	}
 
-	if (m_isClient && !m_host.empty() && !SSL_set_tlsext_host_name((SSL*)m_session, m_host.c_str()))
+	if (m_isClient && !m_host.empty() && !SSL_set_tlsext_host_name(m_session.get(), m_host.c_str()))
 	{
 		ReportError("Could not set host name for TLS");
 		Close();
 		return false;
 	}
 
-	if (!SSL_set_fd((SSL*)m_session, (int)m_socket))
+	if (!SSL_set_fd(m_session.get(), static_cast<int>(m_socket)))
 	{
 		ReportError("Could not set the file descriptor for TLS");
 		Close();
 		return false;
 	}
 
-	int error_code = m_isClient ? SSL_connect((SSL*)m_session) : SSL_accept((SSL*)m_session);
+	if (!SSL_CTX_set_min_proto_version(m_context.get(), SSL3_VERSION))
+	{
+		ReportError("Could not set minimum protocol to SSL3", false);
+		return false;
+	}
+
+	int error_code = m_isClient ? SSL_connect(m_session.get()) : SSL_accept(m_session.get());
 	if (error_code < 1 && m_certVerifLevel > Options::ECertVerifLevel::cvNone)
 	{
-		long verifyRes = SSL_get_verify_result((SSL*)m_session);
+		long verifyRes = SSL_get_verify_result(m_session.get());
 		if (verifyRes != X509_V_OK)
 		{
 			PrintError(BString<1024>("TLS certificate verification failed for %s: %s."
@@ -335,7 +203,7 @@ bool TlsSocket::Start()
 		return false;
 	}
 
-	if (m_isClient && !m_certStore.empty() && !ValidateCert())
+	if (m_isClient && m_X509Store && !ValidateCert())
 	{
 		Close();
 		return false;
@@ -348,7 +216,7 @@ bool TlsSocket::Start()
 bool TlsSocket::ValidateCert()
 {
 	// verify a server certificate was presented during the negotiation
-	X509* cert = SSL_get_peer_certificate((SSL*)m_session);
+	OpenSSL::X509Ptr cert{ SSL_get_peer_certificate(m_session.get()), &X509_free };
 	if (!cert)
 	{
 		PrintError(BString<1024>("TLS certificate verification failed for %s: no certificate provided by server."
@@ -358,65 +226,53 @@ bool TlsSocket::ValidateCert()
 
 #ifdef HAVE_X509_CHECK_HOST
 	// hostname verification
-	if (m_certVerifLevel > Options::ECertVerifLevel::cvMinimal && !m_host.empty() && X509_check_host(cert, m_host.c_str(), m_host.size(), 0, nullptr) != 1)
+	if (m_certVerifLevel > Options::ECertVerifLevel::cvMinimal && !m_host.empty() && !X509_check_host(cert.get(), m_host.c_str(), m_host.size(), 0, nullptr))
 	{
 		const unsigned char* certHost = nullptr;
         // Find the position of the CN field in the Subject field of the certificate
-        int common_name_loc = X509_NAME_get_index_by_NID(X509_get_subject_name(cert), NID_commonName, -1);
+        int common_name_loc = X509_NAME_get_index_by_NID(X509_get_subject_name(cert.get()), NID_commonName, -1);
         if (common_name_loc >= 0)
 		{
 			// Extract the CN field
-			X509_NAME_ENTRY* common_name_entry = X509_NAME_get_entry(X509_get_subject_name(cert), common_name_loc);
+			X509_NAME_ENTRY* common_name_entry = X509_NAME_get_entry(X509_get_subject_name(cert.get()), common_name_loc);
 			if (common_name_entry != nullptr)
 			{
 				// Convert the CN field to a C string
 				ASN1_STRING* common_name_asn1 = X509_NAME_ENTRY_get_data(common_name_entry);
 				if (common_name_asn1 != nullptr)
 				{
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 					certHost = ASN1_STRING_get0_data(common_name_asn1);
-#else
-					certHost = ASN1_STRING_data(common_name_asn1);
-#endif
 				}
 			}
         }
 
 		PrintError(BString<1024>("TLS certificate verification failed for %s: certificate hostname mismatch (%s)."
 			" For more info visit https://nzbget.com/documentation/certificate-verification/", m_host.c_str(), certHost));
-		X509_free(cert);
 		return false;
 	}
 #endif
 
-	X509_free(cert);
 	return true;
 }
 
 void TlsSocket::Close()
 {
-	if (m_session)
+	if (m_session && m_connected)
 	{
-		if (m_connected)
+		if (SSL_shutdown(m_session.get()) == 0)
 		{
-			SSL_shutdown((SSL*)m_session);
+			// The bidirectional shutdown is not yet complete. Call SSL_shutdown again.
+			SSL_shutdown(m_session.get());
 		}
-		SSL_free((SSL*)m_session);
-
-		m_session = nullptr;
 	}
 
-	if (m_context)
-	{
-		SSL_CTX_free((SSL_CTX*)m_context);
-
-		m_context = nullptr;
-	}
+	m_context.reset();
+	m_session.reset();
 }
 
 int TlsSocket::Send(const char* buffer, int size)
 {
-	m_retCode = SSL_write((SSL*)m_session, buffer, size);
+	m_retCode = SSL_write(m_session.get(), buffer, size);
 
 	if (m_retCode < 0)
 	{
@@ -434,7 +290,7 @@ int TlsSocket::Send(const char* buffer, int size)
 
 int TlsSocket::Recv(char* buffer, int size)
 {
-	m_retCode = SSL_read((SSL*)m_session, buffer, size);
+	m_retCode = SSL_read(m_session.get(), buffer, size);
 
 	if (m_retCode < 0)
 	{

--- a/daemon/main/nzbget.h
+++ b/daemon/main/nzbget.h
@@ -187,13 +187,7 @@
 #include <boost/asio.hpp>
 #ifndef DISABLE_TLS
 #include <boost/asio/ssl.hpp>
-#include <openssl/ssl.h>
-#include <openssl/err.h>
-#include <openssl/rsa.h>
-#include <openssl/sha.h>
-#include <openssl/pem.h>
-#include <openssl/x509v3.h>
-#include <openssl/comp.h>
+#include "OpenSSL.h"
 #endif
 
 // NOTE: do not include <iostream> in "nzbget.h". <iostream> contains objects requiring

--- a/daemon/nntp/ArticleDownloader.cpp
+++ b/daemon/nntp/ArticleDownloader.cpp
@@ -41,6 +41,10 @@ ArticleDownloader::ArticleDownloader()
 ArticleDownloader::~ArticleDownloader()
 {
 	debug("Destroying ArticleDownloader");
+
+#ifndef DISABLE_TLS
+	OpenSSL::StopSSLThread();
+#endif
 }
 
 void ArticleDownloader::SetInfoName(const char* infoName)

--- a/daemon/nntp/ArticleDownloader.h
+++ b/daemon/nntp/ArticleDownloader.h
@@ -41,7 +41,7 @@ public:
 	virtual void Append(const void* buffer, int len) = 0;
 };
 
-class ArticleDownloader : public Thread, public Subject
+class ArticleDownloader final : public Thread, public Subject
 {
 public:
 	enum EStatus
@@ -66,8 +66,8 @@ public:
 	ArticleInfo* GetArticleInfo() { return m_articleInfo; }
 	EStatus GetStatus() { return m_status; }
 	ServerStatList* GetServerStats() { return &m_serverStats; }
-	virtual void Run();
-	virtual void Stop();
+	void Run() override;
+	void Stop() override;
 	time_t GetLastUpdateTime() { return m_lastUpdateTime; }
 	void SetLastUpdateTimeNow();
 	const char* GetArticleFilename() { return m_articleFilename; }

--- a/daemon/nserv/NntpServer.cpp
+++ b/daemon/nserv/NntpServer.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2016-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -24,6 +25,10 @@
 #include "Util.h"
 #include "YEncoder.h"
 
+#ifndef DISABLE_TLS
+#include "OpenSSL.h"
+#endif
+
 class NntpProcessor : public Thread
 {
 public:
@@ -32,8 +37,15 @@ public:
 		m_id(id), m_serverId(serverId), m_dataDir(dataDir), m_cacheDir(cacheDir),
 		m_secureCert(secureCert), m_secureKey(secureKey), m_latency(latency),
 		m_speed(speed), m_cache(cache) {}
-	~NntpProcessor() { m_connection->Disconnect(); }
-	virtual void Run();
+	~NntpProcessor()
+	{
+		m_connection->Disconnect();
+
+#ifndef DISABLE_TLS
+		OpenSSL::StopSSLThread();
+#endif
+	}
+	void Run() override;
 	void SetConnection(std::unique_ptr<Connection>&& connection) { m_connection = std::move(connection); }
 
 private:

--- a/daemon/postprocess/RarRenamer.h
+++ b/daemon/postprocess/RarRenamer.h
@@ -57,7 +57,6 @@ private:
 	CString m_destDir;
 	CString m_progressLabel;
 	int m_stageProgress = 0;
-	bool m_cancelled = false;
 	DirList m_dirList;
 	int m_fileCount = 0;
 	int m_curFile = 0;

--- a/daemon/postprocess/Unpack.cpp
+++ b/daemon/postprocess/Unpack.cpp
@@ -27,6 +27,13 @@
 #include "ParParser.h"
 #include "Options.h"
 
+UnpackController::~UnpackController()
+{
+#ifndef DISABLE_TLS
+	OpenSSL::StopSSLThread();
+#endif
+}
+
 bool UnpackController::FileList::Exists(const char* filename)
 {
 	return std::find(begin(), end(), filename) != end();

--- a/daemon/postprocess/Unpack.h
+++ b/daemon/postprocess/Unpack.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2013-2018 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -26,18 +27,20 @@
 #include "DownloadInfo.h"
 #include "ScriptController.h"
 
-class UnpackController : public Thread, public ScriptController
+class UnpackController final : public Thread, public ScriptController
 {
 public:
-	virtual void Run();
-	virtual void Stop();
+	void Run() override;
+	void Stop() override;
 	static void StartJob(PostInfo* postInfo);
 	static bool HasCompletedArchiveFiles(NzbInfo* nzbInfo);
 	static const char* DecodeSevenZipExitCode(int ec);
 
+	~UnpackController();
+
 protected:
-	virtual bool ReadLine(char* buf, int bufSize, FILE* stream);
-	virtual void AddMessage(Message::EKind kind, const char* text);
+	bool ReadLine(char* buf, int bufSize, FILE* stream) override;
+	void AddMessage(Message::EKind kind, const char* text) override;
 
 private:
 	enum EUnpacker

--- a/daemon/remote/RemoteServer.cpp
+++ b/daemon/remote/RemoteServer.cpp
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 2005 Bo Cordes Petersen <placebodk@sourceforge.net>
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -29,6 +30,13 @@
 
 //*****************************************************************
 // RemoteServer
+
+RemoteServer::~RemoteServer()
+{
+#ifndef DISABLE_TLS
+	OpenSSL::StopSSLThread();
+#endif
+}
 
 void RemoteServer::Run()
 {
@@ -166,6 +174,10 @@ void RemoteServer::Update(Subject* caller, void* aspect)
 RequestProcessor::~RequestProcessor()
 {
 	m_connection->Disconnect();
+
+#ifndef DISABLE_TLS
+	OpenSSL::StopSSLThread();
+#endif
 }
 
 void RequestProcessor::Run()

--- a/daemon/remote/RemoteServer.h
+++ b/daemon/remote/RemoteServer.h
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 2005 Bo Cordes Petersen <placebodk@users.sourceforge.net>
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -32,8 +33,9 @@ class RemoteServer : public Thread, public Observer
 {
 public:
 	RemoteServer(bool tls) : m_tls(tls) {}
-	virtual void Run();
-	virtual void Stop();
+	~RemoteServer();
+	void Run() override;
+	void Stop() override;
 	void ForceStop();
 	void Update(Subject* caller, void* aspect);
 
@@ -50,8 +52,8 @@ class RequestProcessor : public Thread, public Subject
 {
 public:
 	~RequestProcessor();
-	virtual void Run();
-	virtual void Stop();
+	void Run() override;
+	void Stop() override;
 	void SetTls(bool tls) { m_tls = tls; }
 	void SetConnection(std::unique_ptr<Connection>&& connection) { m_connection = std::move(connection); }
 

--- a/daemon/sources.cmake
+++ b/daemon/sources.cmake
@@ -98,6 +98,7 @@ set(SRC
 	${CMAKE_SOURCE_DIR}/daemon/util/Xml.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/Benchmark.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/DataAnalytics.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/OpenSSL.cpp
 
 	${CMAKE_SOURCE_DIR}/daemon/system/SystemInfo.cpp
 	${CMAKE_SOURCE_DIR}/daemon/system/OS.cpp

--- a/daemon/util/OpenSSL.cpp
+++ b/daemon/util/OpenSSL.cpp
@@ -1,0 +1,37 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "nzbget.h"
+
+#ifndef DISABLE_TLS
+
+namespace OpenSSL
+{
+	void StopSSLThread()
+	{
+#ifndef LIBRESSL_VERSION_NUMBER
+		// OpenSSL specific: cleanly shut down OpenSSL's thread handling.
+		// LibreSSL doesn't require or provide OPENSSL_thread_stop().
+		OPENSSL_thread_stop();
+#endif
+	}
+}
+
+#endif

--- a/daemon/util/OpenSSL.h
+++ b/daemon/util/OpenSSL.h
@@ -1,0 +1,41 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENSSL_H
+#define OPENSSL_H
+
+#include <memory>
+#include <openssl/ssl.h>
+#include <openssl/ec.h>
+#include <openssl/x509v3.h>
+
+namespace OpenSSL
+{
+	using X509StorePtr = std::unique_ptr<X509_STORE, decltype(&X509_STORE_free)>;
+	using X509Ptr = std::unique_ptr<X509, decltype(&X509_free)>;
+	using EVPMdCtxPtr = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
+	using EVPCipherCtxPtr = std::unique_ptr<EVP_CIPHER_CTX, decltype(&EVP_CIPHER_CTX_free)>;
+	using SSLCtxPtr = std::unique_ptr<SSL_CTX, decltype(&SSL_CTX_free)>;
+	using SSLSessionPtr = std::unique_ptr<SSL, decltype(&SSL_free)>;
+
+	void StopSSLThread();
+}
+
+#endif

--- a/docs/POSIX.md
+++ b/docs/POSIX.md
@@ -132,7 +132,7 @@ cmake .. -DDISABLE_CURSES=ON
 ```bash
 cmake .. -DDISABLE_PARCHECK=ON
 ```
-  - Disable TLS. Use this option if you cannot use OpenSSL:
+  - **[Deprecated]** Disable TLS. Use this option if you cannot use OpenSSL:
 ```bash
 cmake .. -DDISABLE_TLS=ON
 ```

--- a/tests/extension/CMakeLists.txt
+++ b/tests/extension/CMakeLists.txt
@@ -25,6 +25,7 @@ set(ExtensionSrc
 	${CMAKE_SOURCE_DIR}/daemon/util/ScriptController.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Thread.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Observer.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/OpenSSL.cpp
 	${CMAKE_SOURCE_DIR}/daemon/postprocess/Unpack.cpp
 	${CMAKE_SOURCE_DIR}/daemon/postprocess/ParParser.cpp
 	${CMAKE_SOURCE_DIR}/daemon/connect/WebDownloader.cpp

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -16,7 +16,8 @@ set(SystemTestsSrc
 	${CMAKE_SOURCE_DIR}/daemon/util/Util.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Json.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Xml.cpp 
-	${CMAKE_SOURCE_DIR}/daemon/util/Log.cpp 
+	${CMAKE_SOURCE_DIR}/daemon/util/Log.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/OpenSSL.cpp
 )
 
 if(WIN32)


### PR DESCRIPTION
## Description

- Fixed memory leaks caused by unreleased per-thread OpenSSL resources.
- Security Improvement: Migrated from `SSLv23_method()` to `TLS_method()` to mitigate known vulnerabilities associated with older SSL/TLS protocols and enforce the use of modern, secure TLS protocols supported.
- Updated OpenSSL API usage to remove deprecated functions and improve compatibility.
- Resolved compiler warnings for cleaner and more maintainable code.
- Deprecated building the app without TLS support (to be removed in future releases).
- Refactored code to use `std::string` instead of `CString` for improved string handling.

## Testing

- macOS Ventura amd64 OpenSSL 3.4.1 / 1.1.1
- Windows 7 amd64 OpenSSL 3.4.1
- Windows 11 amd64 OpenSSL 3.4.1
- Linux Debian 12 amd64 OpenSSL 3.4.1
- FreeBSD 13 amd64 OpenSSL 3.4.1