### PR TITLE
Hardlinking while direct rename

### DIFF
--- a/daemon/nntp/ArticleWriter.cpp
+++ b/daemon/nntp/ArticleWriter.cpp
@@ -583,6 +583,20 @@ void ArticleWriter::CompleteFileParts()
 		GuardedDownloadQueue guard = DownloadQueue::Guard();
 		m_fileInfo->SetCrc(crc);
 
+		if (m_fileInfo->IsHardLinked())
+		{
+			// No need to rename, remove hardlink of .out.tmp-file
+			if (FileSystem::DeleteFile(m_outputFilename.c_str()))
+			{
+				m_fileInfo->SetOutputFilename(nullptr);
+				return;
+			}
+			else
+			{
+				m_fileInfo->GetNzbInfo()->PrintMessage(Message::mkError, "Cannot remove hardlink");
+			}
+		}
+
 		RenameOutputFile(filename, destDir);
 	}
 }

--- a/daemon/queue/DownloadInfo.cpp
+++ b/daemon/queue/DownloadInfo.cpp
@@ -838,6 +838,11 @@ void FileInfo::SetActiveDownloads(int activeDownloads)
 	}
 }
 
+bool FileInfo::IsHardLinked()
+{
+	return !m_hardLinkPath.empty();
+}
+
 
 CompletedFile::CompletedFile(int id, std::string filename, std::string origname, EStatus status,
 	uint32 crc, bool parFile, std::string hash16k, std::string parSetId) 

--- a/daemon/queue/DownloadInfo.h
+++ b/daemon/queue/DownloadInfo.h
@@ -205,6 +205,9 @@ public:
 	void SetParSetId(const char* parSetId) { m_parSetId = parSetId; }
 	bool GetFlushLocked() { return m_flushLocked; }
 	void SetFlushLocked(bool flushLocked) { m_flushLocked = flushLocked; }
+	std::string GetHardLinkPath() { return m_hardLinkPath; }
+	void SetHardLinkPath(std::string hardLinkPath) { m_hardLinkPath = hardLinkPath; }
+	bool IsHardLinked();
 
 	ServerStatList* GetServerStats() { return &m_serverStats; }
 
@@ -246,6 +249,7 @@ private:
 	CString m_hash16k;
 	CString m_parSetId;
 	bool m_flushLocked = false;
+	std::string m_hardLinkPath;
 
 	static int m_idGen;
 	static int m_idMax;

--- a/daemon/queue/QueueCoordinator.cpp
+++ b/daemon/queue/QueueCoordinator.cpp
@@ -918,6 +918,10 @@ void QueueCoordinator::DiscardTempFiles(FileInfo* fileInfo)
 	if (g_Options->GetDirectWrite() && !outputFilename.empty() && !fileInfo->GetForceDirectWrite())
 	{
 		FileSystem::DeleteFile(outputFilename.c_str());
+		if (fileInfo->IsHardLinked())
+		{
+			FileSystem::DeleteFile(fileInfo->GetHardLinkPath().c_str());
+		}
 	}
 }
 

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -67,6 +67,7 @@ public:
 
 	static bool DeleteDirectoryWithContent(const char* dirFilename, CString& errmsg);
 	static bool ForceDirectories(const char* path, CString& errmsg);
+	static bool CreateHardLink(const char *from, const char *to);
 	static CString GetCurrentDirectory();
 	static bool SetCurrentDirectory(const char* dirFilename);
 	static int64 FileSize(const char* filename);


### PR DESCRIPTION
## Description

Direct rename does not rename in-progress (.out.tmp) files. One solution is to create hardlinks to the .out.tmp-files.
The resulting file structure can then be used with streaming software, like jellyfin or plex.