### PR TITLE
Add: Automatic category detection from NZB file metadata

### DIFF
--- a/daemon/extension/ScanScript.h
+++ b/daemon/extension/ScanScript.h
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -28,28 +28,28 @@ class ScanScriptController : public NzbScriptController
 {
 public:
 	static void ExecuteScripts(const char* nzbFilename, NzbInfo* nzbInfo,
-		const char* directory, CString* nzbName, CString* category, int* priority,
+		const char* directory, const char* nzbName, const char* category, int* priority,
 		NzbParameterList* parameters, bool* addTop, bool* addPaused,
-		CString* dupeKey, int* dupeScore, EDupeMode* dupeMode);
+		const char* dupeKey, int* dupeScore, EDupeMode* dupeMode);
 	static bool HasScripts();
 
 protected:
-	virtual void ExecuteScript(std::shared_ptr<const Extension::Script> script);
-	virtual void AddMessage(Message::EKind kind, const char* text);
+	void ExecuteScript(std::shared_ptr<const Extension::Script> script) override;
+	void AddMessage(Message::EKind kind, const char* text) override;
 
 private:
 	const char* m_nzbFilename;
 	const char* m_url;
 	const char* m_directory;
-	CString* m_nzbName;
-	CString* m_category;
+	std::string m_nzbName;
+	std::string m_category;
+	std::string m_dupeKey;
 	int* m_priority;
-	NzbParameterList* m_parameters;
+	int* m_dupeScore;
 	bool* m_addTop;
 	bool* m_addPaused;
-	CString* m_dupeKey;
-	int* m_dupeScore;
 	EDupeMode* m_dupeMode;
+	NzbParameterList* m_parameters;
 	int m_prefixLen;
 
 	void PrepareParams(const char* scriptName);

--- a/daemon/feed/FeedCoordinator.cpp
+++ b/daemon/feed/FeedCoordinator.cpp
@@ -493,19 +493,19 @@ std::shared_ptr<FeedItemList> FeedCoordinator::ViewFeed(int id)
 	std::unique_ptr<FeedInfo>& feedInfo = m_feeds[id - 1];
 
 	return PreviewFeed(feedInfo->GetId(), feedInfo->GetName(), feedInfo->GetUrl(), feedInfo->GetFilter(),
-		feedInfo->GetBacklog(), feedInfo->GetPauseNzb(), feedInfo->GetCategory(),
+		feedInfo->GetBacklog(), feedInfo->GetPauseNzb(), feedInfo->GetCategory(), feedInfo->GetCategorySource(),
 		feedInfo->GetPriority(), feedInfo->GetInterval(), feedInfo->GetExtensions(), 0, nullptr);
 }
 
 std::shared_ptr<FeedItemList> FeedCoordinator::PreviewFeed(int id,
 	const char* name, const char* url, const char* filter, bool backlog, bool pauseNzb,
-	const char* category, int priority, int interval, const char* feedScript,
+	const char* category, FeedInfo::CategorySource categorySource, int priority, int interval, const char* feedScript,
 	int cacheTimeSec, const char* cacheId)
 {
 	debug("Preview feed %s", name);
 
 	std::unique_ptr<FeedInfo> feedInfo = std::make_unique<FeedInfo>(id, name, url, backlog, interval,
-		filter, pauseNzb, category, priority, feedScript);
+		filter, pauseNzb, category, categorySource, priority, feedScript);
 	feedInfo->SetPreview(true);
 
 	std::shared_ptr<FeedItemList> feedItems;

--- a/daemon/feed/FeedCoordinator.cpp
+++ b/daemon/feed/FeedCoordinator.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2013-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  * 
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -470,7 +470,7 @@ std::unique_ptr<NzbInfo> FeedCoordinator::CreateNzbInfo(FeedInfo* feedInfo, Feed
 		nzbInfo->SetFilename(FileSystem::MakeValidFilename(nzbName2));
 	}
 
-	nzbInfo->SetCategory(feedItemInfo.GetAddCategory());
+	nzbInfo->SetCategory(feedItemInfo.GetCategory());
 	nzbInfo->SetPriority(feedItemInfo.GetPriority());
 	nzbInfo->SetAddUrlPaused(feedItemInfo.GetPauseNzb());
 	nzbInfo->SetDupeKey(feedItemInfo.GetDupeKey());

--- a/daemon/feed/FeedCoordinator.cpp
+++ b/daemon/feed/FeedCoordinator.cpp
@@ -470,7 +470,21 @@ std::unique_ptr<NzbInfo> FeedCoordinator::CreateNzbInfo(FeedInfo* feedInfo, Feed
 		nzbInfo->SetFilename(FileSystem::MakeValidFilename(nzbName2));
 	}
 
-	nzbInfo->SetCategory(feedItemInfo.GetCategory());
+	const char* category = feedItemInfo.GetCategory();
+	if (feedInfo->GetCategorySource() == FeedInfo::CategorySource::FeedFile)
+	{
+		nzbInfo->SetCategory(category);
+	}
+	else if (feedInfo->GetCategorySource() == FeedInfo::CategorySource::NZBFile)
+	{
+		nzbInfo->SetAutoCategory(true);
+	}
+	else if (feedInfo->GetCategorySource() == FeedInfo::CategorySource::Auto)
+	{
+		nzbInfo->SetCategory(category);
+		nzbInfo->SetAutoCategory(true);
+	}
+	
 	nzbInfo->SetPriority(feedItemInfo.GetPriority());
 	nzbInfo->SetAddUrlPaused(feedItemInfo.GetPauseNzb());
 	nzbInfo->SetDupeKey(feedItemInfo.GetDupeKey());

--- a/daemon/feed/FeedCoordinator.h
+++ b/daemon/feed/FeedCoordinator.h
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2013-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -48,7 +48,7 @@ public:
 
 	/* may return empty pointer on error */
 	std::shared_ptr<FeedItemList> PreviewFeed(int id, const char* name, const char* url,
-		const char* filter, bool backlog, bool pauseNzb, const char* category, int priority,
+		const char* filter, bool backlog, bool pauseNzb, const char* category, FeedInfo::CategorySource categorySource, int priority,
 		int interval, const char* feedScript, int cacheTimeSec, const char* cacheId);
 
 	/* may return empty pointer on error */

--- a/daemon/feed/FeedInfo.cpp
+++ b/daemon/feed/FeedInfo.cpp
@@ -32,6 +32,7 @@ FeedInfo::FeedInfo(
 	const char* filter,
 	bool pauseNzb,
 	const char* category,
+	FeedInfo::CategorySource categorySource,
 	int priority,
 	const char* extensions
 )
@@ -40,6 +41,7 @@ FeedInfo::FeedInfo(
 	, m_url{ url ? url : "" }
 	, m_filter{ filter ? filter : "" }
 	, m_category{ category ? category : "" }
+	, m_categorySource{ categorySource }
 	, m_extensions{ extensions ? extensions : "" }
 	, m_backlog{ backlog}
 	, m_interval{ interval }

--- a/daemon/feed/FeedInfo.h
+++ b/daemon/feed/FeedInfo.h
@@ -160,7 +160,13 @@ public:
 	void SetUrl(const char* url) { m_url = url ? url : ""; }
 	int64 GetSize() { return m_size; }
 	void SetSize(int64 size) { m_size = size; }
-	const char* GetCategory() const { return m_category.c_str(); }
+	const char* GetCategory() const
+	{
+		if (!m_addCategory.empty())
+			return m_addCategory.c_str();
+
+		return m_category.c_str();
+	}
 	void SetCategory(const char* category) { m_category = category ? category : ""; }
 	int GetImdbId() { return m_imdbId; }
 	void SetImdbId(int imdbId) { m_imdbId = imdbId; }

--- a/daemon/feed/FeedInfo.h
+++ b/daemon/feed/FeedInfo.h
@@ -37,6 +37,14 @@ public:
 		fsFailed
 	};
 
+	/*
+	 *	Auto     - Try to retrieve the category from the NZB file first. If not found,
+	 *           try the feed file.
+	 *	NzbFile  - Always retrieve the category from the NZB file. If not found, the
+	 *           category is left empty.
+	 *	FeedFile - Always retrieve the category from the feed file. If not found, the
+	 *          category is left empty.
+	 */
 	enum class CategorySource
 	{
 		Auto,

--- a/daemon/feed/FeedInfo.h
+++ b/daemon/feed/FeedInfo.h
@@ -37,6 +37,13 @@ public:
 		fsFailed
 	};
 
+	enum class CategorySource
+	{
+		Auto,
+		NZBFile,
+		FeedFile
+	};
+
 	FeedInfo(
 		int id,
 		const char* name,
@@ -46,6 +53,7 @@ public:
 		const char* filter,
 		bool pauseNzb,
 		const char* category,
+		CategorySource categorySource,
 		int priority,
 		const char* extensions
 	);
@@ -77,6 +85,8 @@ public:
 	void SetForce(bool force) { m_force = force; }
 	bool GetBacklog() { return m_backlog; }
 	void SetBacklog(bool backlog) { m_backlog = backlog; }
+	CategorySource GetCategorySource() { return m_categorySource; }
+	void SetCategorySource(CategorySource categorySource) { m_categorySource = categorySource; }
 
 private:
 	int m_id;
@@ -90,6 +100,7 @@ private:
 	time_t m_nextUpdate = 0;
 	uint32 m_filterHash;
 	EStatus m_status = fsUndefined;
+	CategorySource m_categorySource = CategorySource::NZBFile;
 	int m_interval;
 	int m_priority;
 	int m_lastInterval = 0;

--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -3,7 +3,7 @@
  *
  *  Copyright (C) 2004 Sven Henkel <sidddy@users.sourceforge.net>
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -1174,6 +1174,24 @@ void Options::InitFeeds()
 			pauseNzb = (bool)ParseEnumValue(BString<100>("Feed%i.PauseNzb", n), BoolCount, BoolNames, BoolValues);
 		}
 
+		const char* ncategorySource = GetOption(BString<100>("Feed%i.CategorySource", n));
+		auto categorySource = FeedInfo::CategorySource::NZBFile;
+		if (ncategorySource)
+		{
+			if (strncasecmp(ncategorySource, "auto", 5))
+			{
+				categorySource = FeedInfo::CategorySource::Auto;
+			}
+			else if (strncasecmp(ncategorySource, "nzbfile", 8))
+			{
+				categorySource = FeedInfo::CategorySource::NZBFile;
+			}
+			else if (strncasecmp(ncategorySource, "feedfile", 9))
+			{
+				categorySource = FeedInfo::CategorySource::FeedFile;
+			}
+		}
+
 		const char* ninterval = GetOption(BString<100>("Feed%i.Interval", n));
 		const char* npriority = GetOption(BString<100>("Feed%i.Priority", n));
 
@@ -1190,8 +1208,19 @@ void Options::InitFeeds()
 		{
 			if (m_extender)
 			{
-				m_extender->AddFeed(n, nname, nurl, ninterval ? atoi(ninterval) : 0, nfilter,
-					backlog, pauseNzb, ncategory, npriority ? atoi(npriority) : 0, nextensions);
+				m_extender->AddFeed(
+					n,
+					nname,
+					nurl,
+					ninterval ? atoi(ninterval) : 0,
+					nfilter,
+					backlog,
+					pauseNzb,
+					ncategory,
+					categorySource,
+					npriority ? atoi(npriority) : 0,
+					nextensions
+				);
 			}
 		}
 		else

--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -1178,15 +1178,15 @@ void Options::InitFeeds()
 		auto categorySource = FeedInfo::CategorySource::NZBFile;
 		if (ncategorySource)
 		{
-			if (strncasecmp(ncategorySource, "auto", 5))
+			if (!strncasecmp(ncategorySource, "auto", 5))
 			{
 				categorySource = FeedInfo::CategorySource::Auto;
 			}
-			else if (strncasecmp(ncategorySource, "nzbfile", 8))
+			else if (!strncasecmp(ncategorySource, "nzbfile", 8))
 			{
 				categorySource = FeedInfo::CategorySource::NZBFile;
 			}
-			else if (strncasecmp(ncategorySource, "feedfile", 9))
+			else if (!strncasecmp(ncategorySource, "feedfile", 9))
 			{
 				categorySource = FeedInfo::CategorySource::FeedFile;
 			}
@@ -1638,7 +1638,8 @@ bool Options::ValidateOptionName(const char* optname, const char* optvalue)
 		while (*p >= '0' && *p <= '9') p++;
 		if (p && (!strcasecmp(p, ".name") || !strcasecmp(p, ".url") || !strcasecmp(p, ".interval") ||
 			 !strcasecmp(p, ".filter") || !strcasecmp(p, ".backlog") || !strcasecmp(p, ".pausenzb") ||
-			 !strcasecmp(p, ".category") || !strcasecmp(p, ".priority") || !strcasecmp(p, ".extensions")))
+			 !strcasecmp(p, ".category") || !strcasecmp(p, ".categorySource") || !strcasecmp(p, ".priority") || 
+			 !strcasecmp(p, ".extensions")))
 		{
 			return true;
 		}

--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -1175,22 +1175,7 @@ void Options::InitFeeds()
 		}
 
 		const char* ncategorySource = GetOption(BString<100>("Feed%i.CategorySource", n));
-		auto categorySource = FeedInfo::CategorySource::NZBFile;
-		if (ncategorySource)
-		{
-			if (!strncasecmp(ncategorySource, "auto", 5))
-			{
-				categorySource = FeedInfo::CategorySource::Auto;
-			}
-			else if (!strncasecmp(ncategorySource, "nzbfile", 8))
-			{
-				categorySource = FeedInfo::CategorySource::NZBFile;
-			}
-			else if (!strncasecmp(ncategorySource, "feedfile", 9))
-			{
-				categorySource = FeedInfo::CategorySource::FeedFile;
-			}
-		}
+		const auto categorySource = ParseCategorySource(ncategorySource);
 
 		const char* ninterval = GetOption(BString<100>("Feed%i.Interval", n));
 		const char* npriority = GetOption(BString<100>("Feed%i.Priority", n));
@@ -1991,4 +1976,29 @@ bool Options::HasScript(const char* scriptList, const char* scriptName)
 		}
 	}
 	return false;
+}
+
+FeedInfo::CategorySource Options::ParseCategorySource(const char* value)
+{
+	if (!value)
+	{
+		return FeedInfo::CategorySource::NZBFile;
+	}
+
+	if (!strncasecmp(value, "auto", 4))
+	{
+		return FeedInfo::CategorySource::Auto;
+	}
+	else if (!strncasecmp(value, "nzbfile", 8))
+	{
+		return FeedInfo::CategorySource::NZBFile;
+	}
+	else if (!strncasecmp(value, "feedfile", 9))
+	{
+		return FeedInfo::CategorySource::FeedFile;
+	}
+	else
+	{
+		return FeedInfo::CategorySource::NZBFile;
+	}
 }

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -483,6 +483,7 @@ private:
 	void CheckOptions();
 	int ParseEnumValue(const char* OptName, int argc, const char* argn[], const int argv[]);
 	int ParseIntValue(const char* OptName, int base);
+	FeedInfo::CategorySource ParseCategorySource(const char* value);
 	OptEntry* FindOption(const char* optname);
 	const char* GetOption(const char* optname);
 	void SetOption(const char* optname, const char* value);

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -26,6 +26,7 @@
 #include "NString.h"
 #include "Thread.h"
 #include "Util.h"
+#include "FeedInfo.h"
 
 class Options
 {
@@ -178,11 +179,19 @@ public:
 			int port, int ipVersion, const char* user, const char* pass, bool joinGroup,
 			bool tls, const char* cipher, int maxConnections, int retention,
 			int level, int group, bool optional, unsigned int certVerificationfLevel) = 0;
-		virtual void AddFeed([[maybe_unused]] int id, [[maybe_unused]] const char* name,
-			[[maybe_unused]] const char* url, [[maybe_unused]] int interval,
-			[[maybe_unused]] const char* filter, [[maybe_unused]] bool backlog,
-			[[maybe_unused]] bool pauseNzb, [[maybe_unused]] const char* category,
-			[[maybe_unused]] int priority, [[maybe_unused]] const char* extensions) {}
+		virtual void AddFeed(
+			[[maybe_unused]] int id,
+			[[maybe_unused]] const char* name,
+			[[maybe_unused]] const char* url,
+			[[maybe_unused]] int interval,
+			[[maybe_unused]] const char* filter,
+			[[maybe_unused]] bool backlog,
+			[[maybe_unused]] bool pauseNzb,
+			[[maybe_unused]] const char* category,
+			[[maybe_unused]] FeedInfo::CategorySource categorySource,
+			[[maybe_unused]] int priority,
+			[[maybe_unused]] const char* extensions
+		) { }
 		virtual void AddTask([[maybe_unused]] int id, [[maybe_unused]] int hours, [[maybe_unused]] int minutes,
 			[[maybe_unused]] int weekDaysBits, [[maybe_unused]] ESchedulerCommand command,
 			[[maybe_unused]] const char* param) {}

--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -3,7 +3,7 @@
  *
  *  Copyright (C) 2004 Sven Henkel <sidddy@users.sourceforge.net>
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -180,15 +180,15 @@ public:
 	bool GetReloading() { return m_reloading; }
 
 	// Options::Extender
-	virtual void AddNewsServer(int id, bool active, const char* name, const char* host,
+	void AddNewsServer(int id, bool active, const char* name, const char* host,
 		int port, int ipVersion, const char* user, const char* pass, bool joinGroup,
 		bool tls, const char* cipher, int maxConnections, int retention,
-		int level, int group, bool optional, unsigned int certVerificationfLevel);
-	virtual void AddFeed(int id, const char* name, const char* url, int interval,
+		int level, int group, bool optional, unsigned int certVerificationfLevel) override;
+	void AddFeed(int id, const char* name, const char* url, int interval,
 		const char* filter, bool backlog, bool pauseNzb, const char* category,
-		int priority, const char* feedScript);
-	virtual void AddTask(int id, int hours, int minutes, int weekDaysBits,
-		Options::ESchedulerCommand command, const char* param);
+		FeedInfo::CategorySource categorySource, int priority, const char* feedScript) override;
+	void AddTask(int id, int hours, int minutes, int weekDaysBits,
+		Options::ESchedulerCommand command, const char* param) override;
 #ifdef WIN32
 	virtual void SetupFirstStart();
 #endif
@@ -1073,10 +1073,10 @@ void NZBGet::AddNewsServer(int id, bool active, const char* name, const char* ho
 }
 
 void NZBGet::AddFeed(int id, const char* name, const char* url, int interval, const char* filter,
-	bool backlog, bool pauseNzb, const char* category, int priority, const char* feedScript)
+	bool backlog, bool pauseNzb, const char* category, FeedInfo::CategorySource categorySource, int priority, const char* feedScript)
 {
 	m_feedCoordinator->AddFeed(std::make_unique<FeedInfo>(id, name, url, backlog, interval, filter,
-		pauseNzb, category, priority, feedScript));
+		pauseNzb, category, categorySource, priority, feedScript));
 }
 
 void NZBGet::AddTask(int id, int hours, int minutes, int weekDaysBits,

--- a/daemon/queue/DownloadInfo.h
+++ b/daemon/queue/DownloadInfo.h
@@ -669,6 +669,8 @@ public:
 	void SetSkipScriptProcessing(bool skip) { m_skipScriptProcessing = skip; }
 	void SetSkipDiskWrite(bool skipWrite) { m_scipDiskWrite = skipWrite; }
 	bool GetSkipDiskWrite() { return m_scipDiskWrite; }
+	void SetAutoCategory(bool autoCategory) { m_autoCategory = autoCategory; }
+	bool GetAutoCategory() { return m_autoCategory; }
 
 	static const int FORCE_PRIORITY = 900;
 
@@ -769,6 +771,7 @@ private:
 	int m_desiredServerId = 0;
 	bool m_skipScriptProcessing = false;
 	bool m_scipDiskWrite = false;
+	bool m_autoCategory = false;
 
 	static int m_idGen;
 	static int m_idMax;

--- a/daemon/queue/DownloadInfo.h
+++ b/daemon/queue/DownloadInfo.h
@@ -670,7 +670,7 @@ public:
 	void SetSkipDiskWrite(bool skipWrite) { m_scipDiskWrite = skipWrite; }
 	bool GetSkipDiskWrite() { return m_scipDiskWrite; }
 	void SetAutoCategory(bool autoCategory) { m_autoCategory = autoCategory; }
-	bool GetAutoCategory() { return m_autoCategory; }
+	bool GetAutoCategory() const { return m_autoCategory; }
 
 	static const int FORCE_PRIORITY = 900;
 

--- a/daemon/queue/NzbFile.cpp
+++ b/daemon/queue/NzbFile.cpp
@@ -30,8 +30,8 @@
 #include "FileSystem.h"
 #include "Deobfuscation.h"
 
-NzbFile::NzbFile(const char* fileName, const char* category) :
-	m_fileName(fileName)
+NzbFile::NzbFile(const char* fileName, const char* category) 
+	: m_fileName{ fileName ? fileName : "" }
 {
 	debug("Creating NZBFile");
 
@@ -419,6 +419,7 @@ void NzbFile::Parse_StartElement(const char *name, const char **atts)
 			return;
 		}
 		m_hasPassword = atts[0] && atts[1] && !strcmp("type", atts[0]) && !strcmp("password", atts[1]);
+		m_hasCategory = atts[0] && atts[1] && !strcmp("type", atts[0]) && !strcmp("category", atts[1]);
 	}
 }
 
@@ -457,6 +458,10 @@ void NzbFile::Parse_EndElement(const char *name)
 	else if (!strcmp("meta", name) && m_hasPassword)
 	{
 		m_password = m_tagContent;
+	}
+	else if (!strcmp("meta", name) && m_hasCategory)
+	{
+		m_category = m_tagContent;
 	}
 }
 

--- a/daemon/queue/NzbFile.h
+++ b/daemon/queue/NzbFile.h
@@ -3,7 +3,7 @@
  *
  *  Copyright (C) 2004 Sven Henkel <sidddy@users.sourceforge.net>
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@ public:
 	NzbFile(const char* fileName, const char* category);
 	bool Parse();
 	const char* GetFileName() const { return m_fileName.c_str(); }
+	const std::string& GetCategoryFromFile() const { return m_category; }
 	std::unique_ptr<NzbInfo> DetachNzbInfo() { return std::move(m_nzbInfo); }
 	const std::string& GetPassword() const { return m_password; }
 
@@ -40,6 +41,7 @@ public:
 private:
 	std::unique_ptr<NzbInfo> m_nzbInfo;
 	std::string m_fileName;
+	std::string m_category;
 	std::string m_password;
 
 	void AddArticle(FileInfo* fileInfo, std::unique_ptr<ArticleInfo> articleInfo);
@@ -50,13 +52,13 @@ private:
 	void CalcHashes();
 	bool HasDuplicateFilenames();
 	void ReadPasswordFromFilename();
-	
 
 	std::unique_ptr<FileInfo> m_fileInfo;
 	ArticleInfo* m_article = nullptr;
 	StringBuilder m_tagContent;
 	bool m_ignoreNextError;
 	bool m_hasPassword = false;
+	bool m_hasCategory = false;
 
 	static void SAX_StartElement(NzbFile* file, const char *name, const char **atts);
 	static void SAX_EndElement(NzbFile* file, const char *name);

--- a/daemon/queue/Scanner.cpp
+++ b/daemon/queue/Scanner.cpp
@@ -32,24 +32,35 @@
 
 int Scanner::m_idGen = 0;
 
-Scanner::QueueData::QueueData(const char* filename, const char* nzbName, const char* category,
-	int priority, const char* dupeKey, int dupeScore, EDupeMode dupeMode,
-	NzbParameterList* parameters, bool addTop, bool addPaused, NzbInfo* urlInfo,
-	EAddStatus* addStatus, int* nzbId)
+Scanner::QueueData::QueueData(
+	const char* filename,
+	const char* nzbName,
+	const char* category,
+	bool autoCategory,
+	int priority,
+	const char* dupeKey,
+	int dupeScore,
+	EDupeMode dupeMode,
+	NzbParameterList* parameters,
+	bool addTop,
+	bool addPaused,
+	NzbInfo* urlInfo,
+	EAddStatus* addStatus,
+	int* nzbId) 
+	: m_filename{ filename ? filename : "" }
+	, m_nzbName{ nzbName ? nzbName : "" }
+	, m_category{ category ? category : "" }
+	, m_autoCategory{ autoCategory }
+	, m_priority{ priority }
+	, m_dupeKey{ dupeKey ? dupeKey : "" }
+	, m_dupeScore{ dupeScore }
+	, m_dupeMode{ dupeMode }
+	, m_addTop{ addTop }
+	, m_addPaused{ addPaused }
+	, m_urlInfo{ urlInfo }
+	, m_addStatus{ addStatus }
+	, m_nzbId{ nzbId }
 {
-	m_filename = filename;
-	m_nzbName = nzbName;
-	m_category = category ? category : "";
-	m_priority = priority;
-	m_dupeKey = dupeKey ? dupeKey : "";
-	m_dupeScore = dupeScore;
-	m_dupeMode = dupeMode;
-	m_addTop = addTop;
-	m_addPaused = addPaused;
-	m_urlInfo = urlInfo;
-	m_addStatus = addStatus;
-	m_nzbId = nzbId;
-
 	if (parameters)
 	{
 		m_parameters.CopyFrom(parameters);
@@ -121,7 +132,7 @@ void Scanner::ServiceWork()
 
 	// if NzbDirFileAge is less than NzbDirInterval (that can happen if NzbDirInterval
 	// is set for rare scans like once per hour) we make 4 scans:
-	//   - one additional scan is neccessary to check sizes of detected files;
+	//   - one additional scan is necessary to check sizes of detected files;
 	//   - another scan is required to check files which were extracted by scan-scripts;
 	//   - third scan is needed to check sizes of extracted files.
 	if (g_Options->GetNzbDirInterval() > 0 && g_Options->GetNzbDirFileAge() < g_Options->GetNzbDirInterval())
@@ -264,8 +275,12 @@ void Scanner::DropOldFiles()
 		m_fileList.end());
 }
 
-void Scanner::ProcessIncomingFile(const char* directory, const char* baseFilename,
-	const char* fullFilename, const char* category)
+void Scanner::ProcessIncomingFile(
+	const char* directory,
+	const char* baseFilename,
+	const char* fullFilename,
+	const char* category
+)
 {
 	const char* extension = strrchr(baseFilename, '.');
 	if (!extension)
@@ -273,13 +288,14 @@ void Scanner::ProcessIncomingFile(const char* directory, const char* baseFilenam
 		return;
 	}
 
-	CString nzbName = "";
-	CString nzbCategory = category;
+	std::string nzbName;
+	std::string nzbCategory;
+	std::string dupeKey;
 	NzbParameterList parameters;
 	int priority = 0;
 	bool addTop = false;
 	bool addPaused = false;
-	CString dupeKey = "";
+	bool autoCategory = true;
 	int dupeScore = 0;
 	EDupeMode dupeMode = dmScore;
 	EAddStatus addStatus = asSkipped;
@@ -302,10 +318,11 @@ void Scanner::ProcessIncomingFile(const char* directory, const char* baseFilenam
 			addPaused = queueData->GetAddPaused();
 			parameters.CopyFrom(queueData->GetParameters());
 			nzbInfo = queueData->GetUrlInfo();
+			autoCategory = queueData->GetAutoCategory();
 		}
 	}
 
-	InitPPParameters(nzbCategory, &parameters, false);
+	InitPPParameters(nzbCategory.c_str(), &parameters, false);
 
 	bool exists = true;
 
@@ -313,8 +330,16 @@ void Scanner::ProcessIncomingFile(const char* directory, const char* baseFilenam
 	{
 		ScanScriptController::ExecuteScripts(fullFilename,
 			nzbInfo, directory,
-			&nzbName, &nzbCategory, &priority, &parameters, &addTop,
-			&addPaused, &dupeKey, &dupeScore, &dupeMode);
+			nzbName.c_str(),
+			nzbCategory.c_str(),
+			&priority,
+			&parameters,
+			&addTop,
+			&addPaused,
+			dupeKey.c_str(),
+			&dupeScore,
+			&dupeMode
+		);
 		exists = FileSystem::FileExists(fullFilename);
 		if (exists && strcasecmp(extension, ".nzb"))
 		{
@@ -334,8 +359,21 @@ void Scanner::ProcessIncomingFile(const char* directory, const char* baseFilenam
 		bool renameOK = FileSystem::RenameBak(fullFilename, "nzb", true, renamedName);
 		if (renameOK)
 		{
-			bool added = AddFileToQueue(renamedName, nzbName, nzbCategory, priority,
-				dupeKey, dupeScore, dupeMode, &parameters, addTop, addPaused, nzbInfo, &nzbId);
+			bool added = AddFileToQueue(
+				renamedName,
+				nzbName.c_str(),
+				nzbCategory.c_str(),
+				autoCategory,
+				priority,
+				dupeKey.c_str(),
+				dupeScore,
+				dupeMode,
+				&parameters,
+				addTop,
+				addPaused,
+				nzbInfo,
+				&nzbId
+			);
 			addStatus = added ? asSuccess : asFailed;
 		}
 		else
@@ -347,8 +385,21 @@ void Scanner::ProcessIncomingFile(const char* directory, const char* baseFilenam
 	}
 	else if (exists && !strcasecmp(extension, ".nzb"))
 	{
-		bool added = AddFileToQueue(fullFilename, nzbName, nzbCategory, priority,
-			dupeKey, dupeScore, dupeMode, &parameters, addTop, addPaused, nzbInfo, &nzbId);
+		bool added = AddFileToQueue(
+			fullFilename,
+			nzbName.c_str(),
+			nzbCategory.c_str(),
+			autoCategory,
+			priority,
+			dupeKey.c_str(),
+			dupeScore,
+			dupeMode,
+			&parameters,
+			addTop,
+			addPaused,
+			nzbInfo,
+			&nzbId
+		);
 		addStatus = added ? asSuccess : asFailed;
 	}
 
@@ -412,9 +463,43 @@ void Scanner::InitPPParameters(const char* category, NzbParameterList* parameter
 	}
 }
 
-bool Scanner::AddFileToQueue(const char* filename, const char* nzbName, const char* category,
-	int priority, const char* dupeKey, int dupeScore, EDupeMode dupeMode,
-	NzbParameterList* parameters, bool addTop, bool addPaused, NzbInfo* urlInfo, int* nzbId)
+void Scanner::DetectAndSetCategory(const NzbFile& nzbFile, NzbInfo& nzbInfo, const char* nzbName)
+{
+	const std::string& nzbCategory = nzbFile.GetCategoryFromFile();
+	if (nzbCategory.empty())
+	{
+		detail("Auto-category: no category detected in '%s'", nzbName);
+		return;
+	}
+	Options::Category* categoryObj = g_Options->FindCategory(nzbCategory.c_str(), true);
+	if (categoryObj)
+	{
+		const char* category = categoryObj->GetName();
+		detail("Category %s matched to %s for %s", category, nzbCategory.c_str(), nzbName);
+		nzbInfo.SetCategory(category);
+	}
+	else
+	{
+		detail("Auto-category: using detected category %s for %s", nzbCategory.c_str(), nzbName);
+		nzbInfo.SetCategory(nzbCategory.c_str());
+	}
+}
+
+bool Scanner::AddFileToQueue(
+	const char* filename,
+	const char* nzbName,
+	const char* category,
+	bool autoCategory,
+	int priority,
+	const char* dupeKey,
+	int dupeScore,
+	EDupeMode dupeMode,
+	NzbParameterList* parameters,
+	bool addTop,
+	bool addPaused,
+	NzbInfo* urlInfo,
+	int* nzbId
+)
 {
 	const char* basename = FileSystem::BaseFileName(filename);
 
@@ -437,6 +522,11 @@ bool Scanner::AddFileToQueue(const char* filename, const char* nzbName, const ch
 
 	std::unique_ptr<NzbInfo> nzbInfo = nzbFile.DetachNzbInfo();
 	nzbInfo->SetQueuedFilename(bakname2);
+
+	if (autoCategory)
+	{
+		DetectAndSetCategory(nzbFile, *nzbInfo, nzbName);
+	}
 
 	if (nzbName && strlen(nzbName) > 0)
 	{
@@ -514,10 +604,23 @@ void Scanner::ScanNzbDir(bool syncMode)
 	}
 }
 
-Scanner::EAddStatus Scanner::AddExternalFile(const char* nzbName, const char* category,
-	int priority, const char* dupeKey, int dupeScore, EDupeMode dupeMode,
-	NzbParameterList* parameters, bool addTop, bool addPaused, NzbInfo* urlInfo,
-	const char* fileName, const char* buffer, int bufSize, int* nzbId)
+Scanner::EAddStatus Scanner::AddExternalFile(
+	const char* nzbName,
+	const char* category,
+	bool autoCategory,
+	int priority,
+	const char* dupeKey,
+	int dupeScore,
+	EDupeMode dupeMode,
+	NzbParameterList* parameters,
+	bool addTop,
+	bool addPaused,
+	NzbInfo* urlInfo,
+	const char* fileName,
+	const char* buffer,
+	int bufSize,
+	int* nzbId
+)
 {
 	bool nzb = false;
 	BString<1024> tempFileName;
@@ -603,9 +706,22 @@ Scanner::EAddStatus Scanner::AddExternalFile(const char* nzbName, const char* ca
 		}
 
 		addStatus = asSkipped;
-		m_queueList.emplace_back(scanFileName, nzbName, useCategory, priority,
-			dupeKey, dupeScore, dupeMode, parameters, addTop, addPaused, urlInfo,
-			&addStatus, nzbId);
+		m_queueList.emplace_back(
+			scanFileName,
+			nzbName,
+			useCategory,
+			autoCategory,
+			priority,
+			dupeKey,
+			dupeScore,
+			dupeMode,
+			parameters,
+			addTop,
+			addPaused,
+			urlInfo,
+			&addStatus,
+			nzbId
+		);
 	}
 
 	ScanNzbDir(true);

--- a/daemon/queue/Scanner.cpp
+++ b/daemon/queue/Scanner.cpp
@@ -328,7 +328,8 @@ void Scanner::ProcessIncomingFile(
 	if (m_scanScript && strcasecmp(extension, ".nzb_processed"))
 	{
 		ScanScriptController::ExecuteScripts(fullFilename,
-			nzbInfo, directory,
+			nzbInfo, 
+			directory,
 			nzbName.c_str(),
 			nzbCategory.c_str(),
 			&priority,

--- a/daemon/queue/Scanner.cpp
+++ b/daemon/queue/Scanner.cpp
@@ -185,7 +185,7 @@ void Scanner::CheckIncomingNzbs(const char* directory, const char* category, boo
 		}
 		else if (!isDirectory && CanProcessFile(fullfilename, checkStat))
 		{
-			ProcessIncomingFile(directory, filename, fullfilename, category);
+			ProcessIncomingFile(directory, filename, fullfilename);
 		}
 	}
 }
@@ -278,8 +278,7 @@ void Scanner::DropOldFiles()
 void Scanner::ProcessIncomingFile(
 	const char* directory,
 	const char* baseFilename,
-	const char* fullFilename,
-	const char* category
+	const char* fullFilename
 )
 {
 	const char* extension = strrchr(baseFilename, '.');
@@ -526,6 +525,7 @@ bool Scanner::AddFileToQueue(
 	if (autoCategory)
 	{
 		DetectAndSetCategory(nzbFile, *nzbInfo, nzbName);
+		InitPPParameters(nzbInfo->GetCategory(), parameters, true);
 	}
 
 	if (nzbName && strlen(nzbName) > 0)

--- a/daemon/queue/Scanner.h
+++ b/daemon/queue/Scanner.h
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,10 +24,11 @@
 #define SCANNER_H
 
 #include <mutex>
-#include "NString.h"
+#include <string>
 #include "DownloadInfo.h"
 #include "Thread.h"
 #include "Service.h"
+#include "NzbFile.h"
 
 class Scanner final : public Service
 {
@@ -41,72 +42,101 @@ public:
 
 	void InitOptions();
 	void ScanNzbDir(bool syncMode);
-	EAddStatus AddExternalFile(const char* nzbName, const char* category, int priority,
-		const char* dupeKey, int dupeScore, EDupeMode dupeMode,
-		NzbParameterList* parameters, bool addTop, bool addPaused, NzbInfo* urlInfo,
-		const char* fileName, const char* buffer, int bufSize, int* nzbId);
+	EAddStatus AddExternalFile(
+		const char* nzbName, 
+		const char* category,
+		bool autoCategory,
+		int priority,
+		const char* dupeKey, 
+		int dupeScore, 
+		EDupeMode dupeMode,
+		NzbParameterList* parameters, 
+		bool addTop, 
+		bool addPaused, 
+		NzbInfo* urlInfo,
+		const char* fileName, 
+		const char* buffer, 
+		int bufSize, 
+		int* nzbId
+	);
 	void InitPPParameters(const char* category, NzbParameterList* parameters, bool reset);
 
 protected:
-	virtual int ServiceInterval();
-	virtual void ServiceWork();
+	int ServiceInterval() override;
+	void ServiceWork() override;
 
 private:
 	class FileData
 	{
 	public:
-		FileData(const char* filename, int64 size, time_t lastChange) :
-			m_filename(filename), m_size(size), m_lastChange(lastChange) {}
-		const char* GetFilename() { return m_filename; }
+		FileData(const char* filename, int64 size, time_t lastChange)
+			: m_filename(filename ? filename : "")
+			, m_size(size)
+			, m_lastChange(lastChange) {}
+		const char* GetFilename() const { return m_filename.c_str(); }
 		int64 GetSize() { return m_size; }
 		void SetSize(int64 size) { m_size = size; }
 		time_t GetLastChange() { return m_lastChange; }
 		void SetLastChange(time_t lastChange) { m_lastChange = lastChange; }
 	private:
-		CString m_filename;
+		std::string m_filename;
 		int64 m_size;
 		time_t m_lastChange;
 	};
 
-	typedef std::deque<FileData> FileList;
+	using FileList = std::deque<FileData>;
 
 	class QueueData
 	{
 	public:
-		QueueData(const char* filename, const char* nzbName, const char* category,
-			int priority, const char* dupeKey, int dupeScore, EDupeMode dupeMode,
-			NzbParameterList* parameters, bool addTop, bool addPaused, NzbInfo* urlInfo,
-			EAddStatus* addStatus, int* nzbId);
-		const char* GetFilename() { return m_filename; }
-		const char* GetNzbName() { return m_nzbName; }
-		const char* GetCategory() { return m_category; }
+		QueueData(
+			const char* filename,
+			const char* nzbName,
+			const char* category,
+			bool autoCategory,
+			int priority,
+			const char* dupeKey,
+			int dupeScore,
+			EDupeMode dupeMode,
+			NzbParameterList* parameters,
+			bool addTop,
+			bool addPaused,
+			NzbInfo* urlInfo,
+			EAddStatus* addStatus,
+			int* nzbId
+		);
+		const char* GetFilename() const { return m_filename.c_str(); }
+		const char* GetNzbName() const { return m_nzbName.c_str(); }
+		const char* GetCategory() const { return m_category.c_str(); }
 		int GetPriority() { return m_priority; }
-		const char* GetDupeKey() { return m_dupeKey; }
+		const char* GetDupeKey() const { return m_dupeKey.c_str(); }
 		int GetDupeScore() { return m_dupeScore; }
 		EDupeMode GetDupeMode() { return m_dupeMode; }
 		NzbParameterList* GetParameters() { return &m_parameters; }
 		bool GetAddTop() { return m_addTop; }
 		bool GetAddPaused() { return m_addPaused; }
+		bool GetAutoCategory() { return m_autoCategory; }
 		NzbInfo* GetUrlInfo() { return m_urlInfo; }
 		void SetAddStatus(EAddStatus addStatus);
 		void SetNzbId(int nzbId);
 	private:
-		CString m_filename;
-		CString m_nzbName;
-		CString m_category;
-		int m_priority;
-		CString m_dupeKey;
-		int m_dupeScore;
-		EDupeMode m_dupeMode;
 		NzbParameterList m_parameters;
+		std::string m_filename;
+		std::string m_nzbName;
+		std::string m_category;
+		std::string m_dupeKey;
+		int m_priority;
+		int m_dupeScore;
+		bool m_autoCategory;
 		bool m_addTop;
 		bool m_addPaused;
+		EDupeMode m_dupeMode;
 		NzbInfo* m_urlInfo;
 		EAddStatus* m_addStatus;
 		int* m_nzbId;
 	};
 
-	typedef std::deque<QueueData> QueueList;
+	using QueueList = std::deque<QueueData>;
 
 	FileList m_fileList;
 	QueueList m_queueList;
@@ -118,13 +148,35 @@ private:
 	int m_pass = 0;
 	bool m_scanScript = false;
 	
-
+	/**
+	 * @brief Detects the category from the NZB file and sets it in the NzbInfo object.
+	 *
+	 * If a category is found in the NZB file and matches a configured category, it is set in nzbInfo.
+	 * Otherwise, the detected category (if any) is set directly.
+	 */
+	void DetectAndSetCategory(const NzbFile& nzbFile, NzbInfo& nzbInfo, const char* nzbName);
 	void CheckIncomingNzbs(const char* directory, const char* category, bool checkStat);
-	bool AddFileToQueue(const char* filename, const char* nzbName, const char* category,
-		int priority, const char* dupeKey, int dupeScore, EDupeMode dupeMode,
-		NzbParameterList* parameters, bool addTop, bool addPaused, NzbInfo* urlInfo, int* nzbId);
-	void ProcessIncomingFile(const char* directory, const char* baseFilename,
-		const char* fullFilename, const char* category);
+	bool AddFileToQueue(
+		const char* filename, 
+		const char* nzbName, 
+		const char* category,
+		bool autoCategory,
+		int priority, 
+		const char* dupeKey, 
+		int dupeScore, 
+		EDupeMode dupeMode,
+		NzbParameterList* parameters, 
+		bool addTop, 
+		bool addPaused, 
+		NzbInfo* urlInfo, 
+		int* nzbId
+	);
+	void ProcessIncomingFile(
+		const char* directory, 
+		const char* baseFilename,
+		const char* fullFilename, 
+		const char* category
+	);
 	bool CanProcessFile(const char* fullFilename, bool checkStat);
 	void DropOldFiles();
 };

--- a/daemon/queue/Scanner.h
+++ b/daemon/queue/Scanner.h
@@ -70,9 +70,9 @@ private:
 	{
 	public:
 		FileData(const char* filename, int64 size, time_t lastChange)
-			: m_filename(filename ? filename : "")
-			, m_size(size)
-			, m_lastChange(lastChange) {}
+			: m_filename{ filename ? filename : "" }
+			, m_size{ size }
+			, m_lastChange{ lastChange } {}
 		const char* GetFilename() const { return m_filename.c_str(); }
 		int64 GetSize() { return m_size; }
 		void SetSize(int64 size) { m_size = size; }
@@ -115,7 +115,7 @@ private:
 		NzbParameterList* GetParameters() { return &m_parameters; }
 		bool GetAddTop() { return m_addTop; }
 		bool GetAddPaused() { return m_addPaused; }
-		bool GetAutoCategory() { return m_autoCategory; }
+		bool GetAutoCategory() const { return m_autoCategory; }
 		NzbInfo* GetUrlInfo() { return m_urlInfo; }
 		void SetAddStatus(EAddStatus addStatus);
 		void SetNzbId(int nzbId);

--- a/daemon/queue/Scanner.h
+++ b/daemon/queue/Scanner.h
@@ -174,8 +174,7 @@ private:
 	void ProcessIncomingFile(
 		const char* directory, 
 		const char* baseFilename,
-		const char* fullFilename, 
-		const char* category
+		const char* fullFilename
 	);
 	bool CanProcessFile(const char* fullFilename, bool checkStat);
 	void DropOldFiles();

--- a/daemon/queue/UrlCoordinator.cpp
+++ b/daemon/queue/UrlCoordinator.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2012-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2023-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -346,9 +347,20 @@ void UrlCoordinator::UrlCompleted(UrlDownloader* urlDownloader)
 		Scanner::EAddStatus addStatus = g_Scanner->AddExternalFile(
 			!Util::EmptyStr(nzbInfo->GetFilename()) ? nzbInfo->GetFilename() : *filename,
 			!Util::EmptyStr(nzbInfo->GetCategory()) ? nzbInfo->GetCategory() : urlDownloader->GetCategory(),
-			nzbInfo->GetPriority(), nzbInfo->GetDupeKey(), nzbInfo->GetDupeScore(), nzbInfo->GetDupeMode(),
-			nzbInfo->GetParameters(), false, nzbInfo->GetAddUrlPaused(), nzbInfo,
-			urlDownloader->GetOutputFilename(), nullptr, 0, nullptr);
+			nzbInfo->GetAutoCategory(),
+			nzbInfo->GetPriority(),
+			nzbInfo->GetDupeKey(),
+			nzbInfo->GetDupeScore(),
+			nzbInfo->GetDupeMode(),
+			nzbInfo->GetParameters(),
+			false,
+			nzbInfo->GetAddUrlPaused(),
+			nzbInfo,
+			urlDownloader->GetOutputFilename(),
+			nullptr,
+			0,
+			nullptr
+		);
 
 		if (addStatus == Scanner::asSuccess)
 		{

--- a/daemon/remote/BinRpc.cpp
+++ b/daemon/remote/BinRpc.cpp
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 2005 Bo Cordes Petersen <placebodk@sourceforge.net>
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -413,6 +414,7 @@ void DownloadBinCommand::Execute()
 	int priority = ntohl(DownloadRequest.m_priority);
 	bool addPaused = ntohl(DownloadRequest.m_addPaused);
 	bool addTop = ntohl(DownloadRequest.m_addFirst);
+	bool autoCategory = ntohl(DownloadRequest.m_autoCategory);
 	int dupeMode = ntohl(DownloadRequest.m_dupeMode);
 	int dupeScore = ntohl(DownloadRequest.m_dupeScore);
 
@@ -426,6 +428,7 @@ void DownloadBinCommand::Execute()
 		nzbInfo->SetUrl(nzbContent);
 		nzbInfo->SetFilename(DownloadRequest.m_nzbFilename);
 		nzbInfo->SetCategory(DownloadRequest.m_category);
+		nzbInfo->SetAutoCategory(autoCategory);
 		nzbInfo->SetPriority(priority);
 		nzbInfo->SetAddUrlPaused(addPaused);
 		nzbInfo->SetDupeKey(DownloadRequest.m_dupeKey);
@@ -438,9 +441,23 @@ void DownloadBinCommand::Execute()
 	}
 	else
 	{
-		ok = g_Scanner->AddExternalFile(DownloadRequest.m_nzbFilename, DownloadRequest.m_category, priority,
-			DownloadRequest.m_dupeKey, dupeScore, (EDupeMode)dupeMode, nullptr, addTop, addPaused,
-			nullptr, nullptr, nzbContent, bufLen, nullptr) != Scanner::asFailed;
+		ok = g_Scanner->AddExternalFile(
+			DownloadRequest.m_nzbFilename,
+			DownloadRequest.m_category,
+			autoCategory,
+			priority,
+			DownloadRequest.m_dupeKey,
+			dupeScore,
+			static_cast<EDupeMode>(dupeMode),
+			nullptr,
+			addTop,
+			addPaused,
+			nullptr,
+			nullptr,
+			nzbContent,
+			bufLen,
+			nullptr
+		) != Scanner::asFailed;
 	}
 
 	SendBoolResponse(ok, BString<1024>(ok ? "Collection %s added to queue" :

--- a/daemon/remote/MessageBase.h
+++ b/daemon/remote/MessageBase.h
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 2005 Bo Cordes Petersen <placebodk@users.sourceforge.net>
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -103,6 +104,7 @@ struct SNzbDownloadRequest
 	int32 m_priority; // Priority for files (0 - default)
 	int32 m_dupeScore; // Duplicate score
 	int32 m_dupeMode; // Duplicate mode (EDupeMode)
+	int32 m_autoCategory;
 	char m_dupeKey[NZBREQUESTFILENAMESIZE]; // Duplicate key
 	int32 m_trailingDataLength; // Length of nzb-file in bytes
 	//char m_content[m_trailingDataLength]; // variable sized

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -49,7 +49,7 @@ extern void Reload();
 class SafeXmlCommand: public XmlCommand
 {
 public:
-	virtual bool IsSafeMethod() { return true; };
+	bool IsSafeMethod() override { return true; }
 };
 
 class ErrorXmlCommand: public XmlCommand
@@ -57,8 +57,8 @@ class ErrorXmlCommand: public XmlCommand
 public:
 	ErrorXmlCommand(int errCode, const char* errText) :
 		m_errCode(errCode), m_errText(errText) {}
-	virtual void Execute();
-	virtual bool IsError() { return true; };
+	void Execute() override;
+	bool IsError() override { return true; }
 
 private:
 	int m_errCode;
@@ -77,7 +77,7 @@ public:
 
 	PauseUnpauseXmlCommand(bool pause, EPauseAction pauseAction) :
 		m_pause(pause), m_pauseAction(pauseAction) {}
-	virtual void Execute();
+	void Execute() override;
 
 private:
 	bool m_pause;
@@ -87,55 +87,55 @@ private:
 class ScheduleResumeXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ShutdownXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ReloadXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class VersionXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class DumpDebugXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class SetDownloadRateXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class StatusXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class SysInfoXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class LogXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 
 protected:
 	int m_idFrom;
@@ -153,13 +153,13 @@ protected:
 class ListFilesXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ListGroupsXmlCommand: public NzbInfoXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 private:
 	const char* DetectStatus(NzbInfo* nzbInfo);
 };
@@ -167,43 +167,43 @@ private:
 class EditQueueXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class DownloadXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class PostQueueXmlCommand: public NzbInfoXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class WriteLogXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ClearLogXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ScanXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class HistoryXmlCommand: public NzbInfoXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 private:
 	const char* DetectStatus(HistoryInfo* historyInfo);
 };
@@ -211,68 +211,68 @@ private:
 class UrlQueueXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ConfigXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class LoadConfigXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class LoadExtensionsXmlCommand : public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class DownloadExtensionXmlCommand : public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class UpdateExtensionXmlCommand : public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class DeleteExtensionXmlCommand : public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class TestExtensionXmlCommand : public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class SaveConfigXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ConfigTemplatesXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ViewFeedXmlCommand: public XmlCommand
 {
 public:
 	ViewFeedXmlCommand(bool preview) : m_preview(preview) {}
-	virtual void Execute();
+	void Execute() override;
 private:
 	bool m_preview;
 };
@@ -280,31 +280,31 @@ private:
 class FetchFeedXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class EditServerXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ReadUrlXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class CheckUpdatesXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class StartUpdateXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class LogUpdateXmlCommand: public LogXmlCommand
@@ -316,19 +316,19 @@ protected:
 class ServerVolumesXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class ResetServerVolumeXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class LoadLogXmlCommand: public LogXmlCommand
 {
 protected:
-	virtual void Execute();
+	void Execute() override;
 	virtual GuardedMessageList GuardMessages();
 private:
 	int m_nzbId;
@@ -340,7 +340,7 @@ private:
 class TestServerXmlCommand: public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 
 private:
 	CString m_errText;
@@ -361,7 +361,7 @@ private:
 class TestServerSpeedXmlCommand: public SafeXmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class TestDiskSpeedXmlCommand final : public SafeXmlCommand
@@ -436,7 +436,7 @@ public:
 class StartScriptXmlCommand : public XmlCommand
 {
 public:
-	virtual void Execute();
+	void Execute() override;
 };
 
 class LogScriptXmlCommand : public LogXmlCommand
@@ -2394,6 +2394,8 @@ void EditQueueXmlCommand::Execute()
 	BuildBoolResponse(ok);
 }
 
+// v25.2: Added new parameter "autoCategory".
+//   bool append(string NZBFilename, string Category, int Priority, bool AddToTop, string Content, bool AddPaused, string DupeKey, int DupeScore, string DupeMode, bool autoCategory)
 // v16:
 //   int append(string NZBFilename, string NZBContent, string Category, int Priority, bool AddToTop, bool AddPaused, string DupeKey, int DupeScore, string DupeMode, struct[] Parameters)
 // v13 (new param order and new result type):
@@ -2451,6 +2453,7 @@ void DownloadXmlCommand::Execute()
 	bool addPaused = false;
 	char* dupeKey = nullptr;
 	int dupeScore = 0;
+	bool autoCategory = false;
 	EDupeMode dupeMode = dmScore;
 	if (NextParamAsBool(&addPaused))
 	{
@@ -2474,6 +2477,8 @@ void DownloadXmlCommand::Execute()
 		}
 		dupeMode = !strcasecmp(dupeModeStr, "all") ? dmAll :
 			!strcasecmp(dupeModeStr, "force") ? dmForce : dmScore;
+
+		NextParamAsBool(&autoCategory);
 	}
 	else if (v13)
 	{
@@ -2505,6 +2510,7 @@ void DownloadXmlCommand::Execute()
 		nzbInfo->SetUrl(nzbContent);
 		nzbInfo->SetFilename(nzbFilename);
 		nzbInfo->SetCategory(category);
+		nzbInfo->SetAutoCategory(autoCategory);
 		nzbInfo->SetPriority(priority);
 		nzbInfo->SetAddUrlPaused(addPaused);
 		nzbInfo->SetDupeKey(dupeKey ? dupeKey : "");
@@ -2534,9 +2540,23 @@ void DownloadXmlCommand::Execute()
 		//debug("FileContent=%s", szFileContent);
 
 		int nzbId = -1;
-		g_Scanner->AddExternalFile(nzbFilename, category, priority,
-			dupeKey, dupeScore, dupeMode, Params.empty() ? nullptr : &Params, addTop, addPaused, nullptr,
-			nullptr, nzbContent, len, &nzbId);
+		g_Scanner->AddExternalFile(
+			nzbFilename,
+			category,
+			autoCategory,
+			priority,
+			dupeKey,
+			dupeScore,
+			dupeMode,
+			Params.empty() ? nullptr : &Params,
+			addTop,
+			addPaused,
+			nullptr,
+			nullptr,
+			nzbContent,
+			len,
+			&nzbId
+		);
 
 		if (v13)
 		{

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -3198,6 +3198,8 @@ void ViewFeedXmlCommand::Execute()
 		bool backlog = true;
 		bool pauseNzb;
 		char* category;
+		char* categorySourceStr;
+		auto categorySource = FeedInfo::CategorySource::NZBFile;
 		int interval = 0;
 		int priority;
 		char* feedFilter = nullptr;
@@ -3218,6 +3220,8 @@ void ViewFeedXmlCommand::Execute()
 			return;
 		}
 
+		NextParamAsStr(&categorySourceStr);
+
 		DecodeStr(name);
 		DecodeStr(url);
 		DecodeStr(filter);
@@ -3227,8 +3231,21 @@ void ViewFeedXmlCommand::Execute()
 		debug("Url=%s", url);
 		debug("Filter=%s", filter);
 
-		feedItems = g_FeedCoordinator->PreviewFeed(id, name, url, filter, backlog, pauseNzb,
-			category, priority, interval, feedFilter, cacheTimeSec, cacheId);
+		feedItems = g_FeedCoordinator->PreviewFeed(
+			id,
+			name,
+			url,
+			filter,
+			backlog,
+			pauseNzb,
+			category,
+			categorySource,
+			priority,
+			interval,
+			feedFilter,
+			cacheTimeSec,
+			cacheId
+		);
 	}
 	else
 	{

--- a/daemon/util/Service.h
+++ b/daemon/util/Service.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2015-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -27,6 +28,7 @@ class Service
 {
 public:
 	Service();
+	virtual ~Service() = default;
 
 	static const int Now = 0;
 	static const int Sleep = -1;

--- a/docs/api/APPEND.md
+++ b/docs/api/APPEND.md
@@ -12,6 +12,7 @@ int append(
   string DupeKey,
   int DupeScore, 
   string DupeMode, 
+  bool AutoCategory,
   struct[] PPParameters
 );
 ```
@@ -28,6 +29,7 @@ _Add nzb-file or URL to download queue_
 DupeKey (string) - duplicate key for nzb-file. See [RSS](../usage/RSS.md).
 - **DupeScore** `(int)` - duplicate score for nzb-file. See [RSS](../usage/RSS.md).
 - **DupeMode** `(string)` - duplicate mode for nzb-file. See [RSS](../usage/RSS.md).
+- **AutoCategory** `(bool)` - If true, the category will be automatically detected from the NZB file (if available).
 - **PPParameters** `(array)` - `v16.0` post-processing parameters. The array consists of structures with following fields:
   - **Name** `(string)` - name of post-processing parameter.
   - **Value** `(string)` - value of post-processing parameter.

--- a/nzbget.conf
+++ b/nzbget.conf
@@ -693,6 +693,17 @@ Category4.Name=Software
 # is downloaded. If you want to use the providers category leave the option empty.
 #Feed1.Category=
 
+# Where to retrieve the category information for a download (auto, NZBFile, FeedFile).
+#
+#  Auto     - Try to retrieve the category from the NZB file first. If not found,
+#               try the feed file.
+#  NzbFile  - Always retrieve the category from the NZB file. If not found, the
+#               category is left empty.
+#  FeedFile - Always retrieve the category from the feed file. If not found, the
+#               category is left empty.
+#  NOTE: Works only if <Feed1.Category> is empty.
+#Feed1.CategorySource=NzbFile
+
 # Priority for added nzb-files (number).
 #
 # Priority can be any integer value. The web-interface however operates

--- a/tests/main/OptionsTest.cpp
+++ b/tests/main/OptionsTest.cpp
@@ -23,8 +23,15 @@
 
 #include "boost/test/unit_test.hpp"
 
+#include <vector>
+#include <iostream>
 #include "Options.h"
 #include "FeedInfo.h"
+
+std::ostream operator<<(std::ostream& os, FeedInfo::CategorySource categorySource)
+{
+	return os << categorySource;
+}
 
 class OptionsExtenderMock : public Options::Extender
 {
@@ -32,6 +39,7 @@ public:
 	int m_newsServers;
 	int m_feeds;
 	int m_tasks;
+	std::vector<FeedInfo::CategorySource> m_categorySources;
 
 	OptionsExtenderMock() : m_newsServers(0), m_feeds(0), m_tasks(0) {}
 
@@ -59,6 +67,7 @@ protected:
 	) override
 	{
 		m_feeds++;
+		m_categorySources.push_back(categorySource);
 	}
 
 	void AddTask(int id, int hours, int minutes, int weekDaysBits, Options::ESchedulerCommand command, const char* param) override
@@ -111,7 +120,45 @@ BOOST_AUTO_TEST_CASE(CallingExtender)
 	OptionsExtenderMock extender;
 	Options options(&cmdOpts, &extender);
 
-	BOOST_TEST(extender.m_newsServers == 2);
-	BOOST_TEST(extender.m_feeds == 1);
-	BOOST_TEST(extender.m_tasks == 24);
+	BOOST_CHECK_EQUAL(extender.m_newsServers, 2);
+	BOOST_CHECK_EQUAL(extender.m_feeds, 1);
+	BOOST_CHECK_EQUAL(extender.m_tasks, 24);
+	BOOST_CHECK_EQUAL(extender.m_categorySources[0], FeedInfo::CategorySource::NZBFile);
+}
+
+BOOST_AUTO_TEST_CASE(ParseCategorySourceTest)
+{
+	Options::CmdOptList cmdOpts;
+
+	cmdOpts.push_back("Feed1.Url=http://my.feed.com");
+	cmdOpts.push_back("Feed1.CategorySource=Auto");
+
+	cmdOpts.push_back("Feed2.Url=http://my.feed2.com");
+	cmdOpts.push_back("Feed2.CategorySource=NZBFile");
+
+	cmdOpts.push_back("Feed3.Url=http://my.feed3.com");
+	cmdOpts.push_back("Feed3.CategorySource=FeedFile");
+
+	cmdOpts.push_back("Feed4.Url=http://my.feed4.com");
+	cmdOpts.push_back("Feed4.CategorySource=auto");
+
+	cmdOpts.push_back("Feed5.Url=http://my.feed5.com");
+	cmdOpts.push_back("Feed5.CategorySource=nzbfile");
+
+	cmdOpts.push_back("Feed6.Url=http://my.feed6.com");
+	cmdOpts.push_back("Feed6.CategorySource=feedfile");
+
+	cmdOpts.push_back("Feed7.Url=http://my.feed7.com");
+	cmdOpts.push_back("Feed7.CategorySource=auto and nzbfile and feedfile");
+
+	OptionsExtenderMock extender;
+	Options options(&cmdOpts, &extender);
+
+	BOOST_CHECK_EQUAL(extender.m_categorySources[0], FeedInfo::CategorySource::Auto);
+	BOOST_CHECK_EQUAL(extender.m_categorySources[1], FeedInfo::CategorySource::NZBFile);
+	BOOST_CHECK_EQUAL(extender.m_categorySources[2], FeedInfo::CategorySource::FeedFile);
+	BOOST_CHECK_EQUAL(extender.m_categorySources[3], FeedInfo::CategorySource::Auto);
+	BOOST_CHECK_EQUAL(extender.m_categorySources[4], FeedInfo::CategorySource::NZBFile);
+	BOOST_CHECK_EQUAL(extender.m_categorySources[5], FeedInfo::CategorySource::FeedFile);
+	BOOST_CHECK_EQUAL(extender.m_categorySources[6], FeedInfo::CategorySource::Auto);
 }

--- a/tests/main/OptionsTest.cpp
+++ b/tests/main/OptionsTest.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2015-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,6 +24,7 @@
 #include "boost/test/unit_test.hpp"
 
 #include "Options.h"
+#include "FeedInfo.h"
 
 class OptionsExtenderMock : public Options::Extender
 {
@@ -42,8 +44,19 @@ protected:
 		m_newsServers++;
 	}
 
-	void AddFeed(int id, const char* name, const char* url, int interval,
-		const char* filter, bool backlog, bool pauseNzb, const char* category, int priority, const char* feedScript) override
+	void AddFeed(
+		int id, 
+		const char* name, 
+		const char* url, 
+		int interval,
+		const char* filter, 
+		bool backlog, 
+		bool pauseNzb, 
+		const char* category,
+		FeedInfo::CategorySource categorySource, 
+		int priority, 
+		const char* feedScript
+	) override
 	{
 		m_feeds++;
 	}

--- a/tests/testdata/nzbfile/dotless.nzb
+++ b/tests/testdata/nzbfile/dotless.nzb
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.1//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd">
 <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
-<head></head>
+<head>
+<meta type="category">Movies</meta>
+</head>
 <file poster="yEncBin@Poster.com (yEncBin)" date="1435841472" subject="20155f68b0df03cc9bca2c58d426163ff [2/15] - &#34;20155f68b0df03cc9bca2c58d426163ff&#34; yEnc (62/68)">
 <groups>
 <group>alt.binaries.test</group>

--- a/tests/testdata/nzbfile/plain.nzb
+++ b/tests/testdata/nzbfile/plain.nzb
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.0//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.0.dtd">
 <nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+<head>
+<meta type="category">TV &gt; 4K</meta>
+</head>
 <file poster="spitch@ratingshell.com (Dless)" date="1335508618" subject="&quot;ubuntu-12.04-desktop-i386.nfo&quot; yEnc (1/1)">
 <groups>
 <group>alt.binaries.boneless</group>

--- a/webui/config.js
+++ b/webui/config.js
@@ -1844,6 +1844,7 @@ var Config = (new function($)
 			getOptionValue(findOptionByName('Feed' + option.multiid + '.Priority')),
 			getOptionValue(findOptionByName('Feed' + option.multiid + '.Interval')),
 			getOptionValue(findOptionByName('Feed' + option.multiid + '.Extensions')),
+			getOptionValue(findOptionByName('Feed' + option.multiid + '.CategorySource')),
 			function(filter)
 				{
 					var control = $('#' + option.formId);
@@ -1863,7 +1864,9 @@ var Config = (new function($)
 			getOptionValue(findOptionByName('Feed' + multiid + '.Category')),
 			getOptionValue(findOptionByName('Feed' + multiid + '.Priority')),
 			getOptionValue(findOptionByName('Feed' + multiid + '.Interval')),
-			getOptionValue(findOptionByName('Feed' + multiid + '.Extensions')));
+			getOptionValue(findOptionByName('Feed' + multiid + '.Extensions')),
+			getOptionValue(findOptionByName('Feed' + multiid + '.CategorySource')),
+		);
 	}
 
 	/*** TEST SERVER ********************************************************************/

--- a/webui/feed.js
+++ b/webui/feed.js
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2013-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -369,8 +370,19 @@ var FeedDialog = (new function($)
 			{
 				name += '.nzb';
 			}
-			RPC.call('append', [name, fetchItems[0].URL, fetchItems[0].AddCategory, fetchItems[0].Priority, false,
-				false, fetchItems[0].DupeKey, fetchItems[0].DupeScore, fetchItems[0].DupeMode],
+			var category = fetchItems[0].AddCategory ? fetchItems[0].AddCategory : fetchItems[0].Category;
+			RPC.call('append', [
+				name,
+				fetchItems[0].URL,
+				category,
+				fetchItems[0].Priority,
+				false,
+				false,
+				fetchItems[0].DupeKey,
+				fetchItems[0].DupeScore,
+				fetchItems[0].DupeMode,
+				false
+			],
 				function()
 			{
 				fetchItems.shift();

--- a/webui/feed.js
+++ b/webui/feed.js
@@ -145,7 +145,7 @@ var FeedDialog = (new function($)
 		}
 	}
 
-	this.showModal = function(id, name, url, filter, backlog, pauseNzb, category, priority, interval, feedscript)
+	this.showModal = function(id, name, url, filter, backlog, pauseNzb, category, priority, interval, feedscript, categorySource)
 	{
 		Refresher.pause();
 
@@ -187,8 +187,9 @@ var FeedDialog = (new function($)
 			var feedPriority = parseInt(priority);
 			var feedInterval = parseInt(interval);
 			var feedScript = feedscript;
+			var feedCategorySource = categorySource;
 			RPC.call('previewfeed', [id, name, url, filter, feedBacklog, feedPauseNzb, feedCategory,
-				feedPriority, feedInterval, feedScript, false, 0, ''], itemsLoaded, feedFailure);
+				feedPriority, feedInterval, feedScript, false, 0, '', feedCategorySource], itemsLoaded, feedFailure);
 		}
 
 		if (!UISettings.miniTheme)
@@ -444,6 +445,7 @@ var FeedFilterDialog = (new function($)
 	var feedBacklog;
 	var feedPauseNzb;
 	var feedCategory;
+	var feedCategorySource;
 	var feedPriority;
 	var feedInterval;
 	var feedScript;
@@ -510,7 +512,7 @@ var FeedFilterDialog = (new function($)
 		}
 	}
 
-	this.showModal = function(id, name, url, filter, backlog, pauseNzb, category, priority, interval, feedscript, _saveCallback)
+	this.showModal = function(id, name, url, filter, backlog, pauseNzb, category, priority, interval, feedscript, categorySource, _saveCallback)
 	{
 		saveCallback = _saveCallback;
 
@@ -548,6 +550,7 @@ var FeedFilterDialog = (new function($)
 		feedBacklog = backlog === 'yes';
 		feedPauseNzb = pauseNzb === 'yes';
 		feedCategory = category;
+		feedCategorySource = categorySource;
 		feedPriority = parseInt(priority);
 		feedInterval = parseInt(interval);
 		feedScript = feedscript;
@@ -557,7 +560,7 @@ var FeedFilterDialog = (new function($)
 		if (url !== '')
 		{
 			RPC.call('previewfeed', [feedId, name, url, filter, feedBacklog, feedPauseNzb, feedCategory, feedPriority,
-				feedInterval, feedScript, true, cacheTimeSec, cacheId], itemsLoaded, feedFailure);
+				feedInterval, feedScript, true, cacheTimeSec, cacheId, feedCategorySource], itemsLoaded, feedFailure);
 		}
 		else
 		{

--- a/webui/index.html
+++ b/webui/index.html
@@ -2718,10 +2718,11 @@
 				</div>
 
 				<div class="control-group">
-					<label class="control-label" for="AddDialog_Paused">Options</label>
+					<label class="control-label">Options</label>
 					<div class="controls">
-						<label class="checkbox"><input type="checkbox" id="AddDialog_Paused"> Add paused</label>
-						<label class="checkbox"><input type="checkbox" id="AddDialog_DupeForce"> Disable duplicate check</label>
+						<label class="checkbox"><input type="checkbox" id="AddDialog_AutoCategory"> Auto-detect category </label>
+						<label class="checkbox"><input type="checkbox" id="AddDialog_Paused"> Add paused </label>
+						<label class="checkbox"><input type="checkbox" id="AddDialog_DupeForce"> Disable duplicate check </label>
 					</div>
 				</div>
 

--- a/webui/upload.js
+++ b/webui/upload.js
@@ -2,6 +2,7 @@
  * This file is part of nzbget. See <https://nzbget.com>.
  *
  * Copyright (C) 2012-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ * Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -241,6 +242,7 @@ var Upload = (new function($)
 		$('#AddDialog_FilesHelp').show();
 		$('#AddDialog_URLLabel img').hide();
 		$('#AddDialog_URLLabel i').hide();
+		$('#AddDialog_AutoCategory').prop('checked', false);
 		$('#AddDialog_Paused').prop('checked', false);
 		$('#AddDialog_DupeForce').prop('checked', false);
 		enableAllButtons();
@@ -356,9 +358,22 @@ var Upload = (new function($)
 			var priority = parseInt($('#AddDialog_Priority').val());
 			var filename = info.name + info.ext;
 			var addPaused = $('#AddDialog_Paused').is(':checked');
+			var autoCategory = $('#AddDialog_AutoCategory').is(':checked');
 			var dupeMode = $('#AddDialog_DupeForce').is(':checked') ? "FORCE" : "SCORE";
 			var params = info.password === '' ? [] : [{'*Unpack:Password' : info.password}];
-			RPC.call('append', [filename, base64str, category, priority, false, addPaused, info.dupekey, info.dupescore, dupeMode, params], fileCompleted, fileFailure);
+			RPC.call('append', [
+				filename,
+				base64str,
+				category,
+				priority,
+				false,
+				addPaused,
+				info.dupekey,
+				info.dupescore,
+				dupeMode,
+				autoCategory,
+				params,
+			], fileCompleted, fileFailure);
 		};
 
 		if (reader.readAsBinaryString)
@@ -410,10 +425,23 @@ var Upload = (new function($)
 		
 		var category = $('#AddDialog_Category').val();
 		var priority = parseInt($('#AddDialog_Priority').val());
+		var autoCategory = $('#AddDialog_AutoCategory').is(':checked');
 		var addPaused = $('#AddDialog_Paused').is(':checked');
 		var dupeMode = $('#AddDialog_DupeForce').is(':checked') ? "FORCE" : "SCORE";
 		var params = urlInfo.password === '' ? [] : [{'*Unpack:Password' : urlInfo.password}];
-		RPC.call('append', [urlInfo.name, url, category, priority, false, addPaused, urlInfo.dupekey, urlInfo.dupescore, dupeMode, params], urlCompleted, urlFailure);
+		RPC.call('append', [
+			urlInfo.name,
+			url,
+			category,
+			priority,
+			false,
+			addPaused,
+			urlInfo.dupekey,
+			urlInfo.dupescore,
+			dupeMode,
+			autoCategory,
+			params,
+		], urlCompleted, urlFailure);
 	}
 
 	function urlCompleted(result)


### PR DESCRIPTION
## Description

- Implemented automatic category detection from NZB file metadata
- The API method "append" now has a new argument:
    - AutoCategory (bool) - If true, the category will be automatically detected from the NZB file (if available).
- Extended web UI with "Auto-detect category" checkbox in upload dialog
- Introduced a `CategorySource` option for RSS feeds, providing granular control over where category information is retrieved
- Resolved some compiler warnings

## Testing

- macOS Ventura AMD64
- Linux AMD64