### PR TITLE
Docker: add env variables for restricted user/pass

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -64,13 +64,15 @@ docker run -d \
 
 NZBGet container can be configured by passing environment variables to it. This can be done in docker-compose mode by specifying `environment:` and in cli mode by using -e switch.
 
-| Parameter	  | Description
-|:------------|-
-| PUID        | UserID (see below)
-| PGID        | GroupID (see below)
-| TZ          | Timezone
-| NZBGET_USER | User name for web auth
-| NZBGET_PASS | Password for web auth
+| Parameter	             | Description
+|:-----------------------|-
+| PUID                   | UserID (see below)
+| PGID                   | GroupID (see below)
+| TZ                     | Timezone
+| NZBGET_USER            | User name for web auth
+| NZBGET_PASS            | Password for web auth
+| NZBGET_RESTRICTED_USER | Restricted user name
+| NZBGET_RESTRICTED_PASS | Restricted password
 
 # User / Group Identifiers
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -34,6 +34,12 @@ fi
 if [ ! -z "${NZBGET_PASS}" ]; then
     OPTIONS="${OPTIONS}-o ControlPassword=${NZBGET_PASS} "
 fi
+if [ ! -z "${NZBGET_RESTRICTED_USER}" ]; then
+    OPTIONS="${OPTIONS}-o RestrictedUsername=${NZBGET_RESTRICTED_USER} "
+fi
+if [ ! -z "${NZBGET_RESTRICTED_PASS}" ]; then
+    OPTIONS="${OPTIONS}-o RestrictedPassword=${NZBGET_RESTRICTED_PASS} "
+fi
 
 if [ "$(id -u)" -eq 0 ]; then
     chown user:users /config/nzbget.conf


### PR DESCRIPTION
## Description

Support for two optional env variables was added:

- `NZBGET_RESTRICTED_USER` to override `RestrictedUsername` config option
- `NZBGET_RESTRICTED_PASS` to override `RestrictedPassword` config option


## Testing

Tried these changes in a separate shell script to make sure it does what it should.