### PR TITLE
Fix brew head test build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,4 +248,5 @@ jobs:
 
     - name: Build
       run: |
+        brew uninstall cmake
         brew install nzbget --formula --head --verbose


### PR DESCRIPTION
## Description

- fixed brew head test build (caused by `macos-latest` runner image update`
