### PR TITLE
Fix: RSS feeds category reading and applying is not working

### DIFF
--- a/daemon/feed/FeedCoordinator.h
+++ b/daemon/feed/FeedCoordinator.h
@@ -36,6 +36,18 @@
 
 class FeedDownloader;
 
+class NzbInfoCreator final
+{
+public:
+	NzbInfoCreator() = default;
+	~NzbInfoCreator() = default;
+
+	std::unique_ptr<NzbInfo> Create(const FeedInfo& feedInfo, const FeedItemInfo& feedItemInfo) const;
+
+private:
+	void ApplyCategory(NzbInfo& nzbInfo, const FeedInfo& feedInfo, const FeedItemInfo& feedItemInfo) const;
+};
+
 class FeedCoordinator : public Thread, public Observer, public Subject, public Debuggable
 {
 public:
@@ -116,17 +128,17 @@ private:
 	Mutex m_downloadsMutex;
 	DownloadQueueObserver m_downloadQueueObserver;
 	WorkStateObserver m_workStateObserver;
-	std::atomic<bool> m_force{false};
-	bool m_save = false;
+	NzbInfoCreator m_nzbInfoCreator;
 	FeedCache m_feedCache;
 	ConditionVar m_waitCond;
+	std::atomic<bool> m_force{false};
 	bool m_wokenUp = false;
+	bool m_save = false;
 
 	void StartFeedDownload(FeedInfo* feedInfo, bool force);
 	void FeedCompleted(FeedDownloader* feedDownloader);
 	void FilterFeed(FeedInfo* feedInfo, FeedItemList* feedItems);
 	std::vector<std::unique_ptr<NzbInfo>> ProcessFeed(FeedInfo* feedInfo, FeedItemList* feedItems);
-	std::unique_ptr<NzbInfo> CreateNzbInfo(FeedInfo* feedInfo, FeedItemInfo& feedItemInfo);
 	void ResetHangingDownloads();
 	void DownloadQueueUpdate(Subject* caller, void* aspect);
 	void CleanupHistory();

--- a/daemon/feed/FeedInfo.h
+++ b/daemon/feed/FeedInfo.h
@@ -65,15 +65,15 @@ public:
 		int priority,
 		const char* extensions
 	);
-	int GetId() { return m_id; }
+	int GetId() const { return m_id; }
 	const char* GetName() const { return m_name.c_str(); }
 	const char* GetUrl() const { return m_url.c_str(); }
 	int GetInterval() { return m_interval; }
 	const char* GetFilter() const { return m_filter.c_str(); }
 	uint32 GetFilterHash() { return m_filterHash; }
-	bool GetPauseNzb() { return m_pauseNzb; }
+	bool GetPauseNzb() const { return m_pauseNzb; }
 	const char* GetCategory() const { return m_category.c_str(); }
-	int GetPriority() { return m_priority; }
+	int GetPriority() const { return m_priority; }
 	const char* GetExtensions() const { return m_extensions.c_str(); }
 	time_t GetLastUpdate() { return m_lastUpdate; }
 	void SetLastUpdate(time_t lastUpdate) { m_lastUpdate = lastUpdate; }
@@ -93,7 +93,7 @@ public:
 	void SetForce(bool force) { m_force = force; }
 	bool GetBacklog() { return m_backlog; }
 	void SetBacklog(bool backlog) { m_backlog = backlog; }
-	CategorySource GetCategorySource() { return m_categorySource; }
+	CategorySource GetCategorySource() const { return m_categorySource; }
 	void SetCategorySource(CategorySource categorySource) { m_categorySource = categorySource; }
 
 private:
@@ -177,15 +177,9 @@ public:
 	void SetFilename(const char* filename) { m_filename = filename ? filename : ""; }
 	const char* GetUrl() const { return m_url.c_str(); }
 	void SetUrl(const char* url) { m_url = url ? url : ""; }
-	int64 GetSize() { return m_size; }
+	int64 GetSize() const { return m_size; }
 	void SetSize(int64 size) { m_size = size; }
-	const char* GetCategory() const
-	{
-		if (!m_addCategory.empty())
-			return m_addCategory.c_str();
-
-		return m_category.c_str();
-	}
+	const char* GetCategory() const { return m_category.c_str(); }
 	void SetCategory(const char* category) { m_category = category ? category : ""; }
 	int GetImdbId() { return m_imdbId; }
 	void SetImdbId(int imdbId) { m_imdbId = imdbId; }
@@ -203,13 +197,13 @@ public:
 	void SetEpisode(const char* episode);
 	int GetSeasonNum();
 	int GetEpisodeNum();
-	const char* GetAddCategory() const { return m_addCategory.c_str(); }
+	const std::string& GetAddCategory() const { return m_addCategory; }
 	void SetAddCategory(const char* addCategory) { m_addCategory = addCategory ? addCategory : ""; }
-	bool GetPauseNzb() { return m_pauseNzb; }
+	bool GetPauseNzb() const { return m_pauseNzb; }
 	void SetPauseNzb(bool pauseNzb) { m_pauseNzb = pauseNzb; }
-	int GetPriority() { return m_priority; }
+	int GetPriority() const { return m_priority; }
 	void SetPriority(int priority) { m_priority = priority; }
-	time_t GetTime() { return m_time; }
+	time_t GetTime() const { return m_time; }
 	void SetTime(time_t time) { m_time = time; }
 	EStatus GetStatus() { return m_status; }
 	void SetStatus(EStatus status) { m_status = status; }
@@ -221,9 +215,9 @@ public:
 	void SetDupeKey(const char* dupeKey) { m_dupeKey = dupeKey ? dupeKey : ""; }
 	void AppendDupeKey(const char* extraDupeKey);
 	void BuildDupeKey(const char* rageId, const char* tvdbId, const char* tvmazeId, const char* series);
-	int GetDupeScore() { return m_dupeScore; }
+	int GetDupeScore() const { return m_dupeScore; }
 	void SetDupeScore(int dupeScore) { m_dupeScore = dupeScore; }
-	EDupeMode GetDupeMode() { return m_dupeMode; }
+	EDupeMode GetDupeMode() const { return m_dupeMode; }
 	void SetDupeMode(EDupeMode dupeMode) { m_dupeMode = dupeMode; }
 	const char* GetDupeStatus();
 	Attributes* GetAttributes() { return &m_attributes; }

--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -3328,7 +3328,7 @@ void ViewFeedXmlCommand::Execute()
 			AppendFmtResponse(IsJson() ? JSON_FEED_ITEM : XML_FEED_ITEM,
 				*EncodeStr(feedItemInfo.GetTitle()), *EncodeStr(feedItemInfo.GetFilename()),
 				*EncodeStr(feedItemInfo.GetUrl()), sizeLo, sizeHi, sizeMB,
-				*EncodeStr(feedItemInfo.GetCategory()), *EncodeStr(feedItemInfo.GetAddCategory()),
+				*EncodeStr(feedItemInfo.GetCategory()), *EncodeStr(feedItemInfo.GetAddCategory().c_str()),
 				BoolToStr(feedItemInfo.GetPauseNzb()), feedItemInfo.GetPriority(), (int)feedItemInfo.GetTime(),
 				matchStatusType[feedItemInfo.GetMatchStatus()], feedItemInfo.GetMatchRule(),
 				*EncodeStr(feedItemInfo.GetDupeKey()), feedItemInfo.GetDupeScore(),

--- a/nzbget.conf
+++ b/nzbget.conf
@@ -689,8 +689,9 @@ Category4.Name=Software
 
 # Category for added nzb-files.
 #
-# NOTE: Feed providers may include category name within response when nzb-file
-# is downloaded. If you want to use the providers category leave the option empty.
+# NOTE: Feed providers may include category name within response when nzb-file 
+# is downloaded. To use the provider’s category leave this option empty 
+# and use <Feed1.CategorySource> accordingly.
 #Feed1.Category=
 
 # Where to retrieve the category information for a download (auto, NZBFile, FeedFile).
@@ -701,7 +702,7 @@ Category4.Name=Software
 #               category is left empty.
 #  FeedFile - Always retrieve the category from the feed file. If not found, the
 #               category is left empty.
-#  NOTE: Works only if <Feed1.Category> is empty.
+#  NOTE: This option works only when filters did not set a category and the <Feed1.Category> option is empty.
 #Feed1.CategorySource=NzbFile
 
 # Priority for added nzb-files (number).

--- a/tests/feed/CMakeLists.txt
+++ b/tests/feed/CMakeLists.txt
@@ -1,18 +1,69 @@
 set(FeedTestsSrc
 	FeedFilterTest.cpp
 	FeedFileTest.cpp
+	NzbInfoCreatorTest.cpp
 	main.cpp
 	${CMAKE_SOURCE_DIR}/daemon/feed/FeedFilter.cpp
 	${CMAKE_SOURCE_DIR}/daemon/feed/FeedFile.cpp
 	${CMAKE_SOURCE_DIR}/daemon/feed/FeedInfo.cpp
+	${CMAKE_SOURCE_DIR}/daemon/feed/FeedCoordinator.cpp
 	${CMAKE_SOURCE_DIR}/daemon/main/Options.cpp
+	${CMAKE_SOURCE_DIR}/daemon/main/WorkState.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/NString.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/Util.cpp 
 	${CMAKE_SOURCE_DIR}/daemon/util/FileSystem.cpp 
-	${CMAKE_SOURCE_DIR}/daemon/util/Log.cpp 
+	${CMAKE_SOURCE_DIR}/daemon/util/Log.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/ScriptController.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/Observer.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/Thread.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/OpenSSL.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/Service.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/Json.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/Xml.cpp
 	${CMAKE_SOURCE_DIR}/daemon/queue/DownloadInfo.cpp
 	${CMAKE_SOURCE_DIR}/daemon/queue/DiskState.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/Scanner.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/UrlCoordinator.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/DupeCoordinator.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/HistoryCoordinator.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/QueueCoordinator.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/QueueEditor.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/Deobfuscation.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/DirectRenamer.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/NzbFile.cpp
+	${CMAKE_SOURCE_DIR}/daemon/connect/WebDownloader.cpp
+	${CMAKE_SOURCE_DIR}/daemon/connect/Connection.cpp
+	${CMAKE_SOURCE_DIR}/daemon/connect/TlsSocket.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/Repair.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/PrePostProcessor.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/ParChecker.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/DirectUnpack.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/Cleanup.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/Rename.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/DupeMatcher.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/ParRenamer.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/RarRenamer.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/Unpack.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/PostUnpackRenamer.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/PrePostProcessor.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/ParParser.cpp
+	${CMAKE_SOURCE_DIR}/daemon/postprocess/RarReader.cpp
 	${CMAKE_SOURCE_DIR}/daemon/nntp/NewsServer.cpp
+	${CMAKE_SOURCE_DIR}/daemon/nntp/ServerPool.cpp
+	${CMAKE_SOURCE_DIR}/daemon/nntp/ArticleWriter.cpp
+	${CMAKE_SOURCE_DIR}/daemon/nntp/ArticleDownloader.cpp
+	${CMAKE_SOURCE_DIR}/daemon/nntp/NntpConnection.cpp
+	${CMAKE_SOURCE_DIR}/daemon/nntp/Decoder.cpp
+	${CMAKE_SOURCE_DIR}/daemon/nntp/StatMeter.cpp
+	${CMAKE_SOURCE_DIR}/daemon/extension/FeedScript.cpp
+	${CMAKE_SOURCE_DIR}/daemon/extension/NzbScript.cpp
+	${CMAKE_SOURCE_DIR}/daemon/extension/QueueScript.cpp
+	${CMAKE_SOURCE_DIR}/daemon/extension/PostScript.cpp
+	${CMAKE_SOURCE_DIR}/daemon/extension/ScanScript.cpp
+	${CMAKE_SOURCE_DIR}/daemon/extension/ExtensionManager.cpp
+	${CMAKE_SOURCE_DIR}/daemon/extension/ExtensionLoader.cpp
+	${CMAKE_SOURCE_DIR}/daemon/extension/ManifestFile.cpp
+	${CMAKE_SOURCE_DIR}/daemon/extension/Extension.cpp
 )
 
 if(WIN32)

--- a/tests/feed/NzbInfoCreatorTest.cpp
+++ b/tests/feed/NzbInfoCreatorTest.cpp
@@ -1,0 +1,329 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include "FeedCoordinator.h"
+#include "FeedInfo.h"
+#include "DownloadInfo.h"
+
+static FeedInfo MakeFeedInfo(
+	int id,
+	const char* category,
+	FeedInfo::CategorySource categorySource,
+	const char* name = "Test Feed",
+	const char* url = "https://example.com/feed"
+)
+{
+	return FeedInfo(
+		id,
+		name,
+		url,
+		false, // backlog
+		15,    // interval
+		"",    // filter
+		true,  // pauseNzb
+		category,
+		categorySource,
+		10,    // priority
+		"nzb"  // extensions
+	);
+}
+
+static void InitItemInfo(
+	FeedItemInfo& item,
+	const char* url = "https://example.com/file.nzb",
+	const char* filename = "TestFile",
+	const char* category = "",
+	const char* addCategory = "",
+	int64 size = 12345,
+	time_t time = 1000,
+	int priority = 5,
+	bool pause = true,
+	const char* dupeKey = "dupe-key",
+	int dupeScore = 7,
+	EDupeMode dupeMode = EDupeMode::dmAll
+)
+{
+	item.SetUrl(url);
+	item.SetFilename(filename);
+	item.SetCategory(category);
+	item.SetAddCategory(addCategory);
+	item.SetSize(size);
+	item.SetTime(time);
+	item.SetPriority(priority);
+	item.SetPauseNzb(pause);
+	item.SetDupeKey(dupeKey);
+	item.SetDupeScore(dupeScore);
+	item.SetDupeMode(dupeMode);
+}
+
+// Test the NzbInfoCreator class
+BOOST_AUTO_TEST_CASE(CreateNzbInfoTest)
+{
+	const NzbInfoCreator creator;
+	const FeedInfo feedInfo = MakeFeedInfo(42, "Movies", FeedInfo::CategorySource::Auto);
+	FeedItemInfo itemInfo;
+	InitItemInfo(itemInfo);
+
+	const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+
+	BOOST_REQUIRE(nzbInfo);
+	BOOST_CHECK_EQUAL(nzbInfo->GetKind(), NzbInfo::nkUrl);
+	BOOST_CHECK_EQUAL(nzbInfo->GetFeedId(), 42);
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetUrl()), "https://example.com/file.nzb");
+	BOOST_CHECK_EQUAL(nzbInfo->GetPriority(), 5);
+	BOOST_CHECK_EQUAL(nzbInfo->GetAddUrlPaused(), true);
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetDupeKey()), "dupe-key");
+	BOOST_CHECK_EQUAL(nzbInfo->GetDupeScore(), 7);
+	BOOST_CHECK_EQUAL(nzbInfo->GetDupeMode(), EDupeMode::dmAll);
+	BOOST_CHECK_EQUAL(nzbInfo->GetSize(), 12345);
+	BOOST_CHECK_EQUAL(nzbInfo->GetMinTime(), (time_t)1000);
+	BOOST_CHECK_EQUAL(nzbInfo->GetMaxTime(), (time_t)1000);
+}
+
+BOOST_AUTO_TEST_CASE(FilenameExtensionHandlingTest)
+{
+	const NzbInfoCreator creator;
+	const FeedInfo feedInfo = MakeFeedInfo(1, "TV", FeedInfo::CategorySource::Auto);
+
+	// Test 1: No extension -> .nzb appended
+	{
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo, "https://example.com/1", "Alpha.Beta");
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetFilename()), "Alpha.Beta.nzb");
+	}
+
+	// Test 2: Already has .nzb -> ensure single .nzb
+	{
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo, "https://example.com/2", "Gamma.nZb");
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetFilename()), "Gamma.nzb");
+	}
+
+	// Test 3: Empty filename -> no extension added
+	{
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo, "https://example.com/4", "");
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetFilename()), "");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(ApplyCategoryOverridesTest)
+{
+	const NzbInfoCreator creator;
+
+	// AddCategory should always override everything
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, "FeedCategory", FeedInfo::CategorySource::Auto);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory("ItemCategory");
+		itemInfo.SetAddCategory("OverrideCategory");
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "OverrideCategory");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(ApplyCategoryFeedFileSourceTest)
+{
+	const NzbInfoCreator creator;
+
+	// FeedFile source should use feed category, ignore item category
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, "FeedCategory", FeedInfo::CategorySource::FeedFile);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory("ItemCategory");
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "FeedCategory");
+	}
+
+	// Empty feed category should result in empty category
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, "", FeedInfo::CategorySource::FeedFile);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory("ItemCategory");
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(ApplyCategoryNZBFileSourceTest)
+{
+	const NzbInfoCreator creator;
+
+	// NZBFile source should use item category, ignore feed category
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, "FeedCategory", FeedInfo::CategorySource::NZBFile);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory("ItemCategory");
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "ItemCategory");
+	}
+
+	// Empty item category should result in empty category
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, "FeedCategory", FeedInfo::CategorySource::NZBFile);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory("");
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(ApplyCategoryAutoSourceTest)
+{
+	const NzbInfoCreator creator;
+
+	// Auto source should try item category first, fallback to feed category
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, "FeedCategory", FeedInfo::CategorySource::Auto);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory("ItemCategory");
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "ItemCategory");
+	}
+
+	// Auto source should fallback to feed category when item category is empty
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, "FeedCategory", FeedInfo::CategorySource::Auto);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory("");
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "FeedCategory");
+	}
+
+	// Auto source should use empty string when both are empty
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, "", FeedInfo::CategorySource::Auto);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory("");
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(ApplyCategoryEdgeCasesTest)
+{
+	const NzbInfoCreator creator;
+
+	// Test with nullptr categories (should be handled gracefully)
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, nullptr, FeedInfo::CategorySource::FeedFile);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory(nullptr);
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "");
+	}
+
+	// Test with whitespace-only categories
+	{
+		const FeedInfo feedInfo = MakeFeedInfo(1, "   ", FeedInfo::CategorySource::FeedFile);
+		FeedItemInfo itemInfo;
+		InitItemInfo(itemInfo);
+		itemInfo.SetCategory("   ");
+
+		const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+		BOOST_REQUIRE(nzbInfo);
+		// Should preserve whitespace (Util::EmptyStr checks for empty, not whitespace)
+		BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "   ");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(CreateNzbInfoAllPropertiesTest)
+{
+	const NzbInfoCreator creator;
+	const FeedInfo feedInfo = MakeFeedInfo(42, "Movies>HD", FeedInfo::CategorySource::Auto);
+	FeedItemInfo itemInfo;
+	InitItemInfo(
+		itemInfo,
+		"https://example.com/movie.nzb",
+		"Movie.Title.2024",
+		"Movies>HD",
+		"OverrideCategory",
+		987654321,
+		2000,
+		15,
+		false,
+		"movie-key-123",
+		10,
+		EDupeMode::dmScore
+	);
+
+	const auto nzbInfo = creator.Create(feedInfo, itemInfo);
+
+	BOOST_REQUIRE(nzbInfo);
+
+	// Basic properties
+	BOOST_CHECK_EQUAL(nzbInfo->GetKind(), NzbInfo::nkUrl);
+	BOOST_CHECK_EQUAL(nzbInfo->GetFeedId(), 42);
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetUrl()), "https://example.com/movie.nzb");
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetFilename()), "Movie.Title.2024.nzb");
+
+	// Category (AddCategory should override)
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCategory()), "OverrideCategory");
+
+	// Priority and pause settings
+	BOOST_CHECK_EQUAL(nzbInfo->GetPriority(), 15);
+	BOOST_CHECK_EQUAL(nzbInfo->GetAddUrlPaused(), false);
+
+	// Dupe settings
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetDupeKey()), "movie-key-123");
+	BOOST_CHECK_EQUAL(nzbInfo->GetDupeScore(), 10);
+	BOOST_CHECK_EQUAL(nzbInfo->GetDupeMode(), EDupeMode::dmScore);
+
+	// Size and time
+	BOOST_CHECK_EQUAL(nzbInfo->GetSize(), 987654321);
+	BOOST_CHECK_EQUAL(nzbInfo->GetMinTime(), (time_t)2000);
+	BOOST_CHECK_EQUAL(nzbInfo->GetMaxTime(), (time_t)2000);
+}

--- a/tests/feed/main.cpp
+++ b/tests/feed/main.cpp
@@ -26,12 +26,36 @@
 #include "Options.h"
 #include "WorkState.h"
 #include "DiskState.h"
+#include "ArticleWriter.h"
+#include "DupeCoordinator.h"
+#include "ExtensionManager.h"
+#include "HistoryCoordinator.h"
+#include "QueueCoordinator.h"
+#include "UrlCoordinator.h"
+#include "QueueScript.h"
+#include "PrePostProcessor.h"
+#include "Scanner.h"
+#include "StatMeter.h"
+#include "Service.h"
+#include "ServerPool.h"
 
 char* (*g_EnvironmentVariables)[];
 Log* g_Log;
 WorkState* g_WorkState;
 Options* g_Options;
 DiskState* g_DiskState;
+ArticleCache* g_ArticleCache;
+DupeCoordinator* g_DupeCoordinator;
+HistoryCoordinator* g_HistoryCoordinator;
+PrePostProcessor* g_PrePostProcessor;
+QueueScriptCoordinator* g_QueueScriptCoordinator;
+QueueCoordinator* g_QueueCoordinator;
+UrlCoordinator* g_UrlCoordinator;
+ServiceCoordinator* g_ServiceCoordinator;
+Scanner* g_Scanner;
+StatMeter* g_StatMeter;
+ServerPool* g_ServerPool;
+ExtensionManager::Manager* g_ExtensionManager;
 
 struct InitGlobals
 {


### PR DESCRIPTION
## Description

[#652](https://github.com/nzbgetcom/nzbget/issues/652)

- Fixed category retrieving and applying when the category set via filter rules;
- Clarified `Feed.Category` and `Feed.CategorySource` option descriptions;
- Refactored NzbInfo creation to improve testability and added unit test coverage for category resolution.

## Testing

- macOS Ventura AMD64