### PR TITLE
Feat: Setting combined TLS 1.3, TLS 1.2, and below ciphers

### DIFF
--- a/daemon/connect/TlsSocket.h
+++ b/daemon/connect/TlsSocket.h
@@ -66,6 +66,16 @@ private:
 	static void InitX509Store(std::string_view certStore);
 	static OpenSSL::X509StorePtr m_X509Store;
 
+	/**
+	 * This function configures the allowed ciphers for both TLSv1.3 and
+	 * older protocols from a single, combined string. OpenSSL
+	 * will parse the string and apply the relevant ciphers to their
+	 * respective protocol versions.
+	 *
+	 * * @note This implementation allows a mixed list, but TLSv1.3 ciphers will
+	 * always be preferred during the handshake if the server supports them,
+	 * regardless of their order in the string.
+	 */
 	bool SetCipherSuite(std::string_view cipher);
 
 	SOCKET m_socket;

--- a/docs/FINDING_BEST_TLS_CIPHER.md
+++ b/docs/FINDING_BEST_TLS_CIPHER.md
@@ -154,12 +154,14 @@ Therefore, choosing either **TLS_AES_128_GCM_SHA256** or **TLS_AES_256_GCM_SHA38
 ### Recommended Configuration
 Based on your benchmark results, create a colon-separated list starting with your fastest cipher. For most users, **AES-128-GCM** will be the winner.
 
-The following string is recommended for the vast majority of systems. It prioritizes the fastest cipher, provides a strong second choice, and includes a fallback for systems without AES hardware acceleration.
+The following string is recommended for the vast majority of systems. 
+It lists the fastest ciphers first, but the server makes the final choice based on what it supports.
 
 ```text
 ServerX.Cipher=TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
 ```
-**We cannot mix TLS 1.3 cipher suites and older (TLS 1.2 and below) ciphers in the same string.**
 
-The underlying OpenSSL library handles them differently. 
-You must provide a list containing only TLS 1.3 ciphers or a list containing only TLS 1.2 ciphers.
+### A Note on Cipher Priority
+
+If you provide a list that mixes **TLS 1.3** and older **TLS 1.2** ciphers, **OpenSSL** will always prefer **TLS 1.3** during the handshake. 
+The server will choose a **TLS 1.3** cipher if possible, regardless of its order in your list.


### PR DESCRIPTION
## Description

- Allowed configuration of combined TLS 1.3, TLS 1.2, and lower ciphers;
- Added the debug logging for the negotiated TLS protocol version and cipher suite;
- Updates documentation.

## Testing

- macOS Ventura