### PR TITLE
handle AUTHINFO USER & AUTHINFO PASS as defined in RFC

### DIFF
--- a/daemon/nserv/NntpServer.cpp
+++ b/daemon/nserv/NntpServer.cpp
@@ -186,7 +186,11 @@ void NntpProcessor::Run()
 		{
 			m_connection->WriteLine(CString::FormatStr("211 0 0 0 %s\r\n", line + 6));
 		}
-		else if (!strncasecmp(line, "AUTHINFO ", 9))
+		else if (!strncasecmp(line, "AUTHINFO USER", 13))
+		{
+			m_connection->WriteLine("381 Enter passphrase\r\n");
+		}
+		else if (!strncasecmp(line, "AUTHINFO PASS", 13))
 		{
 			m_connection->WriteLine("281 Authentication accepted\r\n");
 		}


### PR DESCRIPTION
## Description

Closes https://github.com/nzbgetcom/nzbget/issues/673


So: AUTHINFO USER / PASS sequence handling according to RFC4643.

## Lib changes


None

## Testing

Old:

```
[INFO] [10] Incoming connection from: 127.0.0.1
[DETAIL] [10] Received: authinfo user myusername123
[DETAIL] [10] Received: QUIT
[DETAIL] [10] Closing connection
```

New:

```
[INFO] [3] Incoming connection from: 127.0.0.1
[DETAIL] [3] Received: authinfo user myusername123
[DETAIL] [3] Received: authinfo pass mypassword456
[DETAIL] [3] Received: QUIT
[DETAIL] [3] Closing connection
```

