### PR TITLE
nserv: implement STAT

### DIFF
--- a/daemon/nserv/NntpServer.cpp
+++ b/daemon/nserv/NntpServer.cpp
@@ -64,6 +64,7 @@ private:
 	int64 m_offset;
 	int m_size;
 	bool m_sendHeaders;
+	bool m_sendStat;
 	int64 m_start;
 	NntpCache* m_cache;
 
@@ -174,12 +175,21 @@ void NntpProcessor::Run()
 		{
 			m_messageid = line + 8;
 			m_sendHeaders = true;
+			m_sendStat = false;
 			ServArticle();
 		}
 		else if (!strncasecmp(line, "BODY ", 5))
 		{
 			m_messageid = line + 5;
 			m_sendHeaders = false;
+			m_sendStat = false;
+			ServArticle();
+		}
+		else if (!strncasecmp(line, "STAT ", 5))
+		{
+			m_messageid = line + 5;
+			m_sendHeaders = false;
+			m_sendStat = true;
 			ServArticle();
 		}
 		else if (!strncasecmp(line, "GROUP ", 6))
@@ -348,6 +358,14 @@ void NntpProcessor::SendSegment()
 	{
 		m_connection->WriteLine(CString::FormatStr("403 %s\r\n", *errmsg));
 		return;
+	}
+
+	// if we get here, everything is ok: input is OK, article exists
+
+	if (m_sendStat)
+	{
+		m_connection->WriteLine(CString::FormatStr("223 %s\r\n", m_messageid));
+		return; // done
 	}
 
 	m_connection->WriteLine(CString::FormatStr("%i, 0 %s\r\n", m_sendHeaders ? 222 : 220, m_messageid));


### PR DESCRIPTION
Solves https://github.com/nzbgetcom/nzbget/issues/688

BUT ... feel free to refuse if code is ugly.

## Description

implements STAT in nserv

## Lib changes

None

## Testing

Manual:

```
$ telnet localhost 6791
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
200 Welcome (NServ)
STAT <100mb.bin?208=103500000:500000>
223 <100mb.bin?208=103500000:500000>
STAT <aaaa>
430 No Such Article Found (invalid message id format)
QUIT
205 Connection closing
Connection closed by foreign host.
```

SABnzbd:

```
2025-11-13 10:29:55,501::DEBUG::[downloader:756] Article <100mb.bin?37=18000000:500000> is present
2025-11-13 10:29:55,501::DEBUG::[downloader:756] Article <100mb.bin?38=18500000:500000> is present
2025-11-13 10:29:55,502::DEBUG::[downloader:756] Article <100mb.bin?39=19000000:500000> is present
2025-11-13 10:29:55,502::DEBUG::[downloader:756] Article <100mb.bin?40=19500000:500000> is present
```