### PR TITLE
AppHealth: Paths handling in Options and improve const correctness

### DIFF
--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -16,7 +16,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
@@ -26,7 +26,6 @@
 #include <string_view>
 #include "NString.h"
 #include "Thread.h"
-#include "Util.h"
 #include "FeedInfo.h"
 
 
@@ -301,20 +300,29 @@ public:
 	class Category
 	{
 	public:
-		Category(const char* name, const char* destDir, bool unpack, const char* extensions) :
-			m_name(name), m_destDir(destDir), m_unpack(unpack), m_extensions(extensions) {}
-		const char* GetName() { return m_name; }
-		const char* GetDestDir() { return m_destDir; }
-		bool GetUnpack() { return m_unpack; }
-		const char* GetExtensions() { return m_extensions; }
+		Category(const char* name, const char* destDir, bool unpack, const char* extensions)
+			: m_name(name ? name : ""),
+			  m_destDir(destDir ? destDir : ""),
+			  m_extensions(extensions ? extensions : ""),
+			  m_destDirPath(m_destDir),
+			  m_unpack(unpack)
+		{
+		}
+		const char* GetName() const { return m_name.c_str(); }
+		const char* GetDestDir() const { return m_destDir.c_str(); }
+		const boost::filesystem::path& GetDestDirPath() const { return m_destDirPath; }
+		bool GetUnpack() const { return m_unpack; }
+		const char* GetExtensions() const { return m_extensions.c_str(); }
 		NameList* GetAliases() { return &m_aliases; }
+		const NameList* GetAliases() const { return &m_aliases; }
 
 	private:
-		CString m_name;
-		CString m_destDir;
-		bool m_unpack;
-		CString m_extensions;
+		const std::string m_name;
+		const std::string m_destDir;
+		const std::string m_extensions;
+		const boost::filesystem::path m_destDirPath;
 		NameList m_aliases;
+		const bool m_unpack;
 	};
 
 	typedef std::deque<Category> CategoriesBase;
@@ -491,6 +499,26 @@ public:
 	void SetRemoteClientMode(bool remoteClientMode) { m_remoteClientMode = remoteClientMode; }
 	bool GetRemoteClientMode() const { return m_remoteClientMode; }
 
+	const boost::filesystem::path& GetAppDirPath() const { return m_appDirPath; }
+	const boost::filesystem::path& GetConfigFilePath() const { return m_configFilePath; }
+	const boost::filesystem::path& GetMainDirPath() const { return m_mainDirPath; }
+	const boost::filesystem::path& GetDestDirPath() const { return m_destDirPath; }
+	const boost::filesystem::path& GetInterDirPath() const { return m_interDirPath; }
+	const boost::filesystem::path& GetTempDirPath() const { return m_tempDirPath; }
+	const boost::filesystem::path& GetQueueDirPath() const { return m_queueDirPath; }
+	const boost::filesystem::path& GetNzbDirPath() const { return m_nzbDirPath; }
+	const boost::filesystem::path& GetWebDirPath() const { return m_webDirPath; }
+	const boost::filesystem::path& GetConfigTemplatePath() const { return m_configTemplatePath; }
+	const boost::filesystem::path& GetScriptDirPath() const { return m_scriptDirPath; }
+	const boost::filesystem::path& GetSecureCertPath() const { return m_secureCertPath; }
+	const boost::filesystem::path& GetSecureKeyPath() const { return m_secureKeyPath; }
+	const boost::filesystem::path& GetCertStorePath() const { return m_certStorePath; }
+	const boost::filesystem::path& GetLockFilePath() const { return m_lockFilePath; }
+	const boost::filesystem::path& GetLogFilePath() const { return m_logFilePath; }
+	const boost::filesystem::path& GetUnpackPassFilePath() const { return m_unpackPassFilePath; }
+	const boost::filesystem::path& GetUnrarPath() const { return m_unrarPath; }
+	const boost::filesystem::path& GetSevenZipPath() const { return m_sevenZipPath; }
+
 private:
 	void CheckDirs();
 
@@ -503,6 +531,26 @@ private:
 	Extender* m_extender;
 
 	// Options
+	boost::filesystem::path m_appDirPath;
+	boost::filesystem::path m_configFilePath;
+	boost::filesystem::path m_mainDirPath;
+	boost::filesystem::path m_destDirPath;
+	boost::filesystem::path m_interDirPath;
+	boost::filesystem::path m_tempDirPath;
+	boost::filesystem::path m_queueDirPath;
+	boost::filesystem::path m_nzbDirPath;
+	boost::filesystem::path m_webDirPath;
+	boost::filesystem::path m_configTemplatePath;
+	boost::filesystem::path m_scriptDirPath;
+	boost::filesystem::path m_secureCertPath;
+	boost::filesystem::path m_secureKeyPath;
+	boost::filesystem::path m_certStorePath;
+	boost::filesystem::path m_lockFilePath;
+	boost::filesystem::path m_logFilePath;
+	boost::filesystem::path m_unpackPassFilePath;
+	boost::filesystem::path m_unrarPath;
+	boost::filesystem::path m_sevenZipPath;
+
 	bool m_configErrors = false;
 	int m_configLine = 0;
 	CString m_appDir;
@@ -642,6 +690,8 @@ private:
 	OptEntry* FindOption(const char* optname);
 	const char* GetOption(const char* optname);
 	void SetOption(const char* optname, const char* value);
+	void SetPathOption(boost::filesystem::path& pathOpt, std::string_view value);
+	void SetCmdOption(boost::filesystem::path& pathOpt, std::string_view value);
 	bool SetOptionString(const char* option);
 	bool ValidateOptionName(const char* optname, const char* optvalue);
 	void LoadConfigFile();

--- a/daemon/main/Scheduler.cpp
+++ b/daemon/main/Scheduler.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2008-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -194,9 +194,9 @@ void Scheduler::ExecuteTask(Task* task)
 	switch (task->m_command)
 	{
 		case scDownloadRate:
-			if (!task->m_param.Empty())
+			if (!task->m_param.empty())
 			{
-				g_WorkState->SetSpeedLimit(atoi(task->m_param) * 1024);
+				g_WorkState->SetSpeedLimit(atoi(task->m_param.c_str()) * 1024);
 				m_downloadRateChanged = true;
 			}
 			break;
@@ -223,19 +223,19 @@ void Scheduler::ExecuteTask(Task* task)
 		case scProcess:
 			if (executeProcess)
 			{
-				SchedulerScriptController::StartScript(task->m_param, task->m_command == scProcess, task->m_id);
+				SchedulerScriptController::StartScript(task->m_param.c_str(), task->m_command == scProcess, task->m_id);
 			}
 			break;
 
 		case scActivateServer:
 		case scDeactivateServer:
-			EditServer(task->m_command == scActivateServer, task->m_param);
+			EditServer(task->m_command == scActivateServer, task->m_param.c_str());
 			break;
 
 		case scFetchFeed:
 			if (executeProcess)
 			{
-				FetchFeed(task->m_param);
+				FetchFeed(task->m_param.c_str());
 				break;
 			}
 	}

--- a/daemon/main/Scheduler.h
+++ b/daemon/main/Scheduler.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2008-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,14 +15,13 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
 #ifndef SCHEDULER_H
 #define SCHEDULER_H
 
-#include "NString.h"
 #include "Thread.h"
 #include "Service.h"
 
@@ -47,31 +47,45 @@ public:
 	class Task
 	{
 	public:
-		Task(int id, int hours, int minutes, int weekDaysBits, ECommand command,
-			const char* param) :
-			m_id(id), m_hours(hours), m_minutes(minutes),
-			m_weekDaysBits(weekDaysBits), m_command(command), m_param(param) {}
+		Task(int id, int hours, int minutes, int weekDaysBits, ECommand command, const char* param)
+			: m_id(id),
+			  m_hours(hours),
+			  m_minutes(minutes),
+			  m_weekDaysBits(weekDaysBits),
+			  m_command(command),
+			  m_param(param ? param : "")
+		{
+		}
 		friend class Scheduler;
 		static const int STARTUP_TASK = -1;
+		int GetId() const { return m_id; }
+		int GetHours() const { return m_hours; }
+		int GetMinutes() const { return m_minutes; }
+		int GetWeeDaysBits() const { return m_weekDaysBits; }
+		ECommand GetCommand() const { return m_command; }
+		const std::string& GetParam() const { return m_param; }
+
 	private:
-		int m_id;
-		int m_hours;
-		int m_minutes;
-		int m_weekDaysBits;
-		ECommand m_command;
-		CString m_param;
+		const int m_id;
+		const int m_hours;
+		const int m_minutes;
+		const int m_weekDaysBits;
+		const ECommand m_command;
+		const std::string m_param;
 		time_t m_lastExecuted = 0;
 	};
 
+	using TaskList = std::vector<std::unique_ptr<Task>>;
+
+	const TaskList& GetTasks() const { return m_taskList; }
 	void AddTask(std::unique_ptr<Task> task);
 
 protected:
-	virtual int ServiceInterval() { return m_serviceInterval; }
-	virtual void ServiceWork();
+	int ServiceInterval() override { return m_serviceInterval; }
+	void ServiceWork() override;
 
 private:
-	typedef std::vector<std::unique_ptr<Task>> TaskList;
-	typedef std::vector<bool> ServerStatusList;
+	using ServerStatusList = std::vector<bool>;
 
 	TaskList m_taskList;
 	Mutex m_taskListMutex;

--- a/daemon/util/Utf8.cpp
+++ b/daemon/util/Utf8.cpp
@@ -26,44 +26,44 @@
 
 namespace Utf8
 {
-	std::optional<std::wstring> Utf8ToWide(const std::string& str)
+	std::optional<std::wstring> Utf8ToWide(std::string_view str)
 	{
 		if (str.empty()) return L"";
 
-		int requiredSize = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
+		int requiredSize = MultiByteToWideChar(CP_UTF8, 0, str.data(), -1, nullptr, 0);
 		if (requiredSize <= 0) return std::nullopt;
 
 		if (requiredSize <= STACK_BUFFER_SIZE)
 		{
 			wchar_t buffer[STACK_BUFFER_SIZE];
-			int result = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, buffer, STACK_BUFFER_SIZE);
+			int result = MultiByteToWideChar(CP_UTF8, 0, str.data(), -1, buffer, STACK_BUFFER_SIZE);
 			if (result <= 0) return std::nullopt;
 			return std::wstring(buffer);
 		}
 
 		auto buffer = std::make_unique<wchar_t[]>(requiredSize);
-		int result = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, buffer.get(), requiredSize);
+		int result = MultiByteToWideChar(CP_UTF8, 0, str.data(), -1, buffer.get(), requiredSize);
 		if (result <= 0) return std::nullopt;
 		return std::wstring(buffer.get());
 	}
 
-	std::optional<std::string> WideToUtf8(const std::wstring& wstr)
+	std::optional<std::string> WideToUtf8(std::wstring_view wstr)
 	{
 		if (wstr.empty()) return "";
 
-		int requiredSize = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr, 0, nullptr, nullptr);
+		int requiredSize = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), -1, nullptr, 0, nullptr, nullptr);
 		if (requiredSize <= 0) return std::nullopt;
 
 		if (requiredSize <= STACK_BUFFER_SIZE)
 		{
 			char buffer[STACK_BUFFER_SIZE];
-			int result = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, buffer, STACK_BUFFER_SIZE, nullptr, nullptr);
+			int result = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), -1, buffer, STACK_BUFFER_SIZE, nullptr, nullptr);
 			if (result <= 0) return std::nullopt;
 			return std::string(buffer);
 		}
 
 		auto buffer = std::make_unique<char[]>(requiredSize);
-		int result = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, buffer.get(), requiredSize, nullptr, nullptr);
+		int result = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), -1, buffer.get(), requiredSize, nullptr, nullptr);
 		if (result <= 0) return std::nullopt;
 		return std::string(buffer.get());
 	}

--- a/daemon/util/Utf8.h
+++ b/daemon/util/Utf8.h
@@ -27,8 +27,8 @@
 namespace Utf8
 {
 	inline constexpr int STACK_BUFFER_SIZE = 1024;
-	std::optional<std::wstring> Utf8ToWide(const std::string& str);
-	std::optional<std::string> WideToUtf8(const std::wstring& wstr);
+	std::optional<std::wstring> Utf8ToWide(std::string_view str);
+	std::optional<std::string> WideToUtf8(std::wstring_view wstr);
 }
 
 #endif


### PR DESCRIPTION
## Description

- Added `boost::filesystem::path` members and accessors to `Options.h` (AppDir, ConfigFile, MainDir, etc.);
- Marked some methods as `const`;
- Replaced usage of `CString` with `std::string` in various locations.

## Testing

- macOS Ventura AMD64;
- Windows 11 AMD64.