### PR TITLE
Fix: Error block overlapping

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -220,30 +220,32 @@
 </div>
 
 <!-- *** ERROR BLOCK  ****************************************************************** -->
-<div class="alert alert-danger alert-block" style="display:none; overflow:auto;" id="ErrorAlert">
-	<h4 class="alert-heading" id="ErrorAlert-title">Communication error!</h4>
-	<p id="ErrorAlert-text"></p>
-</div>
+<div class="error-block">
+	<div class="alert alert-danger alert-block" style="display:none; overflow:auto;" id="ErrorAlert">
+		<h4 class="alert-heading" id="ErrorAlert-title">Communication error!</h4>
+		<p id="ErrorAlert-text"></p>
+	</div>
 
-<!-- *** ERROR BLOCK  ****************************************************************** -->
-<div id="RefreshError" data-duration="1000" style="display:none" class="alert alert-inverse alert-center alert-center-small hide">
-    <strong>Communication error, retrying...</strong>
-</div>
+	<!-- *** ERROR BLOCK  ****************************************************************** -->
+	<div id="RefreshError" data-duration="1000" style="display:none" class="alert alert-inverse alert-center alert-center-small hide">
+		<strong>Communication error, retrying...</strong>
+	</div>
 
-<!-- *** INIT LOADING-ALERT ************************************************************ -->
-<div class="alert alert-info alert-block" id="FirstUpdateInfo">
-	<h4 class="alert-heading">Loading...</h4>
-	Please wait.
-</div>
+	<!-- *** INIT LOADING-ALERT ************************************************************ -->
+	<div class="alert alert-info alert-block" id="FirstUpdateInfo">
+		<h4 class="alert-heading">Loading...</h4>
+		Please wait.
+	</div>
 
-<!-- *** UNSUPPORTED BROWSER: IE < 9 *************************************************** -->
-<div class="alert alert-danger alert-block unsupported-browser" style="display:none;" id="UnsupportedBrowserIE8Alert">
-	<h4 class="alert-heading">Unsupported browser!</h4>
-	<p>Sorry but this application doesn't work with Internet Explorer versions below 9. Please
-	upgrade to at least IE 9 or use another browser.</p>
-	<p>If you believe you are getting this message by mistake, please check
-	whether the compatibility mode is active in IE and switch it off to activate
-	all browser functionality required for the application.</p>
+	<!-- *** UNSUPPORTED BROWSER: IE < 9 *************************************************** -->
+	<div class="alert alert-danger alert-block unsupported-browser" style="display:none;" id="UnsupportedBrowserIE8Alert">
+		<h4 class="alert-heading">Unsupported browser!</h4>
+		<p>Sorry but this application doesn't work with Internet Explorer versions below 9. Please
+		upgrade to at least IE 9 or use another browser.</p>
+		<p>If you believe you are getting this message by mistake, please check
+		whether the compatibility mode is active in IE and switch it off to activate
+		all browser functionality required for the application.</p>
+	</div>
 </div>
 
 <!-- *** CONTENT ************************************************************ -->

--- a/webui/style.css
+++ b/webui/style.css
@@ -925,6 +925,10 @@ h2 {
 	margin-bottom: 10px;
 }
 
+.error-block {
+	margin: 15px 0;
+}
+
 /* remove focus border */
 .nav-tabs > .active > a, .nav-tabs > .active > a:hover,
 .nav-pills > .active > a, .nav-pills > .active > a:hover,


### PR DESCRIPTION
## Description

- Fixed: error block overlapping header

## Testing

- Safari 18.6;
- Chrome 142;
- Firefox 144.