### PR TITLE
Ensure daemon ownership for files created at startup

### DIFF
--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -521,9 +521,24 @@ void Options::CheckDir(CString& dir, const char* optionName,
 
 	// Ensure the dir is created
 	CString errmsg;
-	if (create && !FileSystem::ForceDirectories(dir, errmsg))
+	if (create)
 	{
-		ConfigError("Invalid value for option \"%s\" (%s): %s", optionName, *dir, *errmsg);
+		if (!FileSystem::ForceDirectories(dir, errmsg))
+		{
+			ConfigError("Invalid value for option \"%s\" (%s): %s", optionName, *dir, *errmsg);
+			return;
+		}
+
+#ifndef WIN32
+		if (getuid() == 0 || geteuid() == 0)
+		{
+			struct passwd* pwd = getpwnam(GetOption(DAEMONUSERNAME.data()));
+			if (pwd != nullptr)
+			{
+				chown(dir, pwd->pw_uid, pwd->pw_gid);
+			}
+		}
+#endif
 	}
 }
 

--- a/daemon/util/Log.cpp
+++ b/daemon/util/Log.cpp
@@ -96,6 +96,17 @@ void Log::Filelog(const char* msg, ...)
 			m_logFile.reset();
 			return;
 		}
+
+#ifndef WIN32
+		if (getuid() == 0 || geteuid() == 0)
+		{
+			struct passwd* pwd = getpwnam(g_Options->GetDaemonUsername());
+			if (pwd != nullptr)
+			{
+				chown(m_logFilename, pwd->pw_uid, pwd->pw_gid);
+			}
+		}
+#endif
 	}
 
 	m_logFile->Seek(0, DiskFile::soEnd);


### PR DESCRIPTION
PR #345 introduced checks for successful privdrop and ensured that missing files/directories were created as `DaemonUsername`. However, this was partly reverted due to regressions in extensions (#353).

This partial revert caused a side effect where missing files and folders are once again created by `root` during startup.

This commit fixes the ownership issue by explicitly calling chown(2) after creation, ensuring the privdropped daemon can access its data.

Tested on OpenBSD.


@bacon-cheeseburger, please chime in.