### PR TITLE
Docker: Fix entrypoint to run as PID 1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,11 +22,11 @@ RUN \
   curl -o /tmp/unrar7.tar.gz -L "https://www.rarlab.com/rar/unrarsrc-${UNRAR7_VERSION}.tar.gz" && \
   tar xf /tmp/unrar7.tar.gz -C /tmp/unrar7 --strip-components=1 && \
   cd /tmp/unrar7 && \
-  if [ "${UNRAR7_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/amd64" ]; \
+  if [ "${UNRAR7_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" = "linux/amd64" ]; \
     then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=x86-64-v2|" makefile; fi && \
-  if [ "${UNRAR7_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/arm64" ]; \
+  if [ "${UNRAR7_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" = "linux/arm64" ]; \
     then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=armv8-a+crypto+crc|" makefile; fi && \
-  if [ "${UNRAR7_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" == "linux/arm/v7" ]; \
+  if [ "${UNRAR7_NATIVE}" != "true" ] && [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; \
     then sed -i "s|CXXFLAGS=-march=native|CXXFLAGS=-march=armv7-a|" makefile; fi && \
   make -j ${MAKE_JOBS} && \
   install -v -m755 unrar /usr/bin/unrar7 && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN \
   install -v -m755 _o/7za /usr/bin/7z
 
 #build nzbget
-ADD ./ nzbget
+COPY ./ /nzbget
 RUN \
   echo "**** build nzbget ****" && \
   mkdir -p /app/nzbget && \
@@ -104,7 +104,7 @@ RUN \
   ln -s /usr/bin/unrar /app/nzbget/unrar && \
   echo "**** cleanup ****" && \
   rm -rf /root/.cache /root/.cargo /tmp/*
-ADD docker/entrypoint.sh /entrypoint.sh
+COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && \
   echo "**** create non-root user ****" && \
   adduser -G users -D -u 1000 -h /config -s /bin/sh user && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ARG CMAKE_BUILD_TYPE=Release
 #install build packages
 RUN \
   echo "**** install build packages ****" && \
-  apk add g++ gcc git libxml2-dev libxslt-dev make ncurses-dev openssl-dev boost-dev curl cmake
+  apk add --no-cache g++ gcc git libxml2-dev libxslt-dev make ncurses-dev openssl-dev boost-dev curl cmake
 
 #install archive packages
 RUN \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,7 +98,7 @@ COPY --from=build /usr/bin/7z /usr/bin/7z
 COPY --from=build /app/nzbget/ /app/nzbget/
 RUN \
   echo "**** install packages ****" && \
-  apk add --no-cache --update shadow libxml2 libxslt openssl python3 boost1.84-json boost1.84-filesystem tzdata && \
+  apk add --no-cache --update shadow su-exec libxml2 libxslt openssl python3 boost1.84-json boost1.84-filesystem tzdata && \
   ln -sf /usr/bin/python3 /usr/bin/python && \
   ln -s /usr/bin/7z /app/nzbget/7za && \
   ln -s /usr/bin/unrar /app/nzbget/unrar && \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -48,7 +48,7 @@ if [ "$(id -u)" -eq 0 ]; then
         echo "*** Could not set permissions on /downloads ; this container may not work as expected ***"
     fi
 
-    su -p user -c "/app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}"
+    exec su-exec user:users /app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}
 else
-    /app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}
+    exec /app/nzbget/nzbget -s -c /config/nzbget.conf -o OutputMode=log ${OPTIONS}
 fi


### PR DESCRIPTION
## Description

Replace `su -p -c` with `exec su-exec` when running as root, and add `exec` when running as non-root user.

Without `exec`, the shell script remains as PID 1 and nzbget runs as a child process. This means Docker's stop signal (`SIGTERM`) are sent to the shell, not nzbget, preventing graceful shutdown. `SIGKILL` is sent when the `SIGTERM` times out.

Using `exec` replaces the shell process with nzbget, making it PID 1. 

There are also small improvements in the Dockerfile:

- [Use COPY instead of ADD](https://docs.docker.com/build/building/best-practices/#add-or-copy)
- Fix equality comparison for `sh`
- Missing `--no-cache` argument for `apk`

## Lib changes

N/A

## Testing

I built and ran the image. When I restarted/stopped it and saw `[INFO] Stopping, please wait...` in the logs.

I performed the same test with `ghcr.io/nzbgetcom/nzbget:v26.0` and the log message didn't appear. 