### PR TITLE
Fix missing nzbget.h includes causing compilation errors

### DIFF
--- a/daemon/queue/UrlCoordinator.cpp
+++ b/daemon/queue/UrlCoordinator.cpp
@@ -18,9 +18,8 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
-#include "Unpack.h"
 #include "nzbget.h"
+#include "Unpack.h"
 
 #include "UrlCoordinator.h"
 #include "Options.h"

--- a/daemon/systemhealth/PathsValidator.cpp
+++ b/daemon/systemhealth/PathsValidator.cpp
@@ -17,6 +17,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "nzbget.h"
 #include "Options.h"
 #include "Status.h"
 #include "Validators.h"


### PR DESCRIPTION
## Description

Hi,
While building nzbget 26.0 for Gentoo, I ran into build problems that I couldn't reproduce when building nzbget manually from the git repo. If you know why, please let me know, I'm curious as to how this slipped past the CI.

Include nzbget.h before other headers in UrlCoordinator.cpp (broken since 0fbd1b5d2fce4e353d2a5ea18e8a75cd708a4335, I assume) and PathsValidator.cpp to ensure functions and types are properly declared before use.

Without this fix, compilation fails with errors like:
```
/var/tmp/portage/net-nntp/nzbget-26.0/work/nzbget-26.0/daemon/queue/UrlCoordinator.cpp:208:25: error: ‘error’ was not declared in this scope
  208 |                         error("Cancelling hanging url download %s", urlDownloader->GetInfoName());
      |                         ^~~~~
```
```
/var/tmp/portage/net-nntp/nzbget-26.0/work/nzbget-26.0/daemon/util/NString.h:67:17: error: ‘free’ was not declared in this scope
   67 |                 free(m_data);
      |                 ^~~~
```

## Lib changes

None

## Testing

Build nzbget.