### PR TITLE
Downgrade not-critical config errors to warnings or info

### DIFF
--- a/daemon/systemhealth/ExtensionScriptsValidator.cpp
+++ b/daemon/systemhealth/ExtensionScriptsValidator.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,9 +17,10 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "Status.h"
+
 #include "nzbget.h"
 
+#include "Status.h"
 #include "ExtensionScriptsValidator.h"
 #include "Validators.h"
 #include "Options.h"

--- a/daemon/systemhealth/PathsValidator.cpp
+++ b/daemon/systemhealth/PathsValidator.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -185,8 +185,8 @@ Status ScriptDirValidator::Validate() const
 	const auto& paths = m_options.GetScriptDirPaths();
 	if (paths.empty())
 	{
-		return Status::Error("'" + std::string(Options::SCRIPTDIR) +
-							 "' is required and cannot be empty");
+		return Status::Warning("'" + std::string(Options::SCRIPTDIR) +
+							 "' is empty. Extensions cannot be found or installed");
 	}
 
 	for (const auto& dir : paths)
@@ -239,7 +239,7 @@ Status LogFileValidator::Validate(const boost::filesystem::path& path, Options::
 
 	if (path.empty())
 	{
-		return Status::Error("Logging is enabled, but '" + std::string(Options::LOGFILE) +
+		return Status::Warning("Logging is enabled, but '" + std::string(Options::LOGFILE) +
 							 "' is set to empty");
 	}
 

--- a/daemon/systemhealth/SecurityValidator.cpp
+++ b/daemon/systemhealth/SecurityValidator.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -138,24 +138,31 @@ Status ControlPortValidator::Validate() const
 
 Status ControlUsernameValidator::Validate() const
 {
-	Status s = RequiredOption(Options::CONTROLUSERNAME, m_options.GetControlUsername());
-	if (!s.IsOk()) return s;
-
 	std::string_view username = m_options.GetControlUsername();
+	if (username.empty())
+	{
+		return Status::Info("Using an empty username is not recommended for security reasons");
+	}
+
 	if (username == "nzbget")
-		return Status::Info("Using default username 'nzbget' is not recommended for security");
+	{
+		return Status::Info("Using default username 'nzbget' is not recommended for security reasons");
+	}
 
 	return Status::Ok();
 }
 
 Status ControlPasswordValidator::Validate() const
 {
-	Status s = CheckPassword(m_options.GetControlPassword());
-	if (!s.IsOk()) return s;
+	std::string_view username = m_options.GetControlUsername();
+	if (username.empty()) return Status::Ok();
 
 	std::string_view password = m_options.GetControlPassword();
 	if (password == "tegbzn6789")
 		return Status::Info("Using default password is not recommended for security");
+
+	Status s = CheckPassword(password);
+	if (!s.IsOk()) return s;
 
 	return Status::Ok();
 }

--- a/daemon/systemhealth/Status.cpp
+++ b/daemon/systemhealth/Status.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,6 +16,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+#include "nzbget.h"
 
 #include "Status.h"
 

--- a/tests/systemhealth/PathsValidatorTest.cpp
+++ b/tests/systemhealth/PathsValidatorTest.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(TestLogFileValidator)
 	fs::path log = tempPath / "nzbget.log";
 
 	Status s1 = validator.Validate("", Options::EWriteLog::wlAppend);
-	BOOST_CHECK(s1.IsError());
+	BOOST_CHECK(s1.IsWarning());
 
 	Status s2 = validator.Validate("", Options::EWriteLog::wlNone);
 	BOOST_CHECK(s2.IsOk());


### PR DESCRIPTION
## Description

- downgrade not-critical config errors to warnings or info;
- added missing PCH header.

## Testing

- macOS Tahoe