### PR TITLE
Fix Windows app crash by adding fs::u8string wrapper for safe UTF-8 path extraction

### DIFF
--- a/daemon/extension/ExtensionManager.cpp
+++ b/daemon/extension/ExtensionManager.cpp
@@ -58,12 +58,7 @@ namespace ExtensionManager
 	{
 		fs::path tmpFileName = g_Options->GetTempDirPath() / (extName + ".tmp.zip");
 
-#ifdef _WIN32
-		const auto tmpFileNameStr =
-			Utf8::WideToUtf8(tmpFileName.wstring()).value_or(tmpFileName.string());
-#else
-		const auto tmpFileNameStr = tmpFileName.string();
-#endif
+		const auto tmpFileNameStr = fs::u8string(tmpFileName);
 
 		std::unique_ptr<WebDownloader> downloader = std::make_unique<WebDownloader>();
 		downloader->SetUrl(url.c_str());
@@ -102,7 +97,7 @@ namespace ExtensionManager
 			if (ec)
 			{
 				return "Failed to remove existing extension (Error: " + deleteExtError.value() + 
-									") and failed to cleanup temporary file '" + filename.string() + 
+									") and failed to cleanup temporary file '" + fs::u8string(filename) + 
 									"' (Error: " + ec.message() + ")";
 			}
 
@@ -140,7 +135,7 @@ namespace ExtensionManager
 			const auto result = extractor->Extract();
 			if (!result.success)
 			{
-				return "Extraction failed for archive '" + file.string() +
+				return "Extraction failed for archive '" + fs::u8string(file) +
 					   "'. Error: " + std::string(result.message);
 			}
 
@@ -149,14 +144,14 @@ namespace ExtensionManager
 			if (ec)
 			{
 				return "Extension unpacked, but failed to delete temporary archive '" +
-					   file.string() + "': " + ec.message();
+					   fs::u8string(file) + "': " + ec.message();
 			}
 
 			return std::nullopt;
 		}
 		catch (const std::exception& e)
 		{
-			return "Extraction of " + file.string() + " failed: " + e.what();
+			return "Extraction of " + fs::u8string(file) + " failed: " + e.what();
 		}
 	}
 

--- a/daemon/queue/Scanner.cpp
+++ b/daemon/queue/Scanner.cpp
@@ -224,7 +224,7 @@ void Scanner::UnpackArchives(const std::vector<fs::path>& archives)
 			{
 				error("Failed to extract %s: %s", filename.c_str(), result.message.data());
 				auto processedArchive = archive;
-				const auto newExtension = archive.extension().string() + ".error";
+				const auto newExtension = fs::u8string(archive.extension()) + ".error";
 				processedArchive.replace_extension(newExtension);
 				fs::rename(archive, processedArchive, ec);
 				if (ec)
@@ -753,9 +753,9 @@ Scanner::EAddStatus Scanner::AddArchive(const char* filename, const char* catego
 #else
 	const auto archiveFile = downloadDir / filename;
 #endif
-	const auto unpackDirStr = unpackDir.string();
-	const auto archiveFileStr = archiveFile.string();
-	const auto downloadDirStr = downloadDir.string();
+	const auto unpackDirStr = fs::u8string(unpackDir);
+	const auto archiveFileStr = fs::u8string(archiveFile);
+	const auto downloadDirStr = fs::u8string(downloadDir);
 
 	fs::create_directories(unpackDir, ec);
 	if (ec)
@@ -872,8 +872,8 @@ Scanner::EAddStatus Scanner::AddArchive(const char* filename, const char* catego
 					continue;
 				}
 
-				const auto destPathStr = destPath.string();
-				const auto filenameStr = destPath.filename().string();
+				const auto destPathStr = fs::u8string(destPath);
+				const auto filenameStr = fs::u8string(destPath.filename());
 
 				CString useCategory = ResolveCategory(category, filenameStr.c_str());
 

--- a/daemon/systemhealth/Validators.cpp
+++ b/daemon/systemhealth/Validators.cpp
@@ -159,7 +159,7 @@ Status Executable(const fs::path& path)
 		return Status::Error(ss.str());
 	}
 
-	std::string ext = path.extension().string();
+	std::string ext = fs::u8string(path.extension());
 	std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 	if (ext == ".exe" || ext == ".bat" || ext == ".cmd" || ext == ".com")
 	{

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -38,6 +38,11 @@ namespace fs
 using namespace std::filesystem;
 using error_code = std::error_code;
 using errc = std::errc;
+
+inline std::string u8string(const path& p)
+{
+	return p.u8string(); 
+}
 }
 
 #else
@@ -57,6 +62,15 @@ inline fs::path u8path(std::string_view pathStr)
 	return fs::path(pathStr); 
 #else
 	return fs::path(pathStr);
+#endif
+}
+
+inline std::string u8string(const path& p)
+{
+#ifdef _WIN32
+	return Utf8::WideToUtf8(p.native()).value_or("");
+#else
+	return p.string();
 #endif
 }
 

--- a/daemon/util/SevenZip.cpp
+++ b/daemon/util/SevenZip.cpp
@@ -36,16 +36,9 @@ using namespace Unpack;
 ScriptController::ArgList SevenZip::MakeArgs() const
 {
 	ScriptController::ArgList args;
-#ifdef _WIN32
-	const auto tool = Utf8::WideToUtf8(m_tool.wstring()).value_or(m_tool.string());
-	const auto outputDir =
-		"-o" + Utf8::WideToUtf8(m_outputDir.wstring()).value_or(m_outputDir.string());
-	const auto archive = Utf8::WideToUtf8(m_archive.wstring()).value_or(m_archive.string());
-#else
-	const auto tool = m_tool.string();
-	const auto outputDir = "-o" + m_outputDir.string();
-	const auto archive = m_archive.string();
-#endif
+	const auto tool = fs::u8string(m_tool);
+	const auto outputDir = "-o" + fs::u8string(m_outputDir);
+	const auto archive = fs::u8string(m_archive);
 
 	args.push_back(tool.c_str());
 	args.push_back("x");
@@ -77,7 +70,7 @@ bool SevenZip::IsSupported(const fs::path& path)
 {
 	if (!path.has_filename() || !path.has_extension()) return false;
 
-	auto filename = path.filename().string();
+	auto filename = fs::u8string(path.filename());
 	std::transform(filename.begin(), filename.end(), filename.begin(),
 				   [](auto c) { return std::tolower(c); });
 	const static std::array<std::string_view, 9> formats{".7z", ".zip", ".7z.001", ".tar", ".gz",

--- a/daemon/util/Unpack.cpp
+++ b/daemon/util/Unpack.cpp
@@ -87,9 +87,9 @@ ExtractorPtr MakeExtractor(fs::path archive, fs::path outputDir,
 		fs::error_code ec;
 		bool exists = fs::exists(toolPath, ec);
 		if (ec)
-			throw std::runtime_error("Failed to access '" + toolPath.string() +
+			throw std::runtime_error("Failed to access '" + fs::u8string(toolPath) +
 									 "': " + ec.message());
-		if (!exists) throw std::runtime_error(toolPath.string() + " doesn't exist");
+		if (!exists) throw std::runtime_error(fs::u8string(toolPath) + " doesn't exist");
 
 		return toolPath;
 	};
@@ -108,6 +108,6 @@ ExtractorPtr MakeExtractor(fs::path archive, fs::path outputDir,
 									   std::move(password), mode);
 	}
 
-	throw std::runtime_error("Unsupported archive format: " + archive.extension().string());
+	throw std::runtime_error("Unsupported archive format: " + fs::u8string(archive.extension()));
 }
 }  // namespace Unpack

--- a/daemon/util/Unrar.cpp
+++ b/daemon/util/Unrar.cpp
@@ -17,6 +17,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "FileSystem.h"
 #include "nzbget.h"
 
 #include <regex>
@@ -38,15 +39,9 @@ using namespace Unpack;
 ScriptController::ArgList Unrar::MakeArgs() const
 {
 	ScriptController::ArgList args;
-#ifdef _WIN32
-	const auto tool = Utf8::WideToUtf8(m_tool.wstring()).value_or(m_tool.string());
-	const auto outputDir = Utf8::WideToUtf8(m_outputDir.wstring()).value_or(m_outputDir.string());
-	const auto archive = Utf8::WideToUtf8(m_archive.wstring()).value_or(m_archive.string());
-#else
-	const auto tool = m_tool.string();
-	const auto outputDir = m_outputDir.string();
-	const auto archive = m_archive.string();
-#endif
+	const auto tool = fs::u8string(m_tool);
+	const auto outputDir = fs::u8string(m_outputDir);
+	const auto archive = fs::u8string(m_archive);
 
 	args.push_back(tool.c_str());
 	args.push_back("x");
@@ -79,7 +74,7 @@ bool Unrar::IsSupported(const fs::path& path)
 {
 	if (!path.has_filename()) return false;
 
-	auto filename = path.filename().string();
+	auto filename = fs::u8string(path.filename());
 	static const std::regex part1Rar("\\.part0*1\\.rar$", std::regex_constants::icase);
 	if (std::regex_search(filename, part1Rar)) return true;
 


### PR DESCRIPTION
## Description

- Fixed the app crash by adding fs::u8string wrapper for safe UTF-8 path extraction on Windows

## Testing

- macOS Tahoe
- Windows 10/11