### PR TITLE
Improve extraction and processing of incoming archives

### DIFF
--- a/daemon/extension/ExtensionManager.cpp
+++ b/daemon/extension/ExtensionManager.cpp
@@ -127,32 +127,28 @@ namespace ExtensionManager
 	std::optional<std::string> Manager::InstallExtension(const fs::path& file,
 														 const fs::path& dest)
 	{
-		try
+		const auto extractor =
+			Unpack::MakeExtractor(file, dest, "", Unpack::OverwriteMode::Overwrite);
+
+		if (!extractor)
 		{
-			const auto extractor =
-				Unpack::MakeExtractor(file, dest, "", Unpack::OverwriteMode::Overwrite);
-
-			const auto result = extractor->Extract();
-			if (!result.success)
-			{
-				return "Extraction failed for archive '" + fs::u8string(file) +
-					   "'. Error: " + std::string(result.message);
-			}
-
-			fs::error_code ec;
-			fs::remove(file, ec);
-			if (ec)
-			{
-				return "Extension unpacked, but failed to delete temporary archive '" +
-					   fs::u8string(file) + "': " + ec.message();
-			}
-
-			return std::nullopt;
+			return "Failed to initialize extraction for archive '" + fs::u8string(file);
 		}
-		catch (const std::exception& e)
+
+		if (!extractor->Extract())
 		{
-			return "Extraction of " + fs::u8string(file) + " failed: " + e.what();
+			return "Extraction failed for archive '" + fs::u8string(file);
 		}
+
+		fs::error_code ec;
+		fs::remove(file, ec);
+		if (ec)
+		{
+			return "Extension unpacked, but failed to delete temporary archive '" +
+				   fs::u8string(file) + "': " + ec.message();
+		}
+
+		return std::nullopt;
 	}
 
 	std::optional<std::string>

--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -359,6 +359,8 @@ void Options::InitDefaults()
 	SetOption(WRITEBUFFER.data(), "0");
 	SetOption(NZBDIRINTERVAL.data(), "5");
 	SetOption(NZBDIRFILEAGE.data(), "60");
+	SetOption(NZBDIRARCHIVESCAN.data(), "yes");
+	SetOption(NZBDIRARCHIVEACTION.data(), "delete");
 	SetOption(DISKSPACE.data(), "250");
 	SetOption(CRASHTRACE.data(), "no");
 	SetOption(CRASHDUMP.data(), "no");
@@ -631,6 +633,11 @@ void Options::InitOptions()
 	m_writeBuffer			= ParseIntValue(WRITEBUFFER.data(), 10);
 	m_nzbDirInterval		= ParseIntValue(NZBDIRINTERVAL.data(), 10);
 	m_nzbDirFileAge			= ParseIntValue(NZBDIRFILEAGE.data(), 10);
+	m_nzbDirArchiveScan		= (bool)ParseEnumValue(NZBDIRARCHIVESCAN.data(), BoolCount, BoolNames, BoolValues);
+	const char* ArchiveActions[] = { "move", "delete" };
+	const int ArchiveActionValues[] = { ENzbDirArchiveAction::Move, ENzbDirArchiveAction::Delete };
+	const int ArchiveActionsCount = 2;
+	m_nzbDirArchiveAction 	= (ENzbDirArchiveAction)ParseEnumValue(NZBDIRARCHIVEACTION.data(), ArchiveActionsCount, ArchiveActions, ArchiveActionValues);
 	m_diskSpace				= ParseIntValue(DISKSPACE.data(), 10);
 	m_parTimeLimit			= ParseIntValue(PARTIMELIMIT.data(), 10);
 	m_keepHistory			= ParseIntValue(KEEPHISTORY.data(), 10);

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -120,6 +120,8 @@ public:
 	static constexpr std::string_view WRITEBUFFER = "WriteBuffer";
 	static constexpr std::string_view NZBDIRINTERVAL = "NzbDirInterval";
 	static constexpr std::string_view NZBDIRFILEAGE = "NzbDirFileAge";
+	static constexpr std::string_view NZBDIRARCHIVESCAN = "NzbDirArchiveScan";
+	static constexpr std::string_view NZBDIRARCHIVEACTION = "NzbDirArchiveAction";
 	static constexpr std::string_view DISKSPACE = "DiskSpace";
 	static constexpr std::string_view CRASHTRACE = "CrashTrace";
 	static constexpr std::string_view CRASHDUMP = "CrashDump";
@@ -262,6 +264,12 @@ public:
 		cvMinimal,
 		cvStrict,
 		Count
+	};
+	
+	enum ENzbDirArchiveAction
+	{
+		Delete,
+		Move
 	};
 
 	class OptEntry
@@ -457,6 +465,8 @@ public:
 	int GetWriteBuffer() const { return m_writeBuffer; }
 	int GetNzbDirInterval() const { return m_nzbDirInterval; }
 	int GetNzbDirFileAge() const { return m_nzbDirFileAge; }
+	bool GetNzbDirArchiveScan() const { return m_nzbDirArchiveScan; }
+	ENzbDirArchiveAction GetNzbDirArchiveAction() const { return m_nzbDirArchiveAction; }
 	int GetDiskSpace() const { return m_diskSpace; }
 	bool GetTls() const { return m_tls; }
 	bool GetCrashTrace() const { return m_crashTrace; }
@@ -644,6 +654,8 @@ private:
 	int m_writeBuffer = 0;
 	int m_nzbDirInterval = 0;
 	int m_nzbDirFileAge = 0;
+	bool m_nzbDirArchiveScan = true;
+	ENzbDirArchiveAction m_nzbDirArchiveAction = ENzbDirArchiveAction::Move;
 	int m_diskSpace = 0;
 	bool m_tls = false;
 	bool m_crashTrace = false;

--- a/daemon/queue/ArchiveProcessor.cpp
+++ b/daemon/queue/ArchiveProcessor.cpp
@@ -1,0 +1,203 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "nzbget.h"
+
+#include "Unpack.h"
+#include "Log.h"
+#include "ArchiveProcessor.h"
+
+namespace Incoming
+{
+
+namespace
+{
+	const char* LOG_PREFIX = "ArchiveProcessor:";
+}
+
+std::optional<std::vector<fs::path>> ArchiveProcessor::Process(const fs::path& archiveFile) const
+{
+	const std::string filenameStr = fs::u8string(archiveFile.filename());
+	info("Extracting '%s'", filenameStr.c_str());
+
+	const auto unpackDir = m_config.unpackDir / fs::make_unique_filename();
+	
+	if (!Extract(archiveFile, unpackDir))
+	{
+		return std::nullopt;
+	}
+
+	ScanResult scanResult = ScanUnpackDir(unpackDir);
+
+	MoveNzbFiles(scanResult.from, scanResult.to);
+
+	fs::error_code ec;
+	fs::remove_all(unpackDir, ec);
+	if (ec)
+	{
+		warn("Failed to clean up temp dir '%s': %s (code: %d)", 
+			 fs::u8string(unpackDir).c_str(), ec.message().c_str(), ec.value());
+	}
+
+	DisposeArchive(archiveFile, scanResult.nonNzbFiles);
+
+	if (scanResult.to.empty())
+	{
+		info("Skipped '%s': No NZB files were found inside", filenameStr.c_str());
+	}
+	else
+	{
+		info("Successfully extracted %zu NZB file(s) from '%s'", scanResult.to.size(), filenameStr.c_str());
+	}
+	
+	return std::move(scanResult.to);
+}
+
+bool ArchiveProcessor::Extract(const fs::path& archiveFile, const fs::path& unpackDir) const
+{
+	const auto extractor = Unpack::MakeExtractor(archiveFile, unpackDir, "", Unpack::OverwriteMode::Overwrite);
+	if (!extractor)
+	{
+		return false;
+	}
+
+	if (!extractor->Extract())
+	{
+		const std::string archiveName = fs::u8string(archiveFile.filename());
+		const std::string brokenDirName = fs::u8string(m_config.brokenDir.filename());
+		error("Failed to extract '%s'. Moving to '%s'", archiveName.c_str(), brokenDirName.c_str());
+
+		fs::error_code ec;
+		fs::remove_all(unpackDir, ec);
+		fs::create_directories(m_config.brokenDir, ec);
+		fs::move_file(archiveFile, fs::make_unique_filename(m_config.brokenDir / archiveFile.filename()), ec);
+		return false;
+	}
+
+	return true;
+}
+
+bool ArchiveProcessor::IsNzbFile(const fs::path& filename) const
+{
+	auto ext = fs::u8string(filename.extension());
+	return strcasecmp(ext.c_str(), ".nzb") == 0;
+}
+
+ArchiveProcessor::ScanResult ArchiveProcessor::ScanUnpackDir(const fs::path& unpackDir) const
+{
+	ScanResult result;
+	result.nonNzbFiles = 0;
+	fs::error_code ec;
+
+	for (auto it = fs::recursive_directory_iterator(unpackDir, fs::directory_options::skip_permission_denied, ec); 
+		!ec && it != fs::recursive_directory_iterator(); 
+		it.increment(ec))
+	{
+		if (!fs::is_regular_file(it->path(), ec)) continue;
+
+		const auto& file = it->path();
+		const auto& filename = file.filename();
+		const std::string filenameStr = fs::u8string(filename);
+
+		if (filenameStr.empty() || filenameStr[0] == '.') continue;
+
+		if (!IsNzbFile(filename))
+		{
+			debug("%s Found non-NZB file '%s'", LOG_PREFIX, filenameStr.c_str());
+			++result.nonNzbFiles;
+			continue;
+		}
+
+		auto relativePath = fs::relative(file, unpackDir, ec);
+		if (ec) continue;
+
+		auto finalDestPath = m_config.destDir / relativePath;
+		result.from.push_back(file);
+		result.to.push_back(std::move(finalDestPath));
+	}
+	
+	result.from.shrink_to_fit();
+	result.to.shrink_to_fit();
+	return result;
+}
+
+void ArchiveProcessor::MoveNzbFiles(const std::vector<fs::path>& from, const std::vector<fs::path>& to) const
+{
+	fs::error_code ec;
+	for (size_t i = 0; i < from.size(); ++i)
+	{
+		fs::create_directories(to[i].parent_path(), ec);
+		fs::move_file(from[i], to[i], ec); 
+		if (ec)
+		{
+			error("Failed to move NZB '%s': %s", fs::u8string(from[i].filename()).c_str(), ec.message().c_str());
+		}
+	}
+}
+
+void ArchiveProcessor::DisposeArchive(const fs::path& archiveFile, int nonNzbFileCount) const
+{
+	const std::string filenameStr = fs::u8string(archiveFile.filename());
+	const std::string processedDirName = fs::u8string(m_config.processedDir.filename());
+
+	fs::error_code ec;
+
+	if (m_config.action == Options::ENzbDirArchiveAction::Delete)
+	{
+		if (nonNzbFileCount > 0)
+		{
+			info("Archive '%s' contains %d non-NZB file(s). Moving to '%s' instead of deleting to prevent data loss", 
+				 filenameStr.c_str(), nonNzbFileCount, processedDirName.c_str());
+			
+			fs::create_directories(m_config.processedDir, ec);
+			fs::move_file(archiveFile, fs::make_unique_filename(m_config.processedDir / archiveFile.filename()), ec);
+			if (ec)
+			{
+				warn("Failed to move archive '%s' to '%s': %s (code: %d)", 
+					 filenameStr.c_str(), processedDirName.c_str(), ec.message().c_str(), ec.value());
+			}
+		}
+		else
+		{
+			if (fs::remove(archiveFile, ec) && !ec)
+			{
+				info("Deleted archive '%s'", filenameStr.c_str());
+			}
+			else if (ec)
+			{
+				warn("Failed to delete archive '%s': %s (code: %d)", 
+					 filenameStr.c_str(), ec.message().c_str(), ec.value());
+			}
+		}
+	}
+	else
+	{
+		info("Moving archive '%s' to '%s'", filenameStr.c_str(), processedDirName.c_str());
+		fs::create_directories(m_config.processedDir, ec);
+		fs::move_file(archiveFile, fs::make_unique_filename(m_config.processedDir / archiveFile.filename()), ec);
+		if (ec)
+		{
+			warn("Failed to move archive '%s' to '%s': %s (code: %d)", 
+				 filenameStr.c_str(), processedDirName.c_str(), ec.message().c_str(), ec.value());
+		}
+	}
+}
+
+}

--- a/daemon/queue/ArchiveProcessor.h
+++ b/daemon/queue/ArchiveProcessor.h
@@ -1,0 +1,66 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef ARCHIVE_PROCESSOR_H
+#define ARCHIVE_PROCESSOR_H
+
+#include <vector>
+#include <optional>
+#include "Options.h"
+#include "FileSystem.h"
+
+namespace Incoming
+{
+
+struct Config
+{
+	fs::path unpackDir;
+	fs::path destDir;
+	fs::path processedDir;
+	fs::path brokenDir;
+	Options::ENzbDirArchiveAction action;
+};
+
+class ArchiveProcessor final
+{
+public:
+	explicit ArchiveProcessor(Config config) : m_config(std::move(config))
+	{}
+	std::optional<std::vector<fs::path>> Process(const fs::path& archiveFile) const;
+
+private:
+	struct ScanResult
+	{
+		std::vector<fs::path> from;
+		std::vector<fs::path> to;
+		int nonNzbFiles{};
+	};
+
+	bool Extract(const fs::path& archiveFile, const fs::path& unpackDir) const;
+	bool IsNzbFile(const fs::path& filename) const;
+	ScanResult ScanUnpackDir(const fs::path& unpackDir) const;
+	void MoveNzbFiles(const std::vector<fs::path>& from, const std::vector<fs::path>& to) const;
+	void DisposeArchive(const fs::path& archiveFilePath, int nonNzbFileCount) const;
+	const Config m_config;
+};
+
+}
+
+#endif

--- a/daemon/queue/Scanner.cpp
+++ b/daemon/queue/Scanner.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -22,8 +22,9 @@
 #include "nzbget.h"
 
 #include <exception>
+#include <filesystem>
 #include <fstream>
-#include <ios>
+#include <memory>
 
 #include "Scanner.h"
 #include "Options.h"
@@ -97,6 +98,8 @@ void Scanner::InitOptions()
 {
 	m_nzbDirInterval = 1;
 	m_scanScript = ScanScriptController::HasScripts();
+
+	CleanupStaleUnpackDir();
 }
 
 int Scanner::ServiceInterval()
@@ -127,12 +130,16 @@ void Scanner::ServiceWork()
 
 	std::lock_guard<std::mutex> guard{m_scanMutex};
 
-	CheckIncomingArchives(g_Options->GetNzbDirPath());
-
 	// check nzbdir every g_Options->GetNzbDirInterval() seconds or if requested
 	bool checkStat = !m_requestedNzbDirScan;
 	m_requestedNzbDirScan = false;
 	m_scanning = true;
+
+	if (g_Options->GetNzbDirArchiveScan())
+	{
+		CheckIncomingArchives(g_Options->GetNzbDirPath());
+	}
+
 	CheckIncomingNzbs(g_Options->GetNzbDir(), "", checkStat);
 	if (!checkStat && m_scanScript)
 	{
@@ -174,21 +181,32 @@ void Scanner::CheckIncomingArchives(const fs::path& dir)
 std::vector<fs::path> Scanner::FindArchives(const fs::path& dir)
 {
 	std::vector<fs::path> archives;
-	archives.reserve(4);
-
-	for (const auto& entry : fs::recursive_directory_iterator(dir))
+	for (auto it = fs::recursive_directory_iterator(dir); it != fs::recursive_directory_iterator(); ++it)
 	{
-		if (!entry.is_regular_file())
-			continue;
+		const auto& path = it->path();
+		const std::string filename = fs::u8string(path.filename());
 
-		if (Unpack::IsArchive(entry.path()))
+		if (ShouldSkipItem(filename))
 		{
-			archives.push_back(entry.path());
+			if (it->is_directory()) 
+			{
+				it.disable_recursion_pending();
+			}
+			continue;
+		}
+
+		if (!it->is_regular_file())
+		{
+			continue;
+		}
+
+		if (Unpack::IsArchive(path))
+		{
+			archives.push_back(path);
 		}
 	}
 
 	archives.shrink_to_fit();
-
 	return archives;
 }
 
@@ -196,50 +214,29 @@ void Scanner::UnpackArchives(const std::vector<fs::path>& archives)
 {
 	if (archives.empty()) return;
 
+	const auto processor = Incoming::ArchiveProcessor({
+		g_Options->GetTempDirPath() / UNPACK_DIR,
+		g_Options->GetNzbDirPath(),
+		g_Options->GetNzbDirPath() / PROCESSED_DIR,
+		g_Options->GetNzbDirPath() / BROKEN_DIR,
+		g_Options->GetNzbDirArchiveAction()
+	});
+
 	for (const auto& archive : archives)
 	{
-		const auto filename = archive.filename();
-		info("Extracting %s", filename.c_str());
+		processor.Process(archive);
+	}
+}
 
-		try
-		{
-			const auto extractor = Unpack::MakeExtractor(archive, archive.parent_path(), "",
-														 Unpack::OverwriteMode::Overwrite);
-
-			const auto result = extractor->Extract();
-			fs::error_code ec;
-			if (result.success)
-			{
-				info("%s extracted successfully", filename.c_str());
-
-				fs::remove(archive, ec);
-				if (ec)
-				{
-					const auto msg = ec.message();
-					error("Failed to remove %s: %s (code %d)", filename.c_str(), msg.c_str(),
-						  ec.value());
-				}
-			}
-			else
-			{
-				error("Failed to extract %s: %s", filename.c_str(), result.message.data());
-				auto processedArchive = archive;
-				const auto newExtension = fs::u8string(archive.extension()) + ".error";
-				processedArchive.replace_extension(newExtension);
-				fs::rename(archive, processedArchive, ec);
-				if (ec)
-				{
-					const auto msg = ec.message();
-					error("Failed to mark archive %s as failed: %s (code %d)", filename.c_str(),
-						  msg.c_str(), ec.value());
-				}
-			}
-		}
-		catch (const std::exception& e)
-		{
-			error("Extraction failed: %s", e.what());
-			continue;
-		}
+void Scanner::CleanupStaleUnpackDir()
+{
+	const fs::path unpackDir = g_Options->GetTempDirPath() / UNPACK_DIR;
+	fs::error_code ec;
+	fs::remove_all(unpackDir, ec);
+	if (ec)
+	{
+		warn("Could not remove stale unpack directory '%s/%s': %s (code %d)", 
+			g_Options->GetTempDir(), UNPACK_DIR.data(), ec.message().c_str(), ec.value());	
 	}
 }
 
@@ -252,9 +249,8 @@ void Scanner::CheckIncomingNzbs(const char* directory, const char* category, boo
 	DirBrowser dir(directory);
 	while (const char* filename = dir.Next())
 	{
-		if (filename[0] == '.')
+		if (ShouldSkipItem(filename))
 		{
-			// skip hidden files
 			continue;
 		}
 
@@ -367,6 +363,12 @@ void Scanner::DropOldFiles()
 			return false;
 		}),
 		m_fileList.end());
+}
+
+bool Scanner::ShouldSkipItem(std::string_view filename)
+{
+	if (filename.empty()) return false;
+	return filename[0] == '.' || filename == PROCESSED_DIR || filename == BROKEN_DIR;
 }
 
 void Scanner::ProcessIncomingFile(
@@ -727,59 +729,28 @@ Scanner::EAddStatus Scanner::AddArchive(const char* filename, const char* catego
 
 	if (g_Options->GetTempDirPath().empty())
 	{
-		error("Failed to create file '%s': '%s' is required and cannot be empty", filename,
-			  Options::TEMPDIR.data());
+		error("Failed to create file '%s': '%s' is required and cannot be empty",
+			filename, Options::TEMPDIR.data());
 		return EAddStatus::asFailed;
 	}
 
 	if (g_Options->GetNzbDirPath().empty())
 	{
-		error("Failed to create file '%s': '%s' is required and cannot be empty", filename,
-			  Options::NZBDIR.data());
+		error("Failed to create file '%s': '%s' is required and cannot be empty",
+			filename, Options::NZBDIR.data());
 		return EAddStatus::asFailed;
 	}
+
+	const auto archiveFilename = FileSystem::MakeValidFilename(filename);
+	const auto archiveFilePath = g_Options->GetTempDirPath() / *archiveFilename;
 
 	fs::error_code ec;
-	const auto downloadDir = g_Options->GetTempDirPath() / fs::make_unique_filename();
-	const auto unpackDir = downloadDir / "_unpack";
-#ifdef _WIN32
-	const auto wfilename = Utf8::Utf8ToWide(filename);
-	if (!wfilename)
 	{
-		error("Failed to covert '%s' to wide string", filename);
-		return EAddStatus::asFailed;
-	}
-	const auto archiveFile = downloadDir / wfilename.value();
-#else
-	const auto archiveFile = downloadDir / filename;
-#endif
-	const auto unpackDirStr = fs::u8string(unpackDir);
-	const auto archiveFileStr = fs::u8string(archiveFile);
-	const auto downloadDirStr = fs::u8string(downloadDir);
-
-	fs::create_directories(unpackDir, ec);
-	if (ec)
-	{
-		const std::string msg = ec.message();
-		error("Could not create directory '%s': %s (code %d)", unpackDirStr.c_str(), msg.c_str(),
-			  ec.value());
-		return EAddStatus::asFailed;
-	}
-
-	{
-		std::ofstream file(archiveFile.c_str(), std::ios::binary);
+		std::ofstream file(archiveFilePath.c_str(), std::ios::binary);
 		if (!file.is_open())
 		{
 			error("Failed to create archive file '%s' in temporary directory: %s",
-				  archiveFileStr.c_str(), std::strerror(errno));
-
-			fs::remove_all(downloadDir, ec);
-			if (ec)
-			{
-				const std::string msg = ec.message();
-				error("Failed to remove temporary directory '%s': %s (code %d)",
-					  downloadDirStr.c_str(), msg.c_str(), ec.value());
-			}
+				*archiveFilename, std::strerror(errno));
 			return EAddStatus::asFailed;
 		}
 
@@ -787,125 +758,65 @@ Scanner::EAddStatus Scanner::AddArchive(const char* filename, const char* catego
 		file.close();
 		if (!file)
 		{
-			error("Failed to write archive file to '%s': %s", archiveFileStr.c_str(),
-				  std::strerror(errno));
-
-			fs::remove_all(downloadDir, ec);
-			if (ec)
-			{
-				const auto msg = ec.message();
-				error("Failed to clean up temporary directory '%s': %s (code %d)",
-					  downloadDirStr.c_str(), msg.c_str(), ec.value());
-			}
+			error("Failed to write data to archive file '%s': %s",
+				*archiveFilename, std::strerror(errno));
+			fs::remove(archiveFilePath, ec);
 			return EAddStatus::asFailed;
 		}
 	}
 
-	try
+	if (!g_Options->GetNzbDirArchiveScan()) 
 	{
-		info("Extracting %s", filename);
-
-		const auto extractor = Unpack::MakeExtractor(std::move(archiveFile), unpackDir, "",
-													 Unpack::OverwriteMode::Overwrite);
-
-		const auto result = extractor->Extract();
-		if (!result.success)
+		const auto finalArchiveFilePath = g_Options->GetNzbDirPath() / *archiveFilename;
+		fs::move_file(archiveFilePath, finalArchiveFilePath, ec);
+		if (ec)
 		{
-			error("Failed to extract '%s' into '%s': %s", archiveFileStr.c_str(),
-				  unpackDirStr.c_str(), result.message.data());
-			fs::remove_all(downloadDir, ec);
-			if (ec)
-			{
-				const auto msg = ec.message();
-				error("Failed to remove temporary directory '%s': %s (code %d)",
-					  downloadDirStr.c_str(), msg.c_str(), ec.value());
-			}
+			error("Failed to move file '%s' to %s: %s",
+				*archiveFilename, Options::NZBDIR.data(), ec.message().c_str());
 			return EAddStatus::asFailed;
 		}
 
-		info("%s extracted successfully", filename);
-
-		std::vector<fs::path> files;
-		files.reserve(4);
-		for (const auto& entry : fs::recursive_directory_iterator(unpackDir))
-		{
-			if (!entry.is_regular_file()) continue;
-
-			files.push_back(std::move(entry.path()));
-		}
-
-		files.shrink_to_fit();
-
-		{
-			std::lock_guard<std::mutex> guard{m_scanMutex};
-
-			for (const auto& file : files)
-			{
-				const auto relativePath = fs::relative(file, unpackDir, ec);
-				if (ec)
-				{
-					const std::string msg = ec.message();
-					error("Failed to calculate relative path for '%s' against '%s': %s (code %d)",
-						  file.c_str(), unpackDirStr.c_str(), msg.c_str(), ec.value());
-					ec.clear();
-					continue;
-				}
-				const auto destPath = g_Options->GetNzbDirPath() / relativePath;
-				const auto parentDir = destPath.parent_path();
-				fs::create_directories(parentDir, ec);
-				if (ec)
-				{
-					const std::string msg = ec.message();
-					error("Failed to create destination directory '%s' for %s (code %d)",
-						  parentDir.c_str(), msg.c_str(), ec.value());
-					ec.clear();
-					continue;
-				}
-
-				fs::copy_file(file, destPath, fs::copy_options::overwrite_existing, ec);
-				if (ec)
-				{
-					const std::string msg = ec.message();
-					error("Failed to copy extracted NZB '%s' to '%s': %s (code %d)", file.c_str(),
-						  destPath.c_str(), msg.c_str(), ec.value());
-					ec.clear();
-					continue;
-				}
-
-				const auto destPathStr = fs::u8string(destPath);
-				const auto filenameStr = fs::u8string(destPath.filename());
-
-				CString useCategory = ResolveCategory(category, filenameStr.c_str());
-
-				m_queueList.emplace_back(destPathStr.c_str(), filenameStr.c_str(), useCategory,
-										 autoCategory, priority, dupeKey, dupeScore, dupeMode,
-										 parameters, addTop, addPaused, urlInfo, nullptr, nullptr);
-			}
-		}
-
-		fs::remove_all(downloadDir, ec);
-		if (ec)
-		{
-			const auto msg = ec.message();
-			error("Cleanup of temporary directory '%s' failed: %s (code %d)", downloadDir.c_str(),
-				  msg.c_str(), ec.value());
-		}
-
-		ScanNzbDir(true);
-		return EAddStatus::asSuccess;
+		info("Skipping processing of '%s': option '%s' is disabled",
+			*archiveFilename, Options::NZBDIRARCHIVESCAN.data());
+		return EAddStatus::asSkipped;
 	}
-	catch (const std::exception& e)
+
 	{
-		error("Extraction failed: %s", e.what());
-		fs::remove_all(downloadDir, ec);
-		if (ec)
+		std::lock_guard<std::mutex> guard{m_scanMutex};
+
+		const auto processor = Incoming::ArchiveProcessor({
+			g_Options->GetTempDirPath() / UNPACK_DIR,
+			g_Options->GetNzbDirPath(),
+			g_Options->GetNzbDirPath() / PROCESSED_DIR,
+			g_Options->GetNzbDirPath() / BROKEN_DIR,
+			g_Options->GetNzbDirArchiveAction()
+		});
+
+		auto nzbFiles = processor.Process(archiveFilePath);
+		if (!nzbFiles)
 		{
-			const std::string msg = ec.message();
-			error("Failed to remove temporary directory '%s': %s (code %d)", downloadDirStr.c_str(),
-				  msg.c_str(), ec.value());
+			return EAddStatus::asFailed;
 		}
-		return EAddStatus::asFailed;
+
+		if (nzbFiles->empty())
+		{
+			return EAddStatus::asSkipped;
+		}
+
+		for (const auto& nzbFile : *nzbFiles)
+		{
+			const auto nzbFilePathStr = fs::u8string(nzbFile);
+			const auto fileName = fs::u8string(nzbFile.filename());
+			const CString useCategory = ResolveCategory(category, fileName.c_str());
+			m_queueList.emplace_back(
+				nzbFilePathStr.c_str(), fileName.c_str(), useCategory,
+				autoCategory, priority, dupeKey, dupeScore, dupeMode,
+				parameters, addTop, addPaused, urlInfo, nullptr, nullptr);
+		}
 	}
+	
+	ScanNzbDir(true);
+	return EAddStatus::asSuccess;
 }
 
 Scanner::EAddStatus Scanner::AddArchive(

--- a/daemon/queue/Scanner.h
+++ b/daemon/queue/Scanner.h
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -27,13 +27,18 @@
 #include <string>
 #include "FileSystem.h"
 #include "DownloadInfo.h"
-#include "Thread.h"
+#include "ArchiveProcessor.h"
+#include "Options.h"
 #include "Service.h"
 #include "NzbFile.h"
 
 class Scanner final : public Service
 {
 public:
+	static constexpr std::string_view PROCESSED_DIR = "_processed";
+	static constexpr std::string_view BROKEN_DIR = "_broken";
+	static constexpr std::string_view UNPACK_DIR = "_unpack";
+
 	enum EAddStatus
 	{
 		asSkipped,
@@ -189,7 +194,9 @@ private:
 	void CheckIncomingArchives(const fs::path& dir);
 	std::vector<fs::path> FindArchives(const fs::path& dir);
 	void UnpackArchives(const std::vector<fs::path>& archives);
+	void CleanupStaleUnpackDir();
 	void CheckIncomingNzbs(const char* directory, const char* category, bool checkStat);
+	bool ShouldSkipItem(std::string_view filename);
 	bool AddFileToQueue(
 		const char* filename, 
 		const char* nzbName, 

--- a/daemon/sources.cmake
+++ b/daemon/sources.cmake
@@ -77,6 +77,7 @@ set(SRC
 	${CMAKE_SOURCE_DIR}/daemon/queue/Scanner.cpp
 	${CMAKE_SOURCE_DIR}/daemon/queue/UrlCoordinator.cpp
 	${CMAKE_SOURCE_DIR}/daemon/queue/Deobfuscation.cpp
+	${CMAKE_SOURCE_DIR}/daemon/queue/ArchiveProcessor.cpp
 
 	${CMAKE_SOURCE_DIR}/daemon/remote/BinRpc.cpp
 	${CMAKE_SOURCE_DIR}/daemon/remote/RemoteClient.cpp
@@ -139,12 +140,12 @@ set(WIN32_SRC
 	${CMAKE_SOURCE_DIR}/daemon/util/Utf8.cpp
 )
 
-if(WIN32) 
+if(WIN32)
 	set(SRC ${SRC} ${WIN32_SRC})
 	set(INCLUDES ${INCLUDES} ${CMAKE_SOURCE_DIR}/windows)
 endif()
 
-set(INCLUDES ${INCLUDES} 
+set(INCLUDES ${INCLUDES}
 	${CMAKE_SOURCE_DIR}/daemon/connect
 	${CMAKE_SOURCE_DIR}/daemon/extension
 	${CMAKE_SOURCE_DIR}/daemon/feed

--- a/daemon/systemhealth/IncomingNzbValidator.cpp
+++ b/daemon/systemhealth/IncomingNzbValidator.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+
 #include "nzbget.h"
 
 #include "IncomingNzbValidator.h"
@@ -29,6 +30,8 @@ IncomingNzbValidator::IncomingNzbValidator(const Options& options) : m_options(o
 	m_validators.push_back(std::make_unique<AppendCategoryDirValidator>(options));
 	m_validators.push_back(std::make_unique<NzbDirIntervalValidator>(options));
 	m_validators.push_back(std::make_unique<NzbDirFileAgeValidator>(options));
+	m_validators.push_back(std::make_unique<NzbDirArchiveScanValidator>(options));
+	m_validators.push_back(std::make_unique<NzbDirArchiveActionValidator>(options));
 	m_validators.push_back(std::make_unique<DupeCheckValidator>(options));
 }
 
@@ -73,6 +76,16 @@ Status NzbDirFileAgeValidator::Validate() const
 		return Status::Warning(ss.str());
 	}
 
+	return Status::Ok();
+}
+
+Status NzbDirArchiveScanValidator::Validate() const
+{
+	return Status::Ok();
+}
+
+Status NzbDirArchiveActionValidator::Validate() const
+{
 	return Status::Ok();
 }
 

--- a/daemon/systemhealth/IncomingNzbValidator.h
+++ b/daemon/systemhealth/IncomingNzbValidator.h
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -62,6 +62,28 @@ class NzbDirFileAgeValidator final : public Validator
 public:
 	explicit NzbDirFileAgeValidator(const Options& options) : m_options(options) {}
 	std::string_view GetName() const override { return Options::NZBDIRFILEAGE; }
+	Status Validate() const override;
+
+private:
+	const Options& m_options;
+};
+
+class NzbDirArchiveScanValidator final : public Validator
+{
+public:
+	explicit NzbDirArchiveScanValidator(const Options& options) : m_options(options) {}
+	std::string_view GetName() const override { return Options::NZBDIRARCHIVESCAN; }
+	Status Validate() const override;
+
+private:
+	const Options& m_options;
+};
+
+class NzbDirArchiveActionValidator final : public Validator
+{
+public:
+	explicit NzbDirArchiveActionValidator(const Options& options) : m_options(options) {}
+	std::string_view GetName() const override { return Options::NZBDIRARCHIVEACTION; }
 	Status Validate() const override;
 
 private:

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -80,10 +80,50 @@ inline std::string u8string(const path& p)
 
 namespace fs
 {
-	inline path make_unique_filename()
+inline path make_unique_filename()
+{
+	return std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+}
+
+inline fs::path make_unique_filename(const fs::path& targetPath)
+{
+	fs::error_code ec;
+	if (!fs::exists(targetPath, ec) && !ec) 
 	{
-		return std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+		return targetPath;
 	}
+
+	const fs::path baseDir = targetPath.parent_path();
+	const std::string stem = fs::u8string(targetPath.stem());
+	const std::string ext = fs::u8string(targetPath.extension());
+	
+	int counter = 1;
+	fs::path uniquePath;
+	do 
+	{
+		uniquePath = baseDir / (stem + " (" + std::to_string(counter++) + ")" + ext);
+	} while (fs::exists(uniquePath, ec) && !ec);
+
+	return uniquePath;
+}
+
+inline void move_file(const fs::path& src, const fs::path& dest, fs::error_code& ec) noexcept
+{
+	fs::rename(src, dest, ec);
+	if (ec == std::errc::cross_device_link)
+	{
+		ec.clear();
+		fs::copy_file(src, dest, fs::copy_options::overwrite_existing, ec);
+		if (!ec) fs::remove(src, ec);
+	}
+}
+
+inline void move_file(const fs::path& src, const fs::path& dest)
+{
+	error_code ec;
+	move_file(src, dest, ec);
+	if (ec) throw std::runtime_error(ec.message());
+}
 }
 
 class FileSystem

--- a/daemon/util/ScriptController.h
+++ b/daemon/util/ScriptController.h
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -68,6 +68,7 @@ public:
 	void SetEnvVar(const char* name, const char* value);
 	void SetEnvVarSpecial(const char* prefix, const char* name, const char* value);
 	void SetIntEnvVar(const char* name, int value);
+	bool IsTerminated() const { return m_terminated; }
 
 protected:
 	void ProcessOutput(char* text);

--- a/daemon/util/SevenZip.cpp
+++ b/daemon/util/SevenZip.cpp
@@ -80,27 +80,29 @@ bool SevenZip::IsSupported(const fs::path& path)
 					   { return Util::EndsWith(filename.c_str(), ext.data(), false); });
 }
 
-Result SevenZip::DecodeExitCode(int ec) const
+bool SevenZip::DecodeExitCode(int ec) const
 {
 	switch (ec)
 	{
 		case ExitCode::Success:
-			return {true, ""};
+			return true;
 		case ExitCode::Warning:
-			return {false,
-					"Completed with warnings. Some files may have been skipped because they were "
-					"in use"};
+			error("Completed with warnings. Some files may have been skipped because they were in use");
+			return false;
 		case ExitCode::FatalError:
-			return {false,
-					"A fatal error occurred. Check for permission issues, a corrupt archive, "
-					"password, disk space"};
+			error("A fatal error occurred. Check for permission issues, a corrupt archive, password, disk space");
+			return false;
 		case ExitCode::CmdLineError:
-			return {false, "Command line error"};
+			error("Command line error");
+			return false;
 		case ExitCode::NotEnoughMemoryError:
-			return {false, "Not enough memory for operation"};
+			error("Not enough memory for operation");
+			return false;
 		case ExitCode::CanceledByUser:
-			return {false, "User stopped the process"};
+			error("User stopped the process");
+			return false;
 		default:
-			return {false, "Unknown 7-Zip error"};
+			error("Unknown 7-Zip error (%d)", ec);
+			return false;
 	};
 }

--- a/daemon/util/Unpack.cpp
+++ b/daemon/util/Unpack.cpp
@@ -19,12 +19,9 @@
 
 #include "nzbget.h"
 
-#include <exception>
-#include <sstream>
-#include <stdexcept>
-
 #include "Options.h"
 #include "Unpack.h"
+#include "Log.h"
 
 namespace Unpack
 {
@@ -41,27 +38,36 @@ ExtractorBase::ExtractorBase(fs::path tool, fs::path archive,
 {
 }
 
-Result ExtractorBase::Extract()
+bool ExtractorBase::Extract()
 {
-	const auto result = CheckPrerequisites();
-	if (!result.success) return result;
+	if (!CheckPrerequisites()) return false;
 
 	auto args = MakeArgs();
 	ScriptController executor;
 	executor.SetArgs(std::move(args));
 
 	int exitCode = executor.Execute();
+	if (executor.IsTerminated())
+	{
+		error("Unpack: Extraction process for '%s' was interrupted", fs::u8string(m_archive).c_str());
+		return false;
+	}
 
 	return DecodeExitCode(exitCode);
 }
 
-Result ExtractorBase::CheckPrerequisites() const
+bool ExtractorBase::CheckPrerequisites() const
 {
 	fs::error_code ec;
 	fs::create_directories(m_outputDir, ec);
-	if (ec) return {false, "Failed to create the output directory"};
+	if (ec)
+	{
+		error("Unpack: Failed to create the output directory '%s': %s", 
+			  fs::u8string(m_outputDir).c_str(), ec.message().c_str());
+		return false;
+	}
 
-	return {true, ""};
+	return true;
 }
 
 std::string ExtractorBase::MakePassword() const
@@ -79,17 +85,28 @@ bool IsArchive(const fs::path& file)
 ExtractorPtr MakeExtractor(fs::path archive, fs::path outputDir,
 						   std::string password, OverwriteMode mode)
 {
-	auto validateTool = [](const fs::path& toolPath, std::string_view optionName)
+	const std::string archiveName = fs::u8string(archive.filename());
+
+	auto validateTool = [&archiveName](const fs::path& toolPath, std::string_view optionName) -> std::optional<fs::path>
 	{
 		if (toolPath.empty())
-			throw std::runtime_error(std::string(optionName) + " is not configured");
+		{
+			error("Unpack: Could not process '%s': %s is not configured", archiveName.c_str(), std::string(optionName).c_str());
+			return std::nullopt;
+		}
 
 		fs::error_code ec;
 		bool exists = fs::exists(toolPath, ec);
 		if (ec)
-			throw std::runtime_error("Failed to access '" + fs::u8string(toolPath) +
-									 "': " + ec.message());
-		if (!exists) throw std::runtime_error(fs::u8string(toolPath) + " doesn't exist");
+		{
+			error("Unpack: Could not process '%s': Failed to access '%s': %s", archiveName.c_str(), fs::u8string(toolPath).c_str(), ec.message().c_str());
+			return std::nullopt;
+		}
+		if (!exists)
+		{
+			error("Unpack: Could not process '%s': %s doesn't exist", archiveName.c_str(), fs::u8string(toolPath).c_str());
+			return std::nullopt;
+		}
 
 		return toolPath;
 	};
@@ -97,17 +114,20 @@ ExtractorPtr MakeExtractor(fs::path archive, fs::path outputDir,
 	if (SevenZip::IsSupported(archive))
 	{
 		const auto tool = validateTool(g_Options->GetSevenZipPath(), Options::SEVENZIPCMD);
-		return std::make_unique<SevenZip>(tool, std::move(archive), std::move(outputDir),
+		if (!tool) return nullptr;
+		return std::make_unique<SevenZip>(*tool, std::move(archive), std::move(outputDir),
 										  std::move(password), mode);
 	}
 
 	if (Unrar::IsSupported(archive))
 	{
 		const auto tool = validateTool(g_Options->GetUnrarPath(), Options::UNRARCMD);
-		return std::make_unique<Unrar>(tool, std::move(archive), std::move(outputDir),
+		if (!tool) return nullptr;
+		return std::make_unique<Unrar>(*tool, std::move(archive), std::move(outputDir),
 									   std::move(password), mode);
 	}
 
-	throw std::runtime_error("Unsupported archive format: " + fs::u8string(archive.extension()));
+	error("Unpack: Could not process '%s': Unsupported archive format: %s", archiveName.c_str(), fs::u8string(archive.extension()).c_str());
+	return nullptr;
 }
 }  // namespace Unpack

--- a/daemon/util/Unpack.h
+++ b/daemon/util/Unpack.h
@@ -31,12 +31,6 @@
 
 namespace Unpack
 {
-struct Result
-{
-	bool success;
-	std::string_view message;
-};
-
 enum class OverwriteMode
 {
 	Skip,
@@ -47,7 +41,7 @@ enum class OverwriteMode
 class Extractor
 {
 public:
-	virtual Result Extract() = 0;
+	virtual bool Extract() = 0;
 	virtual ~Extractor();
 };
 
@@ -56,12 +50,12 @@ class ExtractorBase : public Extractor
 public:
 	ExtractorBase(fs::path tool, fs::path archive,
 		fs::path outputDir, std::string password, OverwriteMode mode);
-	Result Extract() final;
+	bool Extract() final;
 
 protected:
 	virtual ScriptController::ArgList MakeArgs() const = 0;
 	virtual std::string MakePassword() const;
-	virtual Result DecodeExitCode(int ec) const = 0;
+	virtual bool DecodeExitCode(int ec) const = 0;
 
 	const fs::path m_tool;
 	const fs::path m_archive;
@@ -70,7 +64,7 @@ protected:
 	const OverwriteMode m_mode;
 
 private:
-	Result CheckPrerequisites() const;
+	bool CheckPrerequisites() const;
 };
 
 class SevenZip final : public ExtractorBase
@@ -94,7 +88,7 @@ public:
 	static bool IsSupported(const fs::path& path);
 private:
 	ScriptController::ArgList MakeArgs() const override;
-	Result DecodeExitCode(int ec) const override;
+	bool DecodeExitCode(int ec) const override;
 };
 
 class Unrar final : public ExtractorBase
@@ -126,12 +120,12 @@ public:
 	static bool IsSupported(const fs::path& path);
 private:
 	ScriptController::ArgList MakeArgs() const override;
-	Result DecodeExitCode(int ec) const override;
+	bool DecodeExitCode(int ec) const override;
 };
 
 using ExtractorPtr = std::unique_ptr<Extractor>;
 ExtractorPtr MakeExtractor(fs::path archive, fs::path outputDir,
-						   std::string password, OverwriteMode mode) noexcept(false);
+						std::string password, OverwriteMode mode);
 bool IsArchive(const fs::path& file);
 }  // namespace Unpack
 

--- a/daemon/util/Unrar.cpp
+++ b/daemon/util/Unrar.cpp
@@ -17,7 +17,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "FileSystem.h"
+
 #include "nzbget.h"
 
 #include <regex>
@@ -88,42 +88,47 @@ bool Unrar::IsSupported(const fs::path& path)
 	return false;
 }
 
-Result Unrar::DecodeExitCode(int ec) const
+bool Unrar::DecodeExitCode(int ec) const
 {
 	switch (ec)
 	{
 		case ExitCode::Success:
-			return {true, ""};
+			return true;
 		case ExitCode::NonFatalError:
-			return {false, "Extraction finished, but some files might be missing or incomplete"};
+			error("Extraction finished, but some files might be missing or incomplete");
+			return false;
 		case ExitCode::FatalError:
-			return {false, "The process could not start or was interrupted unexpectedly"};
+			error("The process could not start or was interrupted unexpectedly");
+			return false;
 		case ExitCode::InvalidChecksum:
-			return {false, "The archive is damaged. The extracted files are likely corrupt"};
+			error("The archive is damaged. The extracted files are likely corrupt");
+			return false;
 		case ExitCode::LockedArchive:
-			return {false, "This archive is locked and cannot be modified or unpacked"};
+			error("This archive is locked and cannot be modified or unpacked");
+			return false;
 		case ExitCode::WriteError:
-			return {false,
-					"Could not write files to the destination. Please check your permissions and "
-					"disk space"};
+			error("Could not write files to the destination. Please check your permissions and disk space");
+			return false;
 		case ExitCode::FileOpenError:
-			return {false,
-					"Couldn't open the archive. The file may be missing or you don't have "
-					"permission to read it"};
+			error("Couldn't open the archive. The file may be missing or you don't have permission to read it");
+			return false;
 		case ExitCode::CommandLineError:
-			return {false, "An internal program error occurred"};
+			error("An internal program error occurred");
+			return false;
 		case ExitCode::NotEnoughMemory:
-			return {false,
-					"Your computer ran out of memory. Please try closing other applications first"};
+			error("Your computer ran out of memory. Please try closing other applications first");
+			return false;
 		case ExitCode::FileCreateError:
-			return {false,
-					"Couldn't create files in the destination folder. Please check your "
-					"permissions"};
+			error("Couldn't create files in the destination folder. Please check your permissions");
+			return false;
 		case ExitCode::NoFilesFound:
-			return {false, "There were no files inside the archive to extract"};
+			error("There were no files inside the archive to extract");
+			return false;
 		case ExitCode::WrongPassword:
-			return {false, "The password you entered was incorrect"};
+			error("The password you entered was incorrect");
+			return false;
 		default:
-			return {false, "Unknown Unrar error"};
+			error("Unknown error %d", ec);
+			return false;
 	}
 }

--- a/nzbget.conf
+++ b/nzbget.conf
@@ -39,10 +39,11 @@ InterDir=${MainDir}/inter
 # is saved into this directory and then processed by extension
 # scripts (option <Extensions>).
 #
-# This directory is also monitored for new nzb-files. If a new file
-# is found it is added to download queue. The directory can have
-# sub-directories. A nzb-file queued from a subdirectory is automatically
-# assigned to category with sub-directory-name.
+# This directory is also monitored for new nzb-files and compressed archives
+# (zip, rar, 7z, tar, gz, etc.). See options <NzbDirArchiveScan> and <NzbDirArchiveAction>.
+#
+# The directory can have sub-directories. A file queued from a subdirectory
+# is automatically assigned to the category matching the sub-directory name.
 NzbDir=${MainDir}/nzb
 
 # Directory to store program state.
@@ -746,6 +747,26 @@ NzbDirInterval=5
 # were not yet completely saved to disk, for example if they are still being
 # downloaded in web-browser.
 NzbDirFileAge=60
+
+# Scan archives (zip, rar, 7z, etc.) in <NzbDir> for .nzb files (yes, no).
+#
+#  yes - scan archives (extract to temporary sandbox). See option <NzbDirArchiveAction> 
+#        for post-scan behavior.
+#  no  - ignore archives (only process raw .nzb files).
+NzbDirArchiveScan=yes
+
+# Action for processed archives in NzbDir (move, delete).
+#
+#  Move   - move the archive to '_processed' (on success) or '_broken'
+#           (on failure) sub-directory.
+#  Delete - delete the archive.
+#
+# NOTE: Files are deleted ONLY if .nzb files were successfully imported.
+# NOTE: If the archive contains files other than .nzb, the archive will NOT 
+# be deleted to prevent accidental data loss. Instead, it will be moved to 
+# the '_processed' directory.
+# If processing fails, the file is moved to '_broken' directory to prevent data loss.
+NzbDirArchiveAction=delete
 
 # Check for duplicate titles (yes, no).
 #

--- a/tests/util/Unpack.cpp
+++ b/tests/util/Unpack.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(IsSupportedTests)
 
 BOOST_AUTO_TEST_CASE(MakeExtractorUnsupportedTest)
 {
-	BOOST_CHECK_THROW(MakeExtractor("file.txt", "/tmp/out", "", OverwriteMode::Skip), std::runtime_error);
+	BOOST_CHECK(MakeExtractor("file.txt", "/tmp/out", "", OverwriteMode::Skip) == nullptr);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description

- Added the new `NzbDirArchiveScan` option to toggle the feature, and `NzbDirArchiveAction` option to decide if the original archive should be deleted or moved to a `_processed` folder when done.
-  Sandbox Extraction: Archives are extracted to a temporary `_unpack` directory. Valid `.nzb` files are filtered and moved to the active directory for queuing.
-   Data Loss Prevention: If an archive contains files other than `.nzb`, the system refuses to delete it (even if set to `delete`) and instead moves it to the `_processed` folder. Failed extractions are moved to `_broken`.
-   Robust File Operations: Added cross-device file move utilities and collision-free unique file naming (e.g., `archive(1).zip`);
- Refactored logic to more stable error-handling approach and added extra logging

## Testing

- macOS Tahoe/Mojave
- Windows 7,10
- Docker