### PR TITLE
macOS: x64 builds - downgrade 7zip to 25.01; CI: update GitHub Actions versions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Prepare ${{ matrix.arch }} / ${{ matrix.type }} environment
       run: |
@@ -54,7 +54,7 @@ jobs:
       run: bash linux/build-nzbget.sh bin ${{ matrix.arch }} ${{ matrix.type }} ${{ env.BUILD_TESTING }}
 
     - name: Upload full build log on failure
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-android-${{ matrix.arch }}-${{ matrix.type }}-build-log
@@ -62,7 +62,7 @@ jobs:
         retention-days: 5
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-android-bin-${{ matrix.arch }}-${{ matrix.type }}
         path: build/*.tar.gz
@@ -75,7 +75,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Prepare build environment
       run: |
@@ -85,7 +85,7 @@ jobs:
         tar zxf /build/unpack.tar.gz -C /build
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: nzbget-android-bin-*
 
@@ -111,12 +111,12 @@ jobs:
         done
 
     - name: Delete unneeded platform-specific artifacts
-      uses: geekyeggo/delete-artifact@v5
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: nzbget-android-bin-*
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-android-installers
         path: build/*.run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
 
     - name: Generate signatures
       run: |
@@ -124,7 +124,7 @@ jobs:
         echo "Done."
 
     - name: Upload build artifacts with signatures
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-installers
         path: builds/*
@@ -158,18 +158,17 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Delete tag and release
-      uses: dev-drprasad/delete-tag-and-release@v0.2.1
+      uses: dev-drprasad/delete-tag-and-release@v1.1
       with:
         delete_release: true
         tag_name: testing
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+        github_token: ${{ github.token }}
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
 
     - name: Create latest artifacts
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare
         id: prepare
@@ -59,17 +59,17 @@ jobs:
           echo "platform-slug=${platform//\//-}" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         env:
           DOCKER_BUILD_SUMMARY: false
         with:
@@ -90,7 +90,7 @@ jobs:
           touch "digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ needs.prepare.outputs.build_type }}-${{ steps.prepare.outputs.platform-slug }}
           path: digests/*
@@ -105,23 +105,23 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: digests
           pattern: digests-${{ needs.prepare.outputs.build_type }}-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -154,7 +154,7 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Create manifest list, push and inspect
         run: |
@@ -186,6 +186,6 @@ jobs:
           dry-run: false
 
       - name: Delete unneeded digests artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: digests-${{ needs.prepare.outputs.build_type }}-*

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: nzbget-linux-installers
         path: nzbget-linux-installers
@@ -40,7 +40,7 @@ jobs:
         bash linux/flatpak/build-flatpak.sh
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-flatpak-packages
         path: build/flatpak/*.flatpak

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Prepare freebsd build environment
       run: |
@@ -37,7 +37,7 @@ jobs:
       run: bash linux/build-nzbget.sh bin installer ${{ env.BUILD_ARCHS }} ${{ env.BUILD_TYPES }} ${{ env.BUILD_TESTING }}
 
     - name: Upload full build log on failure
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-freebsd-build-log
@@ -56,7 +56,7 @@ jobs:
         done
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-freebsd-installers
         path: build/*.run

--- a/.github/workflows/linux-pkg.yml
+++ b/.github/workflows/linux-pkg.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: nzbget-linux-installers
         path: nzbget-linux-installers
@@ -40,14 +40,14 @@ jobs:
         bash linux/pkg/build-pkg.sh
 
     - name: Upload DEB build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-deb-packages
         path: build/deb/*.deb
         retention-days: 5
 
     - name: Upload RPM build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-rpm-packages
         path: build/rpm/*.rpm

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Prepare ${{ matrix.arch }} / ${{ matrix.type }} environment
       run: |
@@ -57,7 +57,7 @@ jobs:
       run: bash linux/build-nzbget.sh bin ${{ matrix.arch }} ${{ matrix.type }} ${{ env.BUILD_TESTING }}
 
     - name: Upload full build log on failure
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-linux-${{ matrix.arch }}-${{ matrix.type }}-build-log
@@ -65,7 +65,7 @@ jobs:
         retention-days: 5
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-linux-bin-${{ matrix.arch }}-${{ matrix.type }}
         path: build/*.tar.gz
@@ -78,7 +78,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Prepare build environment
       run: |
@@ -88,7 +88,7 @@ jobs:
         tar zxf /build/unpack.tar.gz -C /build
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: nzbget-linux-bin-*
 
@@ -114,12 +114,12 @@ jobs:
         done
 
     - name: Delete unneeded platform-specific artifacts
-      uses: geekyeggo/delete-artifact@v5
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: nzbget-linux-bin-*
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-linux-installers
         path: build/*.run

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -24,6 +24,7 @@ jobs:
 
     - name: Build
       run: |
+        export ZIP7_VERSION=2501
         export EXTRA_ARGS="-DCMAKE_OSX_SYSROOT=/Applications/Xcode_14.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
         bash osx/build-nzbget.sh x64 ${{ env.BUILD_TYPES }} ${{ env.BUILD_TESTING }}
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Prepare build environment
       run: |
@@ -29,7 +29,7 @@ jobs:
         bash osx/build-nzbget.sh x64 ${{ env.BUILD_TYPES }} ${{ env.BUILD_TESTING }}
 
     - name: Upload full build log on failure
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-osx-x64-build-log
@@ -48,7 +48,7 @@ jobs:
         done
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-osx-installers-x64
         path: build/*.zip
@@ -60,7 +60,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Prepare build environment
       run: |
@@ -71,7 +71,7 @@ jobs:
       run: bash osx/build-nzbget.sh universal ${{ env.BUILD_TYPES }} ${{ env.BUILD_TESTING }}
 
     - name: Upload full build log on failure
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-osx-universal-build-log
@@ -90,7 +90,7 @@ jobs:
         done
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-osx-installers-universal
         path: build/*-universal*.zip
@@ -103,10 +103,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: nzbget-osx-installers-universal
         path: nzbget-osx-installers-universal
@@ -155,7 +155,7 @@ jobs:
         done
 
     - name: Upload signed build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-osx-installers-universal-signed
         path: build_signed/*.dmg
@@ -169,13 +169,13 @@ jobs:
     steps:
 
     - name: Download x64 build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: nzbget-osx-installers-x64
         path: nzbget-osx-installers-x64
 
     - name: Download universal signed build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: nzbget-osx-installers-universal-signed
         path: nzbget-osx-installers-universal-signed
@@ -187,7 +187,7 @@ jobs:
         mv nzbget-osx-installers-universal-signed/* nzbget-osx-installers
 
     - name: Upload combined build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-osx-installers
         path: nzbget-osx-installers/*

--- a/.github/workflows/qnap-repack.yml
+++ b/.github/workflows/qnap-repack.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: nzbget-linux-installers
         path: nzbget-linux-installers
@@ -58,7 +58,7 @@ jobs:
         done
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-qnap-packages
         path: /qnap/nzbget/build/*.qpkg

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -21,7 +21,7 @@ jobs:
         sudo snap install snapcraft --classic
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build and publish latest release snap
       env:
@@ -35,7 +35,7 @@ jobs:
         done
 
     - name: Upload builded snaps
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-snaps
         path: linux/snap/*.snap

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download and extract vcpkg cache and unpackers
       run: |
@@ -43,7 +43,7 @@ jobs:
         ctest -C Release
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-windows-test-log
@@ -60,7 +60,7 @@ jobs:
         sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev unrar 7zip
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build
       run: |
@@ -75,7 +75,7 @@ jobs:
         ctest -C Release
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-linux-test-log
@@ -92,7 +92,7 @@ jobs:
         sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev unrar 7zip
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build
       run: |
@@ -107,7 +107,7 @@ jobs:
         ctest -C Release
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-linux-test-log
@@ -124,7 +124,7 @@ jobs:
         brew install --cask rar
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build
       run: |
@@ -139,7 +139,7 @@ jobs:
         ctest -C Release
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-linux-test-log
@@ -151,7 +151,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: OpenBSD build and test
       uses: cross-platform-actions/action@v0.28.0
@@ -167,7 +167,7 @@ jobs:
           ctest -C Release --repeat until-pass:5
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-openbsd-test-log
@@ -179,7 +179,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: FreeBSD build and test
       uses: cross-platform-actions/action@v0.27.0
@@ -195,7 +195,7 @@ jobs:
           ctest -C Release
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: nzbget-freebsd-test-log
@@ -212,7 +212,7 @@ jobs:
         sudo apt-get install -y cmake libxml2-dev libssl-dev libncurses-dev libboost-all-dev
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build
       run: |
@@ -226,7 +226,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: OpenBSD build
       uses: cross-platform-actions/action@v0.28.0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Prepare build environment
       run: |
@@ -57,7 +57,7 @@ jobs:
       run: Invoke-Expression "windows\build-nzbget.ps1 -Build${{ matrix.type }} -Build${{ matrix.arch }} ${{ env.BUILD_TESTING }}"
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       id: upload-unsigned-artifact
       with:
         name: ${{ matrix.type }}${{ matrix.arch }}
@@ -82,7 +82,7 @@ jobs:
 
     - name: Upload signed build artifacts
       if: env.SIGN == 'true' && matrix.type == 'Release'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.type }}${{ matrix.arch }}
         overwrite: true
@@ -96,15 +96,15 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download release build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: Release*
 
     - name: Download debug build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: Debug*
 
@@ -130,7 +130,7 @@ jobs:
         }
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       id: upload-unsigned-installer-artifact
       with:
         name: nzbget-windows-installers
@@ -153,7 +153,7 @@ jobs:
 
     - name: Upload signed build artifacts
       if: env.SIGN == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nzbget-windows-installers
         overwrite: true
@@ -161,7 +161,7 @@ jobs:
         retention-days: 5
 
     - name: Delete unneeded platform-specific artifacts
-      uses: geekyeggo/delete-artifact@v5
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: |
           Release*

--- a/osx/build-nzbget.sh
+++ b/osx/build-nzbget.sh
@@ -22,9 +22,10 @@
 set -o nounset
 set -o errexit
 
-# unpackers versions
-UNRAR_VERSION=720
-ZIP7_VERSION=2600
+# unpackers versions defaults
+# can be overridden by environment variables
+UNRAR_VERSION="${UNRAR_VERSION-720}"
+ZIP7_VERSION="${ZIP7_VERSION-2600}"
 
 # make jobs
 JOBS=$(sysctl -n hw.ncpu)


### PR DESCRIPTION
## Description

- added the ability to override the UnRAR / 7-Zip version for macOS builds via environment variables
- downgraded 7-Zip for macOS x64 to version 25.01, as version 26.00 does not support macOS 10.14 (Mojave)
- updated GitHub Actions versions

## Testing

by @phnzb:
- x64: macOS Mojave (10.14.6)
- universal: macOS Tahoe (26.2)