### PR TITLE
Fix: prevent SIGFPE crash in JoinFile when file segments are empty

### DIFF
--- a/daemon/postprocess/UnpackController.cpp
+++ b/daemon/postprocess/UnpackController.cpp
@@ -502,6 +502,11 @@ bool UnpackController::JoinFile(const char* fragBaseName)
 	}
 
 	int64 totalSize = firstSegmentSize * (count - 1) + difSegmentSize;
+	if (totalSize <= 0)
+	{
+		PrintMessage(Message::mkError, "Could not join splitted file %s: file segments are empty", *destBaseName);
+		return false;
+	}
 	int64 written = 0;
 
 	CharBuffer buffer(1024 * 50);


### PR DESCRIPTION
## Description

Fixes #773 — a divide-by-zero crash (SIGFPE) in `UnpackController::JoinFile()` that occurs when split file segments (e.g., `.7z.001`, `.7z.002`) are zero-byte or corrupt.

When `totalSize` is calculated as 0 from empty fragments, the progress calculation on [line 530](https://github.com/nzbgetcom/nzbget/blob/develop/daemon/postprocess/UnpackController.cpp#L530):
```cpp
m_postInfo->SetStageProgress(int(written * 1000 / totalSize));
```
triggers a SIGFPE, crashing NZBGet. Since NZBGet resumes post-processing on startup, this causes a crash loop that prevents the application from starting at all.

The fix adds a guard to return early with an error message when `totalSize <= 0`, preventing the divide-by-zero.

## Lib changes

None.

## Testing

- Reproduced the crash on Arch Linux x86_64 with NZBGet v26.0 and v26.1-testing
- Confirmed the crash occurs in `UnpackController::JoinFile` via `coredumpctl info`:
  ```
  Signal: 8 (FPE)
  #0  _ZN16UnpackController8JoinFileEPKc (/usr/bin/nzbget + 0xfcb94)
  #1  _ZN16UnpackController17JoinSplittedFilesEv (/usr/bin/nzbget + 0xfd0bd)
  ```
- With the fix, NZBGet logs an error for the empty segments and continues running normally