### PR TITLE
Fix handling of server speed tests bound to a specific server

### DIFF
--- a/daemon/nntp/ArticleDownloader.cpp
+++ b/daemon/nntp/ArticleDownloader.cpp
@@ -3,7 +3,7 @@
  *
  *  Copyright (C) 2004 Sven Henkel <sidddy@users.sourceforge.net>
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -217,6 +217,12 @@ void ArticleDownloader::Run()
 			serverConfigGeneration != g_ServerPool->GetGeneration())
 		{
 			status = adRetry;
+			break;
+		}
+
+		if (!wantServer && m_fileInfo->GetNzbInfo()->HasDesiredServer())
+		{
+			status = adFailed;
 			break;
 		}
 

--- a/daemon/queue/DownloadInfo.h
+++ b/daemon/queue/DownloadInfo.h
@@ -677,6 +677,7 @@ public:
 	bool GetSkipDiskWrite() { return m_scipDiskWrite; }
 	void SetAutoCategory(bool autoCategory) { m_autoCategory = autoCategory; }
 	bool GetAutoCategory() const { return m_autoCategory; }
+	bool HasDesiredServer() const { return m_desiredServerId > 0; }
 
 	static const int FORCE_PRIORITY = 900;
 

--- a/daemon/queue/QueueCoordinator.cpp
+++ b/daemon/queue/QueueCoordinator.cpp
@@ -222,6 +222,10 @@ void QueueCoordinator::Run()
 					{
 						connection = g_ServerPool->GetConnection(desiredServer->GetLevel(), desiredServer, nullptr);
 					}
+					else
+					{
+						connection = g_ServerPool->GetConnection(0, nullptr, nullptr);
+					}
 				}
 				else
 				{

--- a/daemon/queue/QueueCoordinator.cpp
+++ b/daemon/queue/QueueCoordinator.cpp
@@ -3,7 +3,7 @@
  *
  *  Copyright (C) 2005 Bo Cordes Petersen <placebodk@users.sourceforge.net>
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -213,11 +213,15 @@ void QueueCoordinator::Run()
 			if (hasMoreArticles && canProceed && (!g_WorkState->GetTempPauseDownload() || fileInfo->GetExtraPriority()))
 			{
 				NntpConnection* connection = nullptr;
-				NewsServer* desiredServer = g_ServerPool->GetServerById(fileInfo->GetNzbInfo()->GetDesiredServerId());
-
-				if (desiredServer)
+			
+				if (fileInfo->GetNzbInfo()->HasDesiredServer())
 				{
-					connection = g_ServerPool->GetConnection(desiredServer->GetLevel(), desiredServer, nullptr);
+					int desiredServerId = fileInfo->GetNzbInfo()->GetDesiredServerId();
+					NewsServer* desiredServer = g_ServerPool->GetServerById(desiredServerId);
+					if (desiredServer)
+					{
+						connection = g_ServerPool->GetConnection(desiredServer->GetLevel(), desiredServer, nullptr);
+					}
 				}
 				else
 				{


### PR DESCRIPTION
## Description

Fixes server speed tests bound to a specific server failing silently by properly handling the desired server state during article download.

## Testing

- macOS Tahoe