### PR TITLE
Fix missing nzbget.h include order in Cleanup.cpp

### DIFF
--- a/daemon/postprocess/Cleanup.cpp
+++ b/daemon/postprocess/Cleanup.cpp
@@ -19,8 +19,8 @@
  */
 
 
-#include "DownloadInfo.h"
 #include "nzbget.h"
+#include "DownloadInfo.h"
 #include "Cleanup.h"
 #include "Log.h"
 #include "Util.h"


### PR DESCRIPTION

## Description

Include nzbget.h before other headers in Cleanup.cpp to ensure macros and types are properly declared before use. This is not caught when building with precompiled headers, as nzbget.h is implicitly available to all translation units. Broken since 488e50d3.

See also 063e1cd82ee719b18a1dae40f65c0971de44edef which fixed the same issue in UrlCoordinator.cpp and PathsValidator.cpp.

Without this fix, compilation fails with errors like:
```
daemon/util/NString.h:34:49: error: expected ';' at end of member declaration [-Wtemplate-body]
   34 |         explicit BString(const char* format, ...) PRINTF_SYNTAX(2);
      |                                                 ^
      |                                                  ;
daemon/util/NString.h:34:65: error: expected identifier before numeric constant [-Wtemplate-body]
```


## Lib changes

None

## Testing

@dnzbk can you please add `DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON` to the CI to catch these?