### PR TITLE
CI: change 7-zip sources from 7-zip.org to GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
         retention-days: 5
 
     - name: Delete unneeded platform-specific artifacts
-      uses: geekyeggo/delete-artifact@v4
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: |
           nzbget-windows-installers
@@ -143,7 +143,7 @@ jobs:
           nzbget-flatpak-packages
 
     - name: Delete unneeded linux packages artifacts
-      uses: geekyeggo/delete-artifact@v4
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: |
           nzbget-deb-packages

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -48,6 +48,6 @@ jobs:
 
     - name: Delete unneeded linux artifacts
       if: ${{ inputs.external_call == false }}
-      uses: geekyeggo/delete-artifact@v4
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: nzbget-linux-installers

--- a/.github/workflows/linux-pkg.yml
+++ b/.github/workflows/linux-pkg.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Delete unneeded linux artifacts
       if: ${{ inputs.external_call == false }}
-      uses: geekyeggo/delete-artifact@v4
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: |
           nzbget-linux-installers

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -194,7 +194,7 @@ jobs:
         retention-days: 5
 
     - name: Delete unneeded artifacts
-      uses: geekyeggo/delete-artifact@v4
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: |
           nzbget-osx-installers-x64

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Build
       run: |
-        export ZIP7_VERSION=2501
+        export ZIP7_VERSION="25.01"
         export EXTRA_ARGS="-DCMAKE_OSX_SYSROOT=/Applications/Xcode_14.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
         bash osx/build-nzbget.sh x64 ${{ env.BUILD_TYPES }} ${{ env.BUILD_TESTING }}
 

--- a/.github/workflows/qnap-repack.yml
+++ b/.github/workflows/qnap-repack.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Delete unneeded linux artifacts
       if: ${{ inputs.external_call == false }}
-      uses: geekyeggo/delete-artifact@v4
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: |
           nzbget-linux-installers

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.22.2 AS build
 # args
 ARG UNRAR6_VERSION=6.2.12
 ARG UNRAR7_VERSION=7.2.4
-ARG ZIP7_VERSION=2600
+ARG ZIP7_VERSION=26.00
 ARG UNRAR7_NATIVE=false
 ARG MAKE_JOBS=1
 ARG TARGETPLATFORM
@@ -39,7 +39,7 @@ RUN \
   install -v -m755 unrar /usr/bin/ && \
   echo "**** install 7zip from source ****" && \
   mkdir /tmp/7z && \
-  curl -o /tmp/7z/7z.tar.xz -lL https://www.7-zip.org/a/7z${ZIP7_VERSION}-src.tar.xz && \
+  curl -o /tmp/7z/7z.tar.xz -lL https://github.com/ip7z/7zip/releases/download/${ZIP7_VERSION}/7z${ZIP7_VERSION//./}-src.tar.xz && \
   cd /tmp/7z && \
   tar xf 7z.tar.xz && \
   cd CPP/7zip/Bundles/Alone && \

--- a/linux/build-nzbget.sh
+++ b/linux/build-nzbget.sh
@@ -43,7 +43,7 @@ FREEBSD_CLANG_VER=14
 # unpackers versions
 UNRAR6_VERSION=6.2.12
 UNRAR7_VERSION=7.2.4
-ZIP7_VERSION=2600
+ZIP7_VERSION=26.00
 
 # libs versions
 # https://invisible-island.net/ncurses/announce.html
@@ -423,7 +423,7 @@ build_7zip()
     if [ ! -d "$LIB_PATH/$ARCH/7zip" ]; then
         rm -rf /tmp/7z
         mkdir -p /tmp/7z
-        curl -o /tmp/7z/7z.tar.xz -lL https://www.7-zip.org/a/7z$ZIP7_VERSION-src.tar.xz
+        curl -o /tmp/7z/7z.tar.xz -lL "https://github.com/ip7z/7zip/releases/download/$ZIP7_VERSION/7z${ZIP7_VERSION//./}-src.tar.xz"
         cd /tmp/7z
         tar xf 7z.tar.xz
         rm 7z.tar.xz

--- a/osx/build-nzbget.sh
+++ b/osx/build-nzbget.sh
@@ -25,7 +25,7 @@ set -o errexit
 # unpackers versions defaults
 # can be overridden by environment variables
 UNRAR_VERSION="${UNRAR_VERSION-720}"
-ZIP7_VERSION="${ZIP7_VERSION-2600}"
+ZIP7_VERSION="${ZIP7_VERSION-26.00}"
 
 # make jobs
 JOBS=$(sysctl -n hw.ncpu)
@@ -150,8 +150,8 @@ for CONFIG in $CONFIGS; do
         rm -rf $DAEMON_PATH/etc
 
         # 7zip
-        URL_7Z=https://www.7-zip.org/a/7z$ZIP7_VERSION-mac.tar.xz
-        curl -o 7z.tar.xz $URL_7Z
+        URL_7Z="https://github.com/ip7z/7zip/releases/download/$ZIP7_VERSION/7z${ZIP7_VERSION//./}-mac.tar.xz"
+        curl -L -o 7z.tar.xz $URL_7Z
         mkdir -p 7z
         tar xf 7z.tar.xz -C 7z
         cp 7z/7zz $DAEMON_PATH/bin/7za

--- a/windows/build-nzbget.ps1
+++ b/windows/build-nzbget.ps1
@@ -59,7 +59,7 @@ Function DownloadUnpackers {
     $UrlUnrar64="https://www.rarlab.com/rar/unrarw64.exe"
     $UrlRar32="https://www.rarlab.com/rar/winrar-x32-701.exe"
     $UrlRar64="https://www.rarlab.com/rar/winrar-x64-720.exe"
-    $Url7Z="https://www.7-zip.org/a/7z2600-extra.7z"
+    $Url7Z="https://github.com/ip7z/7zip/releases/download/26.00/7z2600-extra.7z"
 
     $ImageDir="$ToolsRoot\image"
     Write-Host "Downloading unpackers to $ImageDir"


### PR DESCRIPTION
## Description

- changed 7-Zip source from 7-zip.org to GitHub due to instability when downloading from GitHub runners
- updated some outdated GitHub Action versions
