### PR TITLE
Fix: prevent auto-category from overriding manual category via CLI

### DIFF
--- a/daemon/main/CommandLineParser.cpp
+++ b/daemon/main/CommandLineParser.cpp
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -168,7 +169,7 @@ void CommandLineParser::InitCommandLine(int argc, const char* const_argv[])
 							ReportError("Could not parse value of option 'A'");
 							return;
 						}
-						m_addCategory = std::move(argv[optind-1]);
+						SetAddCategory(argv[optind-1]);
 					}
 					else if (optarg && !strcasecmp(optarg, "N"))
 					{
@@ -670,7 +671,7 @@ void CommandLineParser::InitCommandLine(int argc, const char* const_argv[])
 				break;
 			case 'K':
 				// switch "K" is provided for compatibility with v. 0.8.0 and can be removed in future versions
-				m_addCategory = optarg;
+				SetAddCategory(optarg);
 				break;
 			case 'S':
 				optind++;

--- a/daemon/main/CommandLineParser.h
+++ b/daemon/main/CommandLineParser.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -81,6 +82,7 @@ public:
 	const char* GetEditQueueText() { return m_editQueueText; }
 	const char* GetArgFilename() { return m_argFilename; }
 	const char* GetAddCategory() { return m_addCategory; }
+	bool GetAutoCategory() const { return m_autoCategory; }
 	bool GetAddPaused() { return m_addPaused; }
 	const char* GetLastArg() { return m_lastArg; }
 	int GetAddPriority() { return m_addPriority; }
@@ -104,6 +106,12 @@ public:
 	bool GetPauseDownload() const { return m_pauseDownload; }
 
 private:
+	void SetAddCategory(const char* category)
+	{ 
+		m_addCategory = category; 
+		m_autoCategory = false; 
+	}
+
 	bool m_noConfig = false;
 	CString m_configFilename;
 
@@ -124,6 +132,7 @@ private:
 	CString m_editQueueText;
 	CString m_argFilename;
 	CString m_addCategory;
+	bool m_autoCategory = true;
 	int m_addPriority = 0;
 	bool m_addPaused = false;
 	CString m_addNzbFilename;

--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -864,9 +864,17 @@ void NZBGet::ProcessClientRequest()
 			break;
 
 		case CommandLineParser::opClientRequestDownload:
-			ok = Client.RequestServerDownload(m_commandLineParser->GetAddNzbFilename(), m_commandLineParser->GetArgFilename(),
-				m_commandLineParser->GetAddCategory(), m_commandLineParser->GetAddTop(), m_commandLineParser->GetAddPaused(), m_commandLineParser->GetAddPriority(),
-				m_commandLineParser->GetAddDupeKey(), m_commandLineParser->GetAddDupeMode(), m_commandLineParser->GetAddDupeScore());
+			ok = Client.RequestServerDownload(
+				m_commandLineParser->GetAddNzbFilename(),
+				m_commandLineParser->GetArgFilename(),
+				m_commandLineParser->GetAddCategory(),
+				m_commandLineParser->GetAutoCategory(),
+				m_commandLineParser->GetAddTop(),
+				m_commandLineParser->GetAddPaused(),
+				m_commandLineParser->GetAddPriority(),
+				m_commandLineParser->GetAddDupeKey(),
+				m_commandLineParser->GetAddDupeMode(),
+				m_commandLineParser->GetAddDupeScore());
 			break;
 
 		case CommandLineParser::opClientRequestVersion:

--- a/daemon/remote/MessageBase.h
+++ b/daemon/remote/MessageBase.h
@@ -104,9 +104,9 @@ struct SNzbDownloadRequest
 	int32 m_priority; // Priority for files (0 - default)
 	int32 m_dupeScore; // Duplicate score
 	int32 m_dupeMode; // Duplicate mode (EDupeMode)
-	int32 m_autoCategory;
 	char m_dupeKey[NZBREQUESTFILENAMESIZE]; // Duplicate key
 	int32 m_trailingDataLength; // Length of nzb-file in bytes
+	int32 m_autoCategory;
 	//char m_content[m_trailingDataLength]; // variable sized
 };
 

--- a/daemon/remote/RemoteClient.cpp
+++ b/daemon/remote/RemoteClient.cpp
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 2005 Bo Cordes Petersen <placebodk@sourceforge.net>
  *  Copyright (C) 2007-2019 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -109,7 +110,7 @@ bool RemoteClient::ReceiveBoolResponse()
  * Sends a message to the running nzbget process.
  */
 bool RemoteClient::RequestServerDownload(const char* nzbFilename, const char* nzbContent,
-	const char* category, bool addFirst, bool addPaused, int priority,
+	const char* category, bool autoCategory, bool addFirst, bool addPaused, int priority,
 	const char* dupeKey, int dupeMode, int dupeScore)
 {
 	// Read the file into the buffer
@@ -141,6 +142,7 @@ bool RemoteClient::RequestServerDownload(const char* nzbFilename, const char* nz
 		DownloadRequest.m_dupeMode = htonl(dupeMode);
 		DownloadRequest.m_dupeScore = htonl(dupeScore);
 		DownloadRequest.m_trailingDataLength = htonl(length);
+		DownloadRequest.m_autoCategory = htonl(autoCategory);
 
 		DownloadRequest.m_nzbFilename[0] = '\0';
 		if (!Util::EmptyStr(nzbFilename))

--- a/daemon/remote/RemoteClient.h
+++ b/daemon/remote/RemoteClient.h
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 2005 Bo Cordes Petersen <placebodk@users.sourceforge.net>
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -31,7 +32,8 @@ class RemoteClient
 {
 public:
 	void SetVerbose(bool verbose) { m_verbose = verbose; };
-	bool RequestServerDownload(const char* nzbFilename, const char* nzbContent, const char* category,
+	bool RequestServerDownload(const char* nzbFilename, const char* nzbContent,
+		const char* category, bool autoCategory,
 		bool addFirst, bool addPaused, int priority,
 		const char* dupeKey, int dupeMode, int dupeScore);
 	bool RequestServerList(bool files, bool groups, const char* pattern);


### PR DESCRIPTION
## Description

Prevented auto-category from overriding manual category via CLI

## Testing
- macOS Tahoe