### PR TITLE
Fix SystemHealth validators

### DIFF
--- a/daemon/systemhealth/ConnectionValidator.cpp
+++ b/daemon/systemhealth/ConnectionValidator.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -157,8 +157,7 @@ Status DownloadRateValidator::Validate() const
 
 	if (val == 0) return Status::Ok();
 
-	return Status::Warning("Global download speed is restricted to " + std::to_string(val) +
-						   " KB/s by '" + std::string(Options::DOWNLOADRATE) + "'");
+	return Status::Info("Global download speed is restricted");
 }
 
 Status UrlConnectionsValidator::Validate() const

--- a/daemon/systemhealth/ExtensionScriptsValidator.cpp
+++ b/daemon/systemhealth/ExtensionScriptsValidator.cpp
@@ -47,8 +47,16 @@ Status ExtensionListValidator::Validate() const
 
 	std::string message;
 	Tokenizer tokDir(extensions.data(), ",;");
-	while (const char* scriptName = tokDir.Next())
+	while (const char* scriptNameRaw = tokDir.Next())
 	{
+		// Strip file extension from script name (e.g., "QueueSort.py" -> "QueueSort")
+		std::string scriptName(scriptNameRaw);
+		size_t dotPos = scriptName.find_last_of('.');
+		if (dotPos != std::string::npos && dotPos > 0)
+		{
+			scriptName = scriptName.substr(0, dotPos);
+		}
+
 		const auto extension =
 			m_extensionManager.FindIf([&](const auto ext) 
 			{
@@ -58,7 +66,7 @@ Status ExtensionListValidator::Validate() const
 		if (!extension)
 		{
 			if (!message.empty()) message += "; ";
-			message += std::string("'") + scriptName + "' doesn't exist";
+			message += std::string("'") + scriptNameRaw + "' doesn't exist";
 			continue;
 		}
 
@@ -86,22 +94,23 @@ Status ShellOverrideValidator::Validate() const
 	if (path.empty()) return Status::Ok();
 
 	std::string message;
-	Tokenizer tok(path.data(), ",;");
-	while (char* shellover = tok.Next())
+	std::string pathStr(path);
+	Tokenizer tok(pathStr.data(), ",;");
+	while (const char* shellover = tok.Next())
 	{
-		char* shellcmd = strchr(shellover, '=');
+		const char* shellcmd = strchr(shellover, '=');
 		if (shellcmd)
 		{
-			*shellcmd = '\0';
-			++shellcmd;
-			const auto exists = File::Exists(shellcmd);
+			std::string cmd(shellover, static_cast<size_t>(shellcmd - shellover));
+			const char* actualCmd = shellcmd + 1;
+			const auto exists = File::Exists(actualCmd);
 			if (!exists.IsOk())
 			{
 				if (!message.empty()) message += "; ";
 				message += exists.GetMessage() + " ";
 				continue;
 			}
-			const auto exe = File::Executable(shellcmd);
+			const auto exe = File::Executable(actualCmd);
 			if (!exe.IsOk())
 			{
 				if (!message.empty()) message += "; ";

--- a/daemon/systemhealth/NewsServerValidator.cpp
+++ b/daemon/systemhealth/NewsServerValidator.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -80,7 +80,7 @@ Status ServerOptionalValidator::Validate() const
 
 	if (m_server.GetOptional() && m_server.GetLevel() == 0)
 	{
-		return Status::Warning(
+		return Status::Info(
 			"Server is marked as optional but assigned to level 0; this may affect primary "
 			"server selection");
 	}

--- a/daemon/systemhealth/NewsServersValidator.cpp
+++ b/daemon/systemhealth/NewsServersValidator.cpp
@@ -50,7 +50,7 @@ Status ServersConfiguredValidator::Validate() const
 {
 	if (m_servers.empty() ||
 		(m_servers.size() == 1 && m_servers.front()->GetHost() == DEFAULT_SERVER_HOST))
-		return Status::Error("No news servers are configured");
+		return Status::Error("No servers are configured");
 
 	return Status::Ok();
 }
@@ -60,16 +60,34 @@ Status AnyServerActiveValidator::Validate() const
 	auto anyActive =
 		std::any_of(m_servers.cbegin(), m_servers.cend(), [](const auto& server)
 					{ return server->GetActive() && server->GetMaxConnections() > 0; });
-	if (!anyActive) return Status::Error("At least one news server must be active");
+	if (!anyActive) return Status::Error("At least one server must be active");
 
 	return Status::Ok();
 }
 
 Status AnyPrimaryServerExistsValidator::Validate() const
 {
-	auto anyLevelZero = std::any_of(m_servers.cbegin(), m_servers.cend(),
-									[](const auto& server) { return server->GetLevel() == 0; });
-	if (!anyLevelZero) return Status::Error("No servers are configured for level 0");
+	if (m_servers.empty())
+	{
+		return Status::Error("At least one server must be configured");
+	}
+
+	int minLevel = m_servers.front()->GetLevel();
+	for (const auto& server : m_servers)
+	{
+		if (server->GetLevel() < minLevel)
+		{
+			minLevel = server->GetLevel();
+		}
+	}
+
+	auto anyPrimaryActive = std::any_of(m_servers.cbegin(), m_servers.cend(),
+		[minLevel](const auto& server) { return server->GetLevel() == minLevel && server->GetActive(); });
+
+	if (!anyPrimaryActive)
+	{
+		return Status::Error("At least one primary server must be active");
+	}
 
 	return Status::Ok();
 }

--- a/daemon/systemhealth/PathsValidator.cpp
+++ b/daemon/systemhealth/PathsValidator.cpp
@@ -245,7 +245,7 @@ Status LogFileValidator::Validate(const fs::path& path, Options::EWriteLog write
 							 "' is set to empty");
 	}
 
-	if (writeLog == Options::EWriteLog::wlRotate && path.has_parent_path())
+	if ((writeLog == Options::EWriteLog::wlRotate || writeLog == Options::EWriteLog::wlReset) && path.has_parent_path())
 	{
 		const auto&& parent = path.parent_path();
 		return Directory::Exists(parent).And(&Directory::Writable, parent);

--- a/tests/systemhealth/ExtensionScriptsValidator.cpp
+++ b/tests/systemhealth/ExtensionScriptsValidator.cpp
@@ -1,0 +1,121 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2025-2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <fstream>
+#include "ExtensionScriptsValidator.h"
+#include "ExtensionManager.h"
+#include "Options.h"
+#include "Util.h"
+#include "FileSystem.h"
+
+BOOST_AUTO_TEST_SUITE(SystemHealthTest)
+
+using namespace SystemHealth::ExtensionScripts;
+using namespace SystemHealth;
+
+struct TempScriptDir
+{
+	fs::path path;
+	TempScriptDir()
+	{
+		path = fs::temp_directory_path() / fs::make_unique_filename();
+		fs::create_directory(path);
+	}
+	~TempScriptDir()
+	{
+		fs::error_code ec;
+		fs::remove_all(path, ec);
+	}
+};
+
+void CreateTestExtension(const fs::path& dir, const std::string& name, const std::string& kind)
+{
+	std::ofstream script((dir / (name + ".py")).string());
+	script << "#!/bin/sh\n"
+		   << "### NZBGET " << kind << " SCRIPT ###\n"
+		   << "echo test\n";
+	script.close();
+}
+
+BOOST_AUTO_TEST_CASE(TestExtensionListValidatorWithoutExt)
+{
+	TempScriptDir tempDir;
+
+	CreateTestExtension(tempDir.path, "QueueSort", "QUEUE");
+	CreateTestExtension(tempDir.path, "Completion", "POST-PROCESSING");
+
+	std::string scriptDirOpt = std::string("ScriptDir=") + tempDir.path.string();
+	std::string extensionsOpt = std::string("Extensions=") + "QueueSort,Completion";
+
+	Options::CmdOptList cmdOpts;
+	cmdOpts.push_back(scriptDirOpt.c_str());
+	cmdOpts.push_back(extensionsOpt.c_str());
+	cmdOpts.push_back("NzbLog=no");
+
+	Options options(&cmdOpts, nullptr);
+
+	Options* oldOptions = g_Options;
+	g_Options = &options;
+
+	ExtensionManager::Manager manager;
+	BOOST_REQUIRE(manager.LoadExtensions() == std::nullopt);
+
+	ExtensionListValidator validator(options, manager);
+	Status status = validator.Validate();
+	BOOST_CHECK_MESSAGE(status.IsOk(), "Validation failed: " << status.GetMessage());
+
+	g_Options = oldOptions;
+}
+
+BOOST_AUTO_TEST_CASE(TestExtensionListValidatorWithExt)
+{
+	TempScriptDir tempDir;
+
+	CreateTestExtension(tempDir.path, "QueueSort", "QUEUE");
+	CreateTestExtension(tempDir.path, "Completion", "POST-PROCESSING");
+
+	std::string scriptDirOpt = std::string("ScriptDir=") + tempDir.path.string();
+	std::string extensionsOpt = std::string("Extensions=") + "QueueSort.py,Completion.py";
+
+	Options::CmdOptList cmdOpts;
+	cmdOpts.push_back(scriptDirOpt.c_str());
+	cmdOpts.push_back(extensionsOpt.c_str());
+	cmdOpts.push_back("NzbLog=no");
+
+	Options options(&cmdOpts, nullptr);
+
+	Options* oldOptions = g_Options;
+	g_Options = &options;
+
+	ExtensionManager::Manager manager;
+	BOOST_REQUIRE(manager.LoadExtensions() == std::nullopt);
+
+	ExtensionListValidator validator(options, manager);
+	Status status = validator.Validate();
+	BOOST_CHECK_MESSAGE(status.IsOk(), "Validation failed: " << status.GetMessage());
+
+	g_Options = oldOptions;
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/systemhealth/NewsServerValidator.cpp
+++ b/tests/systemhealth/NewsServerValidator.cpp
@@ -23,6 +23,7 @@
 #include "Connection.h"
 #include "Options.h"
 #include "NewsServerValidator.h"
+#include "NewsServersValidator.h"
 
 BOOST_AUTO_TEST_SUITE(SystemHealthTest)
 
@@ -198,7 +199,7 @@ BOOST_AUTO_TEST_CASE(TestOptional)
 		SystemHealth::NewsServer::ServerOptionalValidator(
 			*CreateServer(true, "", "", 0, true, "", "", 50, 0, 0, "", Connection::ipAuto, true))
 			.Validate()
-			.IsWarning());
+			.IsInfo());
 }
 
 BOOST_AUTO_TEST_CASE(TestCertVerification)
@@ -220,6 +221,59 @@ BOOST_AUTO_TEST_CASE(TestCertVerification)
 								  Connection::ipAuto, false, 0, 0, Options::cvNone))
 					.Validate()
 					.IsOk());
+}
+
+BOOST_AUTO_TEST_CASE(TestAnyPrimaryServerExists_NoServers)
+{
+	::Servers servers;
+	SystemHealth::NewsServers::AnyPrimaryServerExistsValidator v(servers);
+	SystemHealth::Status s = v.Validate();
+	BOOST_CHECK(s.IsError());
+	BOOST_CHECK(s.GetMessage().find("At least one server must be configured") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(TestAnyPrimaryServerExists_NoActivePrimary)
+{
+	::Servers servers;
+	servers.push_back(CreateServer(false, "Server1", "news1.com", 563, true, "user", "pass", 50, 0));
+	servers.push_back(CreateServer(false, "Server2", "news2.com", 563, true, "user", "pass", 50, 1));
+
+	SystemHealth::NewsServers::AnyPrimaryServerExistsValidator v(servers);
+	SystemHealth::Status s = v.Validate();
+	BOOST_CHECK(s.IsError());
+	BOOST_CHECK(s.GetMessage().find("At least one primary server must be active") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(TestAnyPrimaryServerExists_ActivePrimary)
+{
+	::Servers servers;
+	servers.push_back(CreateServer(true, "Server1", "news1.com", 563, true, "user", "pass", 50, 0));
+	servers.push_back(CreateServer(false, "Server2", "news2.com", 563, true, "user", "pass", 50, 1));
+
+	SystemHealth::NewsServers::AnyPrimaryServerExistsValidator v(servers);
+	BOOST_CHECK(v.Validate().IsOk());
+}
+
+BOOST_AUTO_TEST_CASE(TestAnyPrimaryServerExists_MultiplePrimary)
+{
+	::Servers servers;
+	servers.push_back(CreateServer(true, "Server1", "news1.com", 563, true, "user", "pass", 50, 0));
+	servers.push_back(CreateServer(true, "Server2", "news2.com", 563, true, "user", "pass", 50, 0));
+
+	SystemHealth::NewsServers::AnyPrimaryServerExistsValidator v(servers);
+	BOOST_CHECK(v.Validate().IsOk());
+}
+
+BOOST_AUTO_TEST_CASE(TestAnyPrimaryServerExists_HigherLevelActive)
+{
+	::Servers servers;
+	servers.push_back(CreateServer(false, "Server1", "news1.com", 563, true, "user", "pass", 50, 0));
+	servers.push_back(CreateServer(true, "Server2", "news2.com", 563, true, "user", "pass", 50, 1));
+
+	SystemHealth::NewsServers::AnyPrimaryServerExistsValidator v(servers);
+	SystemHealth::Status s = v.Validate();
+	BOOST_CHECK(s.IsError());
+	BOOST_CHECK(s.GetMessage().find("At least one primary server must be active") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/systemhealth/systemhealth.cmake
+++ b/tests/systemhealth/systemhealth.cmake
@@ -2,4 +2,5 @@ list(APPEND TESTS_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/systemhealth/Validators.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/systemhealth/PathsValidator.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/systemhealth/NewsServerValidator.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/systemhealth/ExtensionScriptsValidator.cpp
 )


### PR DESCRIPTION
## Description

[#753](https://github.com/nzbgetcom/nzbget/pull/753#issuecomment-4229224347)

- Fix LogFileValidator: check directory for wlReset mode (file gets deleted on startup)
- Fix AnyPrimaryServerExistsValidator: check if any lowest level server is active
- Fix DownloadRateValidator: change to Info (not a warning)
- Fix ServerOptionalValidator: change to Info (not a warning)
- Fix ExtensionScriptsValidator: strip file extension from script names before matching
- Fix in-place buffer modification in ShellOverrideValidator (no longer uses *shellcmd = '\0')

## Testing

- macOS Tahoe
- Windows 11