### PR TITLE
Add support for ~/.config config locations

### DIFF
--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -39,6 +39,9 @@ const int BoolCount = 12;
 const char* PossibleConfigLocations[] =
 	{
 		"~/.nzbget",
+		"~/.config/nzbget.conf",
+		"~/.config/nzbget/nzbget",
+		"~/.config/nzbget/nzbget.conf",
 		"/etc/nzbget.conf",
 		"/usr/etc/nzbget.conf",
 		"/usr/local/etc/nzbget.conf",

--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -40,7 +40,6 @@ const char* PossibleConfigLocations[] =
 	{
 		"~/.nzbget",
 		"~/.config/nzbget.conf",
-		"~/.config/nzbget/nzbget",
 		"~/.config/nzbget/nzbget.conf",
 		"/etc/nzbget.conf",
 		"/usr/etc/nzbget.conf",

--- a/docs/HOW_TO_USE.md
+++ b/docs/HOW_TO_USE.md
@@ -25,7 +25,6 @@ On POSIX systems:
 <EXE-DIR>/nzbget.conf
 ~/.nzbget
 ~/.config/nzbget.conf
-~/.config/nzbget/nzbget
 ~/.config/nzbget/nzbget.conf
 /etc/nzbget.conf
 /usr/etc/nzbget.conf

--- a/docs/HOW_TO_USE.md
+++ b/docs/HOW_TO_USE.md
@@ -24,6 +24,9 @@ On POSIX systems:
 ```
 <EXE-DIR>/nzbget.conf
 ~/.nzbget
+~/.config/nzbget.conf
+~/.config/nzbget/nzbget
+~/.config/nzbget/nzbget.conf
 /etc/nzbget.conf
 /usr/etc/nzbget.conf
 /usr/local/etc/nzbget.conf
@@ -247,4 +250,4 @@ http://localhost:6789/username:password/
 ```
 Please note, that in this case the password is saved in a bookmark or in
 browser history in plain text and is easy to find by persons having
-access to your computer. 
+access to your computer.


### PR DESCRIPTION
## Description

[#239](https://github.com/nzbgetcom/nzbget/issues/239)

- Adds `~/.config/nzbget.conf` and `~/.config/nzbget/nzbget.conf` to the default list of fallback configuration file locations for POSIX systems.
