### PR TITLE
Fix macOS dark mode readable text and NZB file association

### DIFF
--- a/osx/DaemonController.h
+++ b/osx/DaemonController.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #import <Cocoa/Cocoa.h>
@@ -62,6 +63,8 @@
 - (void)updateStatus;
 
 - (void)rpc:(NSString*)method success:(SEL)successCallback failure:(SEL)failureCallback;
+
+- (void)rpc:(NSString*)method params:(NSArray*)params receiver:(id)receiver success:(SEL)successCallback failure:(SEL)failureCallback;
 
 - (void)setUpdateInterval:(NSTimeInterval)updateInterval;
 

--- a/osx/DaemonController.m
+++ b/osx/DaemonController.m
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include <libproc.h>
@@ -285,6 +286,11 @@ NSString* TMP_DIR = @"${AppSupDir}/tmp";
 
 - (void)rpc:(NSString*)method success:(SEL)successCallback failure:(SEL)failureCallback {
 	RPC* rpc = [[RPC alloc] initWithMethod:method receiver:self success:successCallback failure:failureCallback];
+	[rpc start];
+}
+
+- (void)rpc:(NSString*)method params:(NSArray*)params receiver:(id)receiver success:(SEL)successCallback failure:(SEL)failureCallback {
+	RPC* rpc = [[RPC alloc] initWithMethod:method params:params receiver:receiver success:successCallback failure:failureCallback];
 	[rpc start];
 }
 

--- a/osx/MainApp.h
+++ b/osx/MainApp.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,14 +15,14 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #import <Cocoa/Cocoa.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>
 #import "DaemonController.h"
 
-@interface MainApp : NSObject <NSMenuDelegate, DaemonControllerDelegate> {
+@interface MainApp : NSObject <NSApplicationDelegate, NSMenuDelegate, DaemonControllerDelegate> {
 	IBOutlet NSMenu *statusMenu;
     NSStatusItem *statusItem;
 	IBOutlet NSMenuItem *webuiItem;
@@ -50,6 +51,7 @@
 	NSTimer* restartTimer;
 	NSMutableArray* categoryItems;
 	NSMutableArray* categoryDirs;
+	NSMutableArray* queuedNzbs;
 }
 
 + (void)setupAppDefaults;
@@ -77,5 +79,9 @@
 - (IBAction)showInFinderClicked:(id)sender;
 
 - (void)updateSleepState:(BOOL)preventSleep;
+
+- (void)appendSuccess:(id)result;
+
+- (void)appendFailure;
 
 @end

--- a/osx/MainApp.h
+++ b/osx/MainApp.h
@@ -44,6 +44,7 @@
 	NSWindowController *preferencesDialog;
 	DaemonController *daemonController;
 	int connectionAttempts;
+	int nzbAppendRetryCount;
 	BOOL restarting;
 	BOOL resetting;
 	BOOL preventingSleep;
@@ -79,9 +80,5 @@
 - (IBAction)showInFinderClicked:(id)sender;
 
 - (void)updateSleepState:(BOOL)preventSleep;
-
-- (void)appendSuccess:(id)result;
-
-- (void)appendFailure;
 
 @end

--- a/osx/MainApp.m
+++ b/osx/MainApp.m
@@ -88,7 +88,6 @@ void InstallSignalHandlers()
 	daemonController = [[DaemonController alloc] init];
 	daemonController.updateInterval = autoStartWebUI ? START_UPDATE_INTERVAL : NORMAL_UPDATE_INTERVAL;
 	daemonController.delegate = self;
-	queuedNzbs = [[NSMutableArray alloc] init];
 
 	[self setupDefaultsObserver];
 	[self userDefaultsDidChange:nil];
@@ -610,6 +609,9 @@ void InstallSignalHandlers()
 }
 
 - (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename {
+    if (!queuedNzbs) {
+        queuedNzbs = [[NSMutableArray alloc] init];
+    }
     BOOL wasEmpty = ([queuedNzbs count] == 0);
     [queuedNzbs addObject:filename];
     if (wasEmpty) {
@@ -619,6 +621,9 @@ void InstallSignalHandlers()
 }
 
 - (void)application:(NSApplication *)sender openFiles:(NSArray *)filenames {
+    if (!queuedNzbs) {
+        queuedNzbs = [[NSMutableArray alloc] init];
+    }
     BOOL wasEmpty = ([queuedNzbs count] == 0);
     [queuedNzbs addObjectsFromArray:filenames];
     if (wasEmpty) {

--- a/osx/MainApp.m
+++ b/osx/MainApp.m
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #import "MainApp.h"
@@ -600,6 +601,71 @@ void InstallSignalHandlers()
 		[categoryItems addObject:item];
 		[categoryDirs addObject:dir];
 	}
+}
+
+- (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename {
+    if (!queuedNzbs) {
+        queuedNzbs = [[NSMutableArray alloc] init];
+    }
+    BOOL wasEmpty = ([queuedNzbs count] == 0);
+    [queuedNzbs addObject:filename];
+    if (wasEmpty) {
+        [self processQueuedNzbs];
+    }
+    return YES;
+}
+
+- (void)application:(NSApplication *)sender openFiles:(NSArray *)filenames {
+    if (!queuedNzbs) {
+        queuedNzbs = [[NSMutableArray alloc] init];
+    }
+    BOOL wasEmpty = ([queuedNzbs count] == 0);
+    [queuedNzbs addObjectsFromArray:filenames];
+    if (wasEmpty) {
+        [self processQueuedNzbs];
+    }
+    [sender replyToOpenOrPrint:NSApplicationDelegateReplySuccess];
+}
+
+- (void)processQueuedNzbs {
+    if ([queuedNzbs count] == 0) return;
+    
+    if (!daemonController || !daemonController.connected) {
+        [self performSelector:@selector(processQueuedNzbs) withObject:nil afterDelay:1.0];
+        return;
+    }
+
+    NSString *filename = [queuedNzbs firstObject];
+    NSData *fileData = [NSData dataWithContentsOfFile:filename];
+    
+    if (!fileData) {
+        if ([queuedNzbs count] > 0) {
+            [queuedNzbs removeObjectAtIndex:0];
+        }
+        [self processQueuedNzbs];
+        return;
+    }
+
+    NSString *content = [fileData base64EncodedStringWithOptions:0];
+
+    // [Filename, Content, Category, Priority, AddToTop, AddPaused, DupeKey, DupeScore, DupeMode, AutoCategory, PPParameters]
+    NSArray *params = @[ filename, content, @"", @0, @NO, @NO, @"", @0, @"SCORE", @NO, @[] ];
+
+    [daemonController rpc:@"append" params:params receiver:self success:@selector(appendSuccess:) failure:@selector(appendFailure)];
+}
+
+- (void)appendSuccess:(id)result {
+    if ([queuedNzbs count] > 0) {
+        [queuedNzbs removeObjectAtIndex:0];
+    }
+    [self processQueuedNzbs];
+}
+
+- (void)appendFailure {
+    if ([queuedNzbs count] > 0) {
+        [queuedNzbs removeObjectAtIndex:0];
+    }
+    [self performSelector:@selector(processQueuedNzbs) withObject:nil afterDelay:1.0];
 }
 
 @end

--- a/osx/MainApp.m
+++ b/osx/MainApp.m
@@ -55,6 +55,11 @@ void InstallSignalHandlers()
 	signal(SIGPIPE, SIG_IGN);
 }
 
+@interface MainApp ()
+- (void)appendSuccess:(id)result;
+- (void)appendFailure;
+@end
+
 @implementation MainApp
 
 - (void)applicationWillFinishLaunching:(NSNotification *)aNotification {
@@ -83,6 +88,7 @@ void InstallSignalHandlers()
 	daemonController = [[DaemonController alloc] init];
 	daemonController.updateInterval = autoStartWebUI ? START_UPDATE_INTERVAL : NORMAL_UPDATE_INTERVAL;
 	daemonController.delegate = self;
+	queuedNzbs = [[NSMutableArray alloc] init];
 
 	[self setupDefaultsObserver];
 	[self userDefaultsDidChange:nil];
@@ -604,9 +610,6 @@ void InstallSignalHandlers()
 }
 
 - (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename {
-    if (!queuedNzbs) {
-        queuedNzbs = [[NSMutableArray alloc] init];
-    }
     BOOL wasEmpty = ([queuedNzbs count] == 0);
     [queuedNzbs addObject:filename];
     if (wasEmpty) {
@@ -616,9 +619,6 @@ void InstallSignalHandlers()
 }
 
 - (void)application:(NSApplication *)sender openFiles:(NSArray *)filenames {
-    if (!queuedNzbs) {
-        queuedNzbs = [[NSMutableArray alloc] init];
-    }
     BOOL wasEmpty = ([queuedNzbs count] == 0);
     [queuedNzbs addObjectsFromArray:filenames];
     if (wasEmpty) {
@@ -631,9 +631,16 @@ void InstallSignalHandlers()
     if ([queuedNzbs count] == 0) return;
     
     if (!daemonController || !daemonController.connected) {
+        if (++nzbAppendRetryCount > 30) {
+            NSLog(@"[NZBGet] Daemon unreachable, dropping %lu queued NZBs", (unsigned long)[queuedNzbs count]);
+            [queuedNzbs removeAllObjects];
+            nzbAppendRetryCount = 0;
+            return;
+        }
         [self performSelector:@selector(processQueuedNzbs) withObject:nil afterDelay:1.0];
         return;
     }
+    nzbAppendRetryCount = 0;
 
     NSString *filename = [queuedNzbs firstObject];
     NSData *fileData = [NSData dataWithContentsOfFile:filename];
@@ -649,12 +656,16 @@ void InstallSignalHandlers()
     NSString *content = [fileData base64EncodedStringWithOptions:0];
 
     // [Filename, Content, Category, Priority, AddToTop, AddPaused, DupeKey, DupeScore, DupeMode, AutoCategory, PPParameters]
-    NSArray *params = @[ filename, content, @"", @0, @NO, @NO, @"", @0, @"SCORE", @NO, @[] ];
+    NSArray *params = @[ [filename lastPathComponent], content, @"", @0, @NO, @NO, @"", @0, @"SCORE", @NO, @[] ];
 
     [daemonController rpc:@"append" params:params receiver:self success:@selector(appendSuccess:) failure:@selector(appendFailure)];
 }
 
 - (void)appendSuccess:(id)result {
+    if (!result || [result isEqual:@NO] ||
+        ([result isKindOfClass:[NSNumber class]] && [result integerValue] <= 0)) {
+        NSLog(@"[NZBGet] append RPC failed for: %@", [queuedNzbs firstObject]);
+    }
     if ([queuedNzbs count] > 0) {
         [queuedNzbs removeObjectAtIndex:0];
     }
@@ -662,9 +673,6 @@ void InstallSignalHandlers()
 }
 
 - (void)appendFailure {
-    if ([queuedNzbs count] > 0) {
-        [queuedNzbs removeObjectAtIndex:0];
-    }
     [self performSelector:@selector(processQueuedNzbs) withObject:nil afterDelay:1.0];
 }
 

--- a/osx/NZBGet-Info.plist
+++ b/osx/NZBGet-Info.plist
@@ -25,6 +25,8 @@
 	<array>
 	<string>nzb</string>
 	</array>
+	<key>CFBundleTypeIconFile</key>
+	<string>mainicon.icns</string>
 	<key>CFBundleTypeRole</key>
 	<string>Editor</string>
 	<key>LSHandlerRank</key>
@@ -38,7 +40,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.13</string>
+	<string>10.14</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSMainNibFile</key>

--- a/osx/NZBGet-Info.plist
+++ b/osx/NZBGet-Info.plist
@@ -40,7 +40,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.14</string>
+	<string>10.13</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSMainNibFile</key>

--- a/osx/RPC.h
+++ b/osx/RPC.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #import <Cocoa/Cocoa.h>
@@ -24,6 +25,12 @@
 }
 
 - (id)initWithMethod:(NSString*)method
+			receiver:(id)receiver
+			 success:(SEL)successCallback
+			 failure:(SEL)failureCallback;
+
+- (id)initWithMethod:(NSString*)method
+			  params:(NSArray*)params
 			receiver:(id)receiver
 			 success:(SEL)successCallback
 			 failure:(SEL)failureCallback;

--- a/osx/RPC.m
+++ b/osx/RPC.m
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #import <Cocoa/Cocoa.h>
@@ -33,6 +34,23 @@ NSString* rpcUrl;
 	return self;
 }
 
+- (id)initWithMethod:(NSString*)method
+			  params:(NSArray*)params
+			receiver:(id)receiver
+			 success:(SEL)successCallback
+			 failure:(SEL)failureCallback {
+	NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:rpcUrl]];
+	[request setHTTPMethod:@"POST"];
+	[request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+	
+	NSDictionary *reqObj = @{ @"version": @"1.1", @"method": method, @"params": params ?: @[] };
+	NSData *reqData = [NSJSONSerialization dataWithJSONObject:reqObj options:0 error:nil];
+	[request setHTTPBody:reqData];
+	
+	self = [super initWithURLRequest:request receiver:receiver success:successCallback failure:failureCallback];
+	return self;
+}
+
 + (void)setRpcUrl:(NSString*)url {
 	rpcUrl = url;
 }
@@ -48,6 +66,7 @@ NSString* rpcUrl;
 		/* JSON was malformed, act appropriately here */
 		failureCode = 999;
 		[self failure];
+		return;
 	}
 
 	id result = [dataObj valueForKey:@"result"];

--- a/osx/WebClient.h
+++ b/osx/WebClient.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #import <Cocoa/Cocoa.h>
@@ -30,6 +31,11 @@
 }
 
 - (id)initWithURLString:(NSString*)urlStr
+			   receiver:(id)receiver
+				success:(SEL)successCallback
+				failure:(SEL)failureCallback;
+
+- (id)initWithURLRequest:(NSURLRequest*)request
 			   receiver:(id)receiver
 				success:(SEL)successCallback
 				failure:(SEL)failureCallback;

--- a/osx/WebClient.m
+++ b/osx/WebClient.m
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #import <Cocoa/Cocoa.h>
@@ -27,14 +28,31 @@
 				success:(SEL)successCallback
 				failure:(SEL)failureCallback {
 	self = [super init];
-	
-	_receiver = receiver;
-	_successCallback = successCallback;
-	_failureCallback = failureCallback;
-	NSURL *url = [NSURL URLWithString:urlStr];
-	NSURLRequest *request = [NSURLRequest requestWithURL:url];
-	connection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
-	[connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+	if (self) {
+		_receiver = receiver;
+		_successCallback = successCallback;
+		_failureCallback = failureCallback;
+		NSURL *url = [NSURL URLWithString:urlStr];
+		NSURLRequest *request = [NSURLRequest requestWithURL:url];
+		connection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
+		[connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+	}
+
+	return self;
+}
+
+- (id)initWithURLRequest:(NSURLRequest*)request
+			   receiver:(id)receiver
+				success:(SEL)successCallback
+				failure:(SEL)failureCallback {
+	self = [super init];
+	if (self) {
+		_receiver = receiver;
+		_successCallback = successCallback;
+		_failureCallback = failureCallback;
+		connection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
+		[connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+	}
 
 	return self;
 }

--- a/osx/WebClient.m
+++ b/osx/WebClient.m
@@ -53,11 +53,10 @@
 		connection = [[NSURLConnection alloc] initWithRequest:request delegate:self startImmediately:NO];
 		[connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
 	}
-
 	return self;
 }
 
-- (void) start {
+- (void)start {
 	[connection start];
 }
 

--- a/osx/WelcomeDialog.m
+++ b/osx/WelcomeDialog.m
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2026 Denis <denis@nzbget.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,7 +15,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #import "WelcomeDialog.h"
@@ -49,6 +50,7 @@
 	[_badgeView setImage:[[NSWorkspace sharedWorkspace] iconForFileType:NSFileTypeForHFSTypeCode(kAlertNoteIcon)]];
 	
     [[_messageText textStorage] readFromURL:[NSURL fileURLWithPath:[[NSBundle mainBundle] pathForResource:@"Welcome" ofType:@"rtf"]] options:nil documentAttributes:nil];
+    [_messageText setTextColor:[NSColor textColor]];
     
 	// adjust height of text control and window
 	[[_messageText layoutManager] ensureLayoutForTextContainer:[_messageText textContainer]];


### PR DESCRIPTION
## Description

[#40](https://github.com/nzbgetcom/nzbget/issues/40)
[#86](https://github.com/nzbgetcom/nzbget/issues/86)

- Use adaptive system text color in Welcome dialog for dark mode visibility
- Fix "Cannot open files of this type" by implementing `application:openFiles:`
- Safely route double-clicked NZB files to the background daemon via RPC

## Testing

- macOS Mojave/Tahoe