### PR TITLE
Resolve text fragmentation issues

### DIFF
--- a/daemon/feed/FeedFile.cpp
+++ b/daemon/feed/FeedFile.cpp
@@ -84,7 +84,7 @@ bool FeedFile::Parse()
 	SAX_handler.getEntity = reinterpret_cast<getEntitySAXFunc>(SAX_getEntity);
 
 	/*
-	 * libxml2 2.4+ sends CDATA via `cdataBlock` instead of `characters`. Earlier
+	 * libxml2 2.14+ sends CDATA via `cdataBlock` instead of `characters`. Earlier
 	 * versions deliver CDATA in `characters`; `cdataBlock` is unused. Both
 	 * require identical handling, so the same handler is assigned.
 	 */
@@ -265,6 +265,9 @@ void FeedFile::Parse_EndElement(const char* name)
 	if (!name)
 		return;
 
+	// Trim the collected content once after all chunks (text + CDATA) are merged
+	Util::Trim(m_tagContent);
+
 	if (!strcmp("title", name) && m_feedItemInfo)
 	{
 		m_feedItemInfo->SetTitle(m_tagContent.c_str());
@@ -328,9 +331,7 @@ void FeedFile::SAX_textHandler(FeedFile* file, const char* xmlstr, int len)
 	if (!xmlstr || len <= 0)
 		return;
 
-	std::string str(xmlstr, len);
-	Util::Trim(str);
-	file->Parse_Content(std::move(str));
+	file->Parse_Content(std::string(xmlstr, len));
 }
 
 xmlEntityPtr FeedFile::SAX_getEntity(FeedFile* file, const xmlChar* name)

--- a/tests/feed/FeedFile.cpp
+++ b/tests/feed/FeedFile.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(FeedFileTest)
 	std::unique_ptr<FeedItemList> items = file.DetachFeedItems();
 	FeedItemInfo& feedInfo = items.get()->back();
 
-	BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string("Movies>HD"));
+	BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string("Movies > HD"));
 	BOOST_CHECK_EQUAL(feedInfo.GetTime(), 1701668883);
 	BOOST_CHECK_EQUAL(feedInfo.GetEpisode(), std::string("1"));
 	BOOST_CHECK_EQUAL(feedInfo.GetEpisodeNum(), 1);


### PR DESCRIPTION
## Description
To prevent whitespace loss caused by fragmented SAX callbacks, the trimming logic is moved from the individual text handler to the element completion phase. By deferring Util::Trim() until Parse_EndElement, the logical content of an element is preserved as a single entity, ensuring that spaces between merged text and CDATA blocks are not prematurely discarded.

While here, correct the libxml2 version reference from 2.4 to 2.14 in a comment (mistake introduced by fd3f07d)

## Lib changes
No changes.

## Testing
After updating `tests/feed/FeedFile.cpp` all tests pass.