### PR TITLE
Fix resource leaks in socket/listener and script pipe error paths

### DIFF
--- a/daemon/connect/Connection.cpp
+++ b/daemon/connect/Connection.cpp
@@ -334,6 +334,8 @@ bool Connection::Bind()
 	if (listen(m_socket, 100) < 0)
 	{
 		ReportError("Listen on socket failed for %s", m_host.c_str(), true);
+		closesocket(m_socket);
+		m_socket = INVALID_SOCKET;
 		return false;
 	}
 

--- a/daemon/util/ScriptController.cpp
+++ b/daemon/util/ScriptController.cpp
@@ -330,7 +330,8 @@ int ScriptController::Execute()
 		if (!m_writepipe)
 		{
 			PrintMessage(Message::mkError, "Could not open write pipe to %s", *m_infoName);
-			close(pipein);
+			fclose(m_readpipe);
+			m_readpipe = nullptr;
 			close(pipeout);
 			m_completed = true;
 			return -1;


### PR DESCRIPTION
## Description
Connection.cpp: close and invalidate the listening socket when listen() fails to prevent descriptor leakage on bind/listen error paths.

ScriptController.cpp: close the already-opened read FILE* and clear its pointer when write-pipe fdopen() fails, preventing a leaked stdio handle in the startup failure path.

## Lib changes
No changes.

## Testing
Passes all tests. Run tested on OpenBSD.