### PR TITLE
Prevent symlink attacks and TOCTOU races in daemon startup

### DIFF
--- a/daemon/main/nzbget.cpp
+++ b/daemon/main/nzbget.cpp
@@ -1025,10 +1025,25 @@ void NZBGet::Daemonize()
 	int lfp = -1;
 	if (!Util::EmptyStr(m_options->GetLockFile()))
 	{
-		lfp = open(m_options->GetLockFile(), O_RDWR | O_CREAT, 0640);
+		int flags = O_RDWR | O_CREAT;
+#ifdef O_NOFOLLOW
+		flags |= O_NOFOLLOW;
+#endif
+#ifdef O_CLOEXEC
+		flags |= O_CLOEXEC;
+#endif
+		lfp = open(m_options->GetLockFile(), flags, 0640);
 		if (lfp < 0)
 		{
 			error("Starting daemon failed: could not create lock-file %s", m_options->GetLockFile());
+			exit(1);
+		}
+
+		struct stat lockFileStat;
+		if (fstat(lfp, &lockFileStat) != 0 || !S_ISREG(lockFileStat.st_mode))
+		{
+			error("Starting daemon failed: lock-file %s is not a regular file", m_options->GetLockFile());
+			close(lfp);
 			exit(1);
 		}
 
@@ -1058,9 +1073,10 @@ void NZBGet::Daemonize()
 			exit(1);
 		}
 
-		// Change owner of lock- and logfile
-		chown(m_options->GetLockFile(), pw->pw_uid, pw->pw_gid);
-		chown(m_options->GetLogFile(), pw->pw_uid, pw->pw_gid);
+		if (lfp > -1)
+		{
+			fchown(lfp, pw->pw_uid, pw->pw_gid);
+		}
 
 		// Set aux groups to null, configure primary and aux groups, and then assign uid
 		if (setgroups(0, (const gid_t*)0) ||

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -264,6 +264,7 @@ public:
 	bool SetWriteBuffer(int size);
 	bool Flush();
 	bool Sync(CString& errmsg);
+	int GetFileDescriptor() const { return m_file ? fileno(m_file) : -1; }
 
 private:
 	FILE* m_file = nullptr;

--- a/daemon/util/Log.cpp
+++ b/daemon/util/Log.cpp
@@ -101,9 +101,10 @@ void Log::Filelog(const char* msg, ...)
 		if (getuid() == 0 || geteuid() == 0)
 		{
 			struct passwd* pwd = getpwnam(g_Options->GetDaemonUsername());
-			if (pwd != nullptr)
+			int fileDescriptor = m_logFile->GetFileDescriptor();
+			if (pwd != nullptr && fileDescriptor >= 0)
 			{
-				chown(m_logFilename.c_str(), pwd->pw_uid, pwd->pw_gid);
+				fchown(fileDescriptor, pwd->pw_uid, pwd->pw_gid);
 			}
 		}
 #endif


### PR DESCRIPTION
## Description
Replace path-based chown() with fchown() for lock and log files to eliminate TOCTOU races between path resolution and ownership change.

Open the lockfile with O_NOFOLLOW to prevent symlink redirection, and O_CLOEXEC to avoid fd leaks into child processes. Validate the opened fd with fstat/S_ISREG as defense-in-depth against non-regular files.

Note: log file ownership change now occurs on first write (in Filelog) rather than eagerly at daemon startup.

## Lib changes
No changes.

## Testing
Passes all tests. Run tested on OpenBSD.