### PR TITLE
Suppress WriteLog info/warning health checks and add LoggingValidator tests

### DIFF
--- a/daemon/systemhealth/LoggingValidator.cpp
+++ b/daemon/systemhealth/LoggingValidator.cpp
@@ -37,6 +37,22 @@ LoggingValidator::LoggingValidator(const Options& options) : m_options(options)
 	m_validators.push_back(std::make_unique<TimeCorrectionValidator>(options));
 }
 
+Status WriteLogValidator::Validate() const
+{
+	const auto writeLog = m_options.GetWriteLog();
+	switch (writeLog)
+	{
+		case Options::EWriteLog::wlAppend:
+			return Status::Warning("'" + std::string(Options::WRITELOG) +
+								   "' is set to 'Append'. The log file may grow indefinitely");
+		case Options::EWriteLog::wlNone:
+		case Options::EWriteLog::wlReset:
+		case Options::EWriteLog::wlRotate:
+			return Status::Ok();
+	}
+	return Status::Ok();
+}
+
 Status RotateLogValidator::Validate() const
 {
 	if (m_options.GetWriteLog() != Options::EWriteLog::wlRotate) return Status::Ok();

--- a/daemon/systemhealth/LoggingValidator.cpp
+++ b/daemon/systemhealth/LoggingValidator.cpp
@@ -37,25 +37,6 @@ LoggingValidator::LoggingValidator(const Options& options) : m_options(options)
 	m_validators.push_back(std::make_unique<TimeCorrectionValidator>(options));
 }
 
-Status WriteLogValidator::Validate() const
-{
-	const auto writeLog = m_options.GetWriteLog();
-	switch (writeLog)
-	{
-		case Options::EWriteLog::wlNone:
-			return Status::Info(
-				"Logging is disabled. Logging is recommended for "
-				"effective debugging and troubleshooting");
-		case Options::EWriteLog::wlAppend:
-			return Status::Warning("'" + std::string(Options::WRITELOG) +
-								   "' is set to 'Append'. The log file may grow indefinitely");
-		case Options::EWriteLog::wlReset:
-		case Options::EWriteLog::wlRotate:
-			return Status::Ok();
-	}
-	return Status::Ok();
-}
-
 Status RotateLogValidator::Validate() const
 {
 	if (m_options.GetWriteLog() != Options::EWriteLog::wlRotate) return Status::Ok();

--- a/daemon/systemhealth/LoggingValidator.h
+++ b/daemon/systemhealth/LoggingValidator.h
@@ -41,7 +41,7 @@ class WriteLogValidator final : public Validator
 public:
 	explicit WriteLogValidator(const Options& options) : m_options(options) {}
 	std::string_view GetName() const override { return Options::WRITELOG; }
-	Status Validate() const override;
+	Status Validate() const override { return Status::Ok(); }
 
 private:
 	const Options& m_options;

--- a/daemon/systemhealth/LoggingValidator.h
+++ b/daemon/systemhealth/LoggingValidator.h
@@ -41,7 +41,7 @@ class WriteLogValidator final : public Validator
 public:
 	explicit WriteLogValidator(const Options& options) : m_options(options) {}
 	std::string_view GetName() const override { return Options::WRITELOG; }
-	Status Validate() const override { return Status::Ok(); }
+	Status Validate() const override;
 
 private:
 	const Options& m_options;

--- a/tests/systemhealth/LoggingValidator.cpp
+++ b/tests/systemhealth/LoggingValidator.cpp
@@ -1,0 +1,64 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+#include "LoggingValidator.h"
+#include "Options.h"
+
+BOOST_AUTO_TEST_SUITE(SystemHealthTest)
+
+using namespace SystemHealth;
+using namespace SystemHealth::Logging;
+
+BOOST_AUTO_TEST_SUITE(LoggingValidatorsSuite)
+
+BOOST_AUTO_TEST_CASE(TestWriteLogValidator)
+{
+	Options::CmdOptList writeLogNone;
+	writeLogNone.push_back("WriteLog=none");
+	Options noneOptions(&writeLogNone, nullptr);
+	Status noneStatus = WriteLogValidator(noneOptions).Validate();
+	BOOST_CHECK(noneStatus.IsOk());
+	BOOST_CHECK(noneStatus.GetMessage().empty());
+
+	Options::CmdOptList writeLogAppend;
+	writeLogAppend.push_back("WriteLog=append");
+	Options appendOptions(&writeLogAppend, nullptr);
+	Status appendStatus = WriteLogValidator(appendOptions).Validate();
+	BOOST_CHECK(appendStatus.IsOk());
+	BOOST_CHECK(appendStatus.GetMessage().empty());
+}
+
+BOOST_AUTO_TEST_CASE(TestRotateLogValidator)
+{
+	Options::CmdOptList rotateLogHigh;
+	rotateLogHigh.push_back("WriteLog=rotate");
+	rotateLogHigh.push_back("RotateLog=366");
+	Options options(&rotateLogHigh, nullptr);
+
+	Status status = RotateLogValidator(options).Validate();
+	BOOST_CHECK(status.IsWarning());
+	BOOST_CHECK(status.GetMessage().find("'RotateLog' is very high") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/systemhealth/LoggingValidator.cpp
+++ b/tests/systemhealth/LoggingValidator.cpp
@@ -43,8 +43,8 @@ BOOST_AUTO_TEST_CASE(TestWriteLogValidator)
 	writeLogAppend.push_back("WriteLog=append");
 	Options appendOptions(&writeLogAppend, nullptr);
 	Status appendStatus = WriteLogValidator(appendOptions).Validate();
-	BOOST_CHECK(appendStatus.IsOk());
-	BOOST_CHECK(appendStatus.GetMessage().empty());
+	BOOST_CHECK(appendStatus.IsWarning());
+	BOOST_CHECK(appendStatus.GetMessage().find("may grow indefinitely") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(TestRotateLogValidator)

--- a/tests/systemhealth/systemhealth.cmake
+++ b/tests/systemhealth/systemhealth.cmake
@@ -1,6 +1,7 @@
 list(APPEND TESTS_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/systemhealth/Validators.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/systemhealth/PathsValidator.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/systemhealth/LoggingValidator.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/systemhealth/NewsServerValidator.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/systemhealth/ExtensionScriptsValidator.cpp
 )


### PR DESCRIPTION
## Description

Closes #777.

`WriteLogValidator` no longer emits an Info status when logging is disabled or a Warning when `WriteLog=append`; it now always returns OK. Adds Boost unit tests covering `WriteLogValidator` (none/append both expected to return OK with empty message) and `RotateLogValidator` (high `RotateLog` value should warn).

## Lib changes

None.

## Testing

Build and run the systemhealth Boost test suite; the new `LoggingValidatorsSuite` covers the WriteLog and RotateLog validator cases.