### PR TITLE
Fix: prevent iOS from auto-capitalizing the login username field

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -3310,7 +3310,7 @@
 				<div class="control-group">
 					<label class="control-label" for="LoginDialog_UsernameGroup">Username</label>
 					<div class="controls" id="LoginDialog_UsernameGroup">
-						<input class="input-medium" id="LoginDialog_Username" type="text">
+						<input class="input-medium" id="LoginDialog_Username" type="text" autocapitalize="none" autocorrect="off" autocomplete="username">
 					</div>
 				</div>
 


### PR DESCRIPTION
## Description

Add autocapitalize="none", autocorrect="off", and autocomplete="username" to the login username input so iOS doesn't capitalize or autocorrect the first character, which causes failed logins for case sensitive usernames. 

## Testing

Local validation