### PR TITLE
Fix WebUI "InternalError: allocation size overflow" on very large file uploads

### DIFF
--- a/webui/config.js
+++ b/webui/config.js
@@ -2947,7 +2947,7 @@ var ConfigBackupRestore = (new function($)
 			}
 			else
 			{
-				var base64str = event.target.result.replace(/^data:[^,]+,/, '');
+				var base64str = event.target.result.slice(event.target.result.indexOf(',') + 1);
 				settings = atob(base64str);
 			}
 			filename = file.name;

--- a/webui/upload.js
+++ b/webui/upload.js
@@ -354,7 +354,7 @@ var Upload = (new function($)
 		reader.onload = function (event)
 		{
 			var result = event.target.result;
-			var base64str = result.replace(/^data:[^,]+,/, '');
+			var base64str = result.slice(result.indexOf(',') + 1);
 			var category = $('#AddDialog_Category').val();
 			var priority = parseInt($('#AddDialog_Priority').val());
 			var filename = info.name + info.ext;

--- a/webui/util.js
+++ b/webui/util.js
@@ -712,8 +712,38 @@ var RPC = (new function($)
 		else
 		{
 			xhr.open('post', this.rpcUrl);
-			xhr._request = JSON.stringify({nocache: new Date().getTime(), method: method, params: params});
-			xhr._reportRequest = xhr._request;
+			var parts = [];
+			parts.push('{"nocache":' + new Date().getTime() + ',"method":' + JSON.stringify(method) + ',"params":[');
+			for (var i = 0; i < params.length; i++)
+			{
+				if (i > 0)
+				{
+					parts.push(',');
+				}
+				parts.push(JSON.stringify(params[i]));
+			}
+			parts.push(']}');
+
+			var isLarge = false;
+			var totalSize = 0;
+			for (var i = 0; i < parts.length; i++)
+			{
+				totalSize += parts[i].length;
+				if (totalSize > 1024 * 1024)
+				{
+					isLarge = true;
+				}
+			}
+
+			xhr._request = new Blob(parts, {type: 'application/json'});
+			if (isLarge)
+			{
+				xhr._reportRequest = '{"method":"' + method + '", "params": [...large payload...]}';
+			}
+			else
+			{
+				xhr._reportRequest = parts.join('');
+			}
 		}
 
 		if (options && ('timeout' in options))

--- a/webui/util.js
+++ b/webui/util.js
@@ -720,7 +720,16 @@ var RPC = (new function($)
 				{
 					parts.push(',');
 				}
-				parts.push(JSON.stringify(params[i]));
+				if (typeof params[i] === 'string' && params[i].length > 1024 * 1024)
+				{
+					parts.push('"');
+					parts.push(params[i]);
+					parts.push('"');
+				}
+				else
+				{
+					parts.push(JSON.stringify(params[i]));
+				}
 			}
 			parts.push(']}');
 


### PR DESCRIPTION
When uploading very large nzb files to nzbget, you get "InternalError: allocation size overflow". This fixes that issue by 

- avoiding the regular expression that matches the data URL containing the entire file and using `slice` instead.
- dealing with `JSON.stringify` running into limits on the heap. Since base64 strings only contain characters that do not require JSON escaping, direct enclosure within double quotes (") forms a perfectly valid JSON string representation at the streaming level.

With these fixes, NZB files larger than 128MB work.