### PR TITLE
Unrar 7.21 update (Windows / macOS)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,7 +50,7 @@ jobs:
         Invoke-WebRequest https://github.com/nzbgetcom/build-files/releases/download/v5.0/vcpkg-windows-x${{ matrix.arch }}.zip -OutFile "${{ github.workspace }}\vcpkg.zip"
         Rename-Item -path "C:\vcpkg" -NewName "C:\vcpkg.old"
         Expand-Archive -Path "${{ github.workspace }}\vcpkg.zip" -DestinationPath C:\
-        Invoke-WebRequest https://github.com/nzbgetcom/build-files/releases/download/v7.0/nzbget-windows-tools.zip -OutFile "${{ github.workspace }}\tools.zip"
+        Invoke-WebRequest https://github.com/nzbgetcom/build-files/releases/download/v9.0/nzbget-windows-tools.zip -OutFile "${{ github.workspace }}\tools.zip"
         Expand-Archive -Path "${{ github.workspace }}\tools.zip" -DestinationPath C:\
 
     - name: Build nzbget ${{ matrix.arch }}-bit / ${{ matrix.type }} binary
@@ -111,7 +111,7 @@ jobs:
     - name: Prepare build environment
       run: |
         $ProgressPreference = "SilentlyContinue"
-        Invoke-WebRequest https://github.com/nzbgetcom/build-files/releases/download/v7.0/nzbget-windows-tools.zip -OutFile "${{ github.workspace }}\tools.zip"
+        Invoke-WebRequest https://github.com/nzbgetcom/build-files/releases/download/v9.0/nzbget-windows-tools.zip -OutFile "${{ github.workspace }}\tools.zip"
         Expand-Archive -Path "${{ github.workspace }}\tools.zip" -DestinationPath C:\
         New-Item build -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
         Copy-Item Release* build -Recurse -ErrorAction SilentlyContinue

--- a/osx/build-nzbget.sh
+++ b/osx/build-nzbget.sh
@@ -24,7 +24,7 @@ set -o errexit
 
 # unpackers versions defaults
 # can be overridden by environment variables
-UNRAR_VERSION="${UNRAR_VERSION-721}"
+UNRAR_VERSION="${UNRAR_VERSION-722}"
 ZIP7_VERSION="${ZIP7_VERSION-26.01}"
 
 # make jobs

--- a/windows/build-nzbget.ps1
+++ b/windows/build-nzbget.ps1
@@ -58,7 +58,7 @@ $ProgressPreference = "SilentlyContinue"
 Function DownloadUnpackers {
     $UrlUnrar64="https://www.rarlab.com/rar/unrarw64.exe"
     $UrlRar32="https://www.rarlab.com/rar/winrar-x32-701.exe"
-    $UrlRar64="https://www.rarlab.com/rar/winrar-x64-721.exe"
+    $UrlRar64="https://www.rarlab.com/rar/winrar-x64-722.exe"
     $Url7Z="https://github.com/ip7z/7zip/releases/download/26.01/7z2601-extra.7z"
 
     $ImageDir="$ToolsRoot\image"


### PR DESCRIPTION
## Description

Unpackers update:
- UnRAR 7.22 (Windows/macOS only) - support is unavailable on other platforms because RARLAB has not released the UnRAR 7.22 source code.

## Testing

by @phnzb:
- Windows 11 25H2 x64
- macOS Tahoe 26.5