### PR TITLE
Fix WebUI: NewsServers TypeError, overflow of labels and modal dialogs

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -793,7 +793,7 @@
 																<div class="controls">
 																	<div class="dist-speedtest__controls">
 																		<input type="text" id="SysInfo_DiskSpeedTestInput" class="editlarge" required>
-																		<button type="button" style="width: 115px;" class="btn btn-default" id="SysInfo_DiskSpeedTestBtn"></button>
+																		<button type="button" class="btn btn-default" id="SysInfo_DiskSpeedTestBtn"></button>
 																	</div>
 																	<p class="help-text-error" id="SysInfo_DiskSpeedTestErrorTxt"></p>
 																</div>

--- a/webui/style.css
+++ b/webui/style.css
@@ -1550,6 +1550,10 @@ textarea[readonly],
     margin-bottom: 15px;
 }
 
+.modal .form-horizontal .control-label {
+    word-wrap: break-word;
+}
+
 .form-horizontal .control-group-last {
     margin-bottom: 0;
 }
@@ -1590,11 +1594,6 @@ textarea[readonly],
 .input-medium.uneditable-input,
 .uneditable-mulitline-input {
     margin-bottom: -4px;
-}
-
-.modal-mini {
-    width: 420px;
-    margin-left: -210px;
 }
 
 .modal-small {

--- a/webui/system-info.js
+++ b/webui/system-info.js
@@ -452,7 +452,9 @@ var SystemInfo = (new function($)
 		renderAppVersion(Options.option('Version'));
 		renderTools(sysInfo['Tools']);
 		renderLibraries(sysInfo['Libraries']);
-		renderNewsServers(Status.getStatus()['NewsServers']);
+		if (Status.getStatus() && Status.getStatus()['NewsServers']) {
+			renderNewsServers(Status.getStatus()['NewsServers']);
+		}
 
 		scrollToTop();
 	}


### PR DESCRIPTION
## Description

- fixed NewsServers TypeError
- fixed overflow of labels and modal dialogs

## Testing

- Chrome
- Firefox