### PR TITLE
Fix: category path matching with spaces and CategorySource ignoring

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,12 +30,10 @@ nzbget-v26.2
     [#793](https://github.com/nzbgetcom/nzbget/pull/793)
     - Fixed macOS dark mode readable text and NZB file association
     [#795](https://github.com/nzbgetcom/nzbget/pull/795)
-    - Normalised category paths parsed from XML entity references
+    - Fixed RSS feed text fragmentation causing whitespace loss in element content
     [#796](https://github.com/nzbgetcom/nzbget/pull/796)
+    - Fixed WebUI RSS "Add" dialog ignoring item-level category when `CategorySource` is `NZBFile` or `Auto`
     [#827](https://github.com/nzbgetcom/nzbget/pull/827)
-      - Category paths (e.g. `Category &gt; Subcategory`) are now stored as
-        `Category>Subcategory` in both NZB files and RSS feeds when parsed from
-        entity references, resolving exact matching issues caused by XML parser chunking.
     - Prevented symlink attacks and TOCTOU races in daemon startup
     [#798](https://github.com/nzbgetcom/nzbget/pull/798)
     - Fixed new-version flag to only trigger on same update channel

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,8 +30,12 @@ nzbget-v26.2
     [#793](https://github.com/nzbgetcom/nzbget/pull/793)
     - Fixed macOS dark mode readable text and NZB file association
     [#795](https://github.com/nzbgetcom/nzbget/pull/795)
-    - Resolved text fragmentation issues
+    - Normalised category paths parsed from XML entity references
     [#796](https://github.com/nzbgetcom/nzbget/pull/796)
+    [#827](https://github.com/nzbgetcom/nzbget/pull/827)
+      - Category paths (e.g. `Category &gt; Subcategory`) are now stored as
+        `Category>Subcategory` in both NZB files and RSS feeds when parsed from
+        entity references, resolving exact matching issues caused by XML parser chunking.
     - Prevented symlink attacks and TOCTOU races in daemon startup
     [#798](https://github.com/nzbgetcom/nzbget/pull/798)
     - Fixed new-version flag to only trigger on same update channel

--- a/daemon/feed/FeedCoordinator.cpp
+++ b/daemon/feed/FeedCoordinator.cpp
@@ -458,7 +458,14 @@ void FeedCoordinator::FilterFeed(FeedInfo* feedInfo, FeedItemList* feedItems)
 		feedItemInfo.SetMatchRule(0);
 		feedItemInfo.SetPauseNzb(feedInfo->GetPauseNzb());
 		feedItemInfo.SetPriority(feedInfo->GetPriority());
-		feedItemInfo.SetAddCategory(feedInfo->GetCategory());
+		if (feedInfo->GetCategorySource() == FeedInfo::CategorySource::FeedFile)
+		{
+			feedItemInfo.SetAddCategory(feedInfo->GetCategory());
+		}
+		else
+		{
+			feedItemInfo.SetAddCategory("");
+		}
 		feedItemInfo.SetDupeScore(0);
 		feedItemInfo.SetDupeMode(dmScore);
 		feedItemInfo.SetFeedFilterHelper(&filterHelper);

--- a/daemon/feed/FeedFile.cpp
+++ b/daemon/feed/FeedFile.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2013-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -175,6 +175,7 @@ void FeedFile::Parse_StartElement(const char* name, const char **atts)
 	if (!name)
 		return;
 
+	m_currentElement = name;
 	ResetTagContent();
 
 	if (!strcmp("item", name))
@@ -304,6 +305,8 @@ void FeedFile::Parse_EndElement(const char* name)
 		}
 		ResetTagContent();
 	}
+
+	m_currentElement.clear();
 }
 
 void FeedFile::Parse_Content(std::string content)
@@ -331,7 +334,13 @@ void FeedFile::SAX_textHandler(FeedFile* file, const char* xmlstr, int len)
 	if (!xmlstr || len <= 0)
 		return;
 
-	file->Parse_Content(std::string(xmlstr, len));
+	std::string str(xmlstr, len);
+	if (file->m_currentElement == "category")
+	{
+		// TODO: Remove this category-specific trimming in the next major release
+		Util::Trim(str);
+	}
+	file->Parse_Content(std::move(str));
 }
 
 xmlEntityPtr FeedFile::SAX_getEntity(FeedFile* file, const xmlChar* name)

--- a/daemon/feed/FeedFile.cpp
+++ b/daemon/feed/FeedFile.cpp
@@ -337,7 +337,7 @@ void FeedFile::SAX_textHandler(FeedFile* file, const char* xmlstr, int len)
 	std::string str(xmlstr, len);
 	if (file->m_currentElement == "category")
 	{
-		// TODO: Remove this category-specific trimming in the next major release
+		// Do not break existing users' filters that rely on this normalization
 		Util::Trim(str);
 	}
 	file->Parse_Content(std::move(str));

--- a/daemon/feed/FeedFile.h
+++ b/daemon/feed/FeedFile.h
@@ -45,6 +45,7 @@ private:
 	FeedItemInfo* m_feedItemInfo;
 	std::string m_tagContent;
 	bool m_ignoreNextError;
+	std::string m_currentElement;
 
 	static void SAX_StartElement(FeedFile* file, const char *name, const char **atts);
 	static void SAX_EndElement(FeedFile* file, const char *name);

--- a/daemon/queue/NzbFile.cpp
+++ b/daemon/queue/NzbFile.cpp
@@ -491,7 +491,7 @@ void NzbFile::SAX_characters(NzbFile* file, const char * xmlstr, int len)
 	std::string str(xmlstr, len);
 	if (file->m_currentElement == "meta" && file->m_hasCategory)
 	{
-		// TODO: Remove this category-specific trimming in the next major release
+		// Do not break existing users' filters that rely on this normalization
 		Util::Trim(str);
 	}
 

--- a/daemon/queue/NzbFile.cpp
+++ b/daemon/queue/NzbFile.cpp
@@ -343,6 +343,7 @@ void NzbFile::Parse_StartElement(const char *name, const char **atts)
 {
 	BString<1024> tagAttrMessage("Malformed nzb-file, tag <%s> must have attributes", name);
 
+	m_currentElement = name;
 	m_tagContent.Clear();
 
 	if (!strcmp("file", name))
@@ -463,6 +464,8 @@ void NzbFile::Parse_EndElement(const char *name)
 	{
 		m_category = m_tagContent;
 	}
+
+	m_currentElement.clear();
 }
 
 void NzbFile::Parse_Content(const char *buf, int len)
@@ -482,43 +485,19 @@ void NzbFile::SAX_EndElement(NzbFile* file, const char *name)
 
 void NzbFile::SAX_characters(NzbFile* file, const char * xmlstr, int len)
 {
-	char* str = (char*)xmlstr;
+	if (len <= 0)
+		return;
 
-	// trim starting blanks
-	int off = 0;
-	for (int i = 0; i < len; i++)
+	std::string str(xmlstr, len);
+	if (file->m_currentElement == "meta" && file->m_hasCategory)
 	{
-		char ch = str[i];
-		if (ch == ' ' || ch == 10 || ch == 13 || ch == 9)
-		{
-			off++;
-		}
-		else
-		{
-			break;
-		}
+		// TODO: Remove this category-specific trimming in the next major release
+		Util::Trim(str);
 	}
 
-	int newlen = len - off;
-
-	// trim ending blanks
-	for (int i = len - 1; i >= off; i--)
+	if (!str.empty())
 	{
-		char ch = str[i];
-		if (ch == ' ' || ch == 10 || ch == 13 || ch == 9)
-		{
-			newlen--;
-		}
-		else
-		{
-			break;
-		}
-	}
-
-	if (newlen > 0)
-	{
-		// interpret tag content
-		file->Parse_Content(str + off, newlen);
+		file->Parse_Content(str.data(), str.length());
 	}
 }
 

--- a/daemon/queue/NzbFile.h
+++ b/daemon/queue/NzbFile.h
@@ -59,6 +59,7 @@ private:
 	bool m_ignoreNextError;
 	bool m_hasPassword = false;
 	bool m_hasCategory = false;
+	std::string m_currentElement;
 
 	static void SAX_StartElement(NzbFile* file, const char *name, const char **atts);
 	static void SAX_EndElement(NzbFile* file, const char *name);

--- a/tests/feed/FeedFile.cpp
+++ b/tests/feed/FeedFile.cpp
@@ -38,23 +38,56 @@ BOOST_AUTO_TEST_CASE(FeedFileTest)
 	BOOST_CHECK_EQUAL(file.Parse(), true);
 
 	std::unique_ptr<FeedItemList> items = file.DetachFeedItems();
-	FeedItemInfo& feedInfo = items.get()->back();
+	BOOST_REQUIRE_EQUAL(items->size(), 6u);
 
-	BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string("Movies > HD"));
-	BOOST_CHECK_EQUAL(feedInfo.GetTime(), 1701668883);
-	BOOST_CHECK_EQUAL(feedInfo.GetEpisode(), std::string("1"));
-	BOOST_CHECK_EQUAL(feedInfo.GetEpisodeNum(), 1);
-	BOOST_CHECK_EQUAL(feedInfo.GetSeason(), std::string("S03"));
-	BOOST_CHECK_EQUAL(feedInfo.GetSeasonNum(), 3);
-	BOOST_CHECK_EQUAL(feedInfo.GetTvmazeId(), 33877);
-	BOOST_CHECK_EQUAL(feedInfo.GetTvdbId(), 33877);
-	BOOST_CHECK_EQUAL(feedInfo.GetRageId(), 33877);
-	BOOST_CHECK_EQUAL(feedInfo.GetImdbId(), 42054);
-	BOOST_CHECK_EQUAL(feedInfo.GetUrl(), std::string("https://indexer.com/getnzb/nzb.nzb"));
-	BOOST_CHECK_EQUAL(feedInfo.GetDescription(), description);
-	BOOST_CHECK_EQUAL(feedInfo.GetFilename(), filename);
-	BOOST_CHECK_EQUAL(feedInfo.GetTitle(), filename);
-	BOOST_CHECK_EQUAL(feedInfo.GetSize(), 7445312955);
+	{
+		FeedItemInfo& feedInfo = items->at(0);
+		BOOST_CHECK_EQUAL(feedInfo.GetTitle(), filename);
+		BOOST_CHECK_EQUAL(feedInfo.GetFilename(), filename);
+		BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string("Movies>HD"));
+		BOOST_CHECK_EQUAL(feedInfo.GetTime(), 1701668883);
+		BOOST_CHECK_EQUAL(feedInfo.GetEpisode(), std::string("1"));
+		BOOST_CHECK_EQUAL(feedInfo.GetEpisodeNum(), 1);
+		BOOST_CHECK_EQUAL(feedInfo.GetSeason(), std::string("S03"));
+		BOOST_CHECK_EQUAL(feedInfo.GetSeasonNum(), 3);
+		BOOST_CHECK_EQUAL(feedInfo.GetTvmazeId(), 33877);
+		BOOST_CHECK_EQUAL(feedInfo.GetTvdbId(), 33877);
+		BOOST_CHECK_EQUAL(feedInfo.GetRageId(), 33877);
+		BOOST_CHECK_EQUAL(feedInfo.GetImdbId(), 42054);
+		BOOST_CHECK_EQUAL(feedInfo.GetUrl(), std::string("https://indexer.com/getnzb/nzb.nzb"));
+		BOOST_CHECK_EQUAL(feedInfo.GetDescription(), description);
+		BOOST_CHECK_EQUAL(feedInfo.GetSize(), 7445312955);
+	}
+
+	{
+		FeedItemInfo& feedInfo = items->at(1);
+		BOOST_CHECK_EQUAL(feedInfo.GetTitle(), std::string("Deep.Path.Item"));
+		BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string("Movies>HD>4K"));
+	}
+
+	{
+		FeedItemInfo& feedInfo = items->at(2);
+		BOOST_CHECK_EQUAL(feedInfo.GetTitle(), std::string("Spaced.Category.Item"));
+		BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string("Movies>HD"));
+	}
+
+	{
+		FeedItemInfo& feedInfo = items->at(3);
+		BOOST_CHECK_EQUAL(feedInfo.GetTitle(), std::string("Empty.Category.Item"));
+		BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string(""));
+	}
+
+	{
+		FeedItemInfo& feedInfo = items->at(4);
+		BOOST_CHECK_EQUAL(feedInfo.GetTitle(), std::string("Preserved.Spaces.Item"));
+		BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string("My Movies"));
+	}
+
+	{
+		FeedItemInfo& feedInfo = items->at(5);
+		BOOST_CHECK_EQUAL(feedInfo.GetTitle(), std::string("Literal.Gt.Item"));
+		BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string("Movies > HD"));
+	}
 
 	xmlCleanupParser();
 }

--- a/tests/queue/NzbFile.cpp
+++ b/tests/queue/NzbFile.cpp
@@ -65,6 +65,8 @@ void TestNzb(std::string testFilename, std::string expectedCategory)
 
 	while (fgets(buffer, sizeof(buffer), infofile) && *buffer == '#') ;
 
+	Util::TrimRight(buffer);
+
 	if(strcmp(lastBuffer, buffer) == 0)
 	{
 		BOOST_CHECK(nzbFile.GetPassword().empty());
@@ -86,8 +88,10 @@ BOOST_AUTO_TEST_CASE(NZBParserTest)
 
 	TestNzb("dotless", "Movies");
 	TestNzb("plain", "TV>4K");
+	TestNzb("literal_gt", "TV > 4K");
 	TestNzb("passwd{{thisisthepassword}}", "");
 	TestNzb("passwdMeta", "");
+	TestNzb("passwdEntity", "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/testdata/feed/feed.xml
+++ b/tests/testdata/feed/feed.xml
@@ -39,5 +39,35 @@
    <nZEDb:attr name="usenetdate" value="Mon, 04 Dec 2023 05:46:59 +0000"/>
    <nZEDb:attr name="group" value="alt.binaries.coolkidweb"/>
   </item>
+  <item>
+   <title>Deep.Path.Item</title>
+   <link>https://indexer.com/getnzb/deep.nzb</link>
+   <pubDate>Mon, 04 Dec 2023 05:48:03 +0000</pubDate>
+   <category>Movies &gt; HD &gt; 4K</category>
+  </item>
+  <item>
+   <title>Spaced.Category.Item</title>
+   <link>https://indexer.com/getnzb/spaced.nzb</link>
+   <pubDate>Mon, 04 Dec 2023 05:48:03 +0000</pubDate>
+   <category>  Movies  &gt;  HD  </category>
+  </item>
+  <item>
+   <title>Empty.Category.Item</title>
+   <link>https://indexer.com/getnzb/empty.nzb</link>
+   <pubDate>Mon, 04 Dec 2023 05:48:03 +0000</pubDate>
+   <category></category>
+  </item>
+   <item>
+    <title>Preserved.Spaces.Item</title>
+    <link>https://indexer.com/getnzb/preserved.nzb</link>
+    <pubDate>Mon, 04 Dec 2023 05:48:03 +0000</pubDate>
+    <category>My Movies</category>
+   </item>
+   <item>
+    <title>Literal.Gt.Item</title>
+    <link>https://indexer.com/getnzb/literal_gt.nzb</link>
+    <pubDate>Mon, 04 Dec 2023 05:48:03 +0000</pubDate>
+    <category>Movies > HD</category>
+   </item>
  </channel>
 </rss>

--- a/tests/testdata/nzbfile/literal_gt.nzb
+++ b/tests/testdata/nzbfile/literal_gt.nzb
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.0//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.0.dtd">
+<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+<head>
+<meta type="category">TV > 4K</meta>
+</head>
+<file poster="spitch@ratingshell.com (Dless)" date="1335508618" subject="&quot;ubuntu-12.04-desktop-i386.nfo&quot; yEnc (1/1)">
+<groups>
+<group>alt.binaries.boneless</group>
+</groups>
+<segments>
+<segment bytes="830" number="1">4f9a3e8a$0$14349$c3e8da3$33a0879d@news.astraweb.com</segment>
+</segments>
+</file>
+<file poster="spitch@ratingshell.com (Dless)" date="1335500602" subject="&quot;ubuntu-12.04-desktop-i386.par2&quot; yEnc (1/1)">
+<groups>
+<group>alt.binaries.boneless</group>
+</groups>
+<segments>
+<segment bytes="28209" number="1">4f9a1f3a$0$26527$c3e8da3$e3f2c276@news.astraweb.com</segment>
+</segments>
+</file>
+<file poster="spitch@ratingshell.com (Dless)" date="1335500615" subject="&quot;ubuntu-12.04-desktop-i386.r00&quot; yEnc (1/59)">
+<groups>
+<group>alt.binaries.boneless</group>
+</groups>
+<segments>
+<segment bytes="925855" number="1">4f9a1f3a$0$23145$c3e8da3$40cb80c2@news.astraweb.com</segment>
+</segments>
+</file>
+</nzb>

--- a/tests/testdata/nzbfile/literal_gt.txt
+++ b/tests/testdata/nzbfile/literal_gt.txt
@@ -1,0 +1,6 @@
+# number of files
+3
+# file names (one line per file)
+ubuntu-12.04-desktop-i386.nfo
+ubuntu-12.04-desktop-i386.par2
+ubuntu-12.04-desktop-i386.r00

--- a/tests/testdata/nzbfile/passwdEntity.nzb
+++ b/tests/testdata/nzbfile/passwdEntity.nzb
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.0//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.0.dtd">
+<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+<head>
+<meta type="password">!d#-&amp;W2;</meta>
+</head>
+<file poster="spitch@ratingshell.com (Dless)" date="1335508618" subject="&quot;ubuntu-12.04-desktop-i386.nfo&quot; yEnc (1/1)">
+<groups>
+<group>alt.binaries.boneless</group>
+</groups>
+<segments>
+<segment bytes="830" number="1">4f9a3e8a$0$14349$c3e8da3$33a0879d@news.astraweb.com</segment>
+</segments>
+</file>
+<file poster="spitch@ratingshell.com (Dless)" date="1335500602" subject="&quot;ubuntu-12.04-desktop-i386.par2&quot; yEnc (1/1)">
+<groups>
+<group>alt.binaries.boneless</group>
+</groups>
+<segments>
+<segment bytes="28209" number="1">4f9a1f3a$0$26527$c3e8da3$e3f2c276@news.astraweb.com</segment>
+</segments>
+</file>
+<file poster="spitch@ratingshell.com (Dless)" date="1335500615" subject="&quot;ubuntu-12.04-desktop-i386.r00&quot; yEnc (1/59)">
+<groups>
+<group>alt.binaries.boneless</group>
+</groups>
+<segments>
+<segment bytes="925855" number="1">4f9a1f3a$0$23145$c3e8da3$40cb80c2@news.astraweb.com</segment>
+</segments>
+</file>
+</nzb>

--- a/tests/testdata/nzbfile/passwdEntity.txt
+++ b/tests/testdata/nzbfile/passwdEntity.txt
@@ -1,0 +1,8 @@
+# number of files
+3
+# file names (one line per file)
+ubuntu-12.04-desktop-i386.nfo
+ubuntu-12.04-desktop-i386.par2
+ubuntu-12.04-desktop-i386.r00
+# unpack password
+!d#-&W2;


### PR DESCRIPTION
## Description

- Fixed RSS feed text fragmentation causing whitespace loss in category element content (other elements unaffected; existing user filters preserved)
- Fixed WebUI RSS "Add" dialog ignoring `CategorySource` setting


## Testing 
- macOS Tahoe
- Windows 10/11
- Docker