### PR TITLE
Fix: guard addEventListener and Status.status accesses

### DIFF
--- a/webui/config.js
+++ b/webui/config.js
@@ -2867,7 +2867,11 @@ var ConfigBackupRestore = (new function($)
 
 	this.init = function(options)
 	{
-		$('#Config_RestoreInput')[0].addEventListener('change', restoreSelectHandler, false);
+		var restoreInput = $('#Config_RestoreInput')[0];
+		if (restoreInput)
+		{
+			restoreInput.addEventListener('change', restoreSelectHandler, false);
+		}
 	}
 
 	/*** BACKUP ********************************************************************/

--- a/webui/downloads.js
+++ b/webui/downloads.js
@@ -968,6 +968,10 @@ var DownloadsUI = (new function($)
 
 		if (minLevel === null)
 		{
+			if (!Status.status || !Status.status.NewsServers)
+			{
+				return 0;
+			}
 			for (var i=0; i < Status.status.NewsServers.length; i++)
 			{
 				var server = Status.status.NewsServers[i];

--- a/webui/edit.js
+++ b/webui/edit.js
@@ -815,6 +815,13 @@ var EditUI = (new function($)
 	this.fillServStats = function(table, editItem)
 	{
 		var data = [];
+
+		if (!Status.status || !Status.status.NewsServers)
+		{
+			table.fasttable('update', data);
+			return;
+		}
+
 		for (var i=0; i < Status.status.NewsServers.length; i++)
 		{
 			var server = Status.status.NewsServers[i];
@@ -1271,7 +1278,7 @@ var DownloadsMultiDialog = (new function($)
 		var size = Util.formatSizeMB(FileSizeMB, FileSizeLo);
 		var remaining = Util.formatSizeMB(RemainingSizeMB-PausedSizeMB, RemainingSizeLo-PausedSizeLo);
 		var unpausedSize = Util.formatSizeMB(PausedSizeMB, PausedSizeLo);
-		var estimated = paused ? '' : (Status.status.DownloadRate > 0 ? Util.formatTimeHMS((RemainingSizeMB-PausedSizeMB)*1024/(Status.status.DownloadRate/1024)) : '');
+		var estimated = paused ? '' : (Status.status && Status.status.DownloadRate > 0 ? Util.formatTimeHMS((RemainingSizeMB-PausedSizeMB)*1024/(Status.status.DownloadRate/1024)) : '');
 
 		var table = '';
 		table += '<tr><td>Total</td><td class="text-right">' + size + '</td></tr>';

--- a/webui/history.js
+++ b/webui/history.js
@@ -167,6 +167,11 @@ var History = (new function($)
 
 	this.redraw = function(force)
 	{
+		if (!Status.status)
+		{
+			return;
+		}
+
 		if (cached && !force)
 		{
 			return;

--- a/webui/index.html
+++ b/webui/index.html
@@ -793,7 +793,7 @@
 																<div class="controls">
 																	<div class="dist-speedtest__controls">
 																		<input type="text" id="SysInfo_DiskSpeedTestInput" class="editlarge" required>
-																		<button type="button" class="btn btn-default" id="SysInfo_DiskSpeedTestBtn"></button>
+																		<button type="button" style="width: 115px;" class="btn btn-default" id="SysInfo_DiskSpeedTestBtn"></button>
 																	</div>
 																	<p class="help-text-error" id="SysInfo_DiskSpeedTestErrorTxt"></p>
 																</div>

--- a/webui/status.js
+++ b/webui/status.js
@@ -694,7 +694,7 @@ var StatDialog = (new function($)
 		$('#StatDialog_Title').attr('data-i18n', 'title_statistics_and_status');
 		I18n.translatePage($('#StatDialog_Title').parent());
 		Util.show('#StatDialog_ArticleCache_Row', Options.option('ArticleCache') !== '0');
-		Util.show('#StatDialog_QueueScripts_Row', Status.status.QueueScriptCount > 0);
+		Util.show('#StatDialog_QueueScripts_Row', Status.status && Status.status.QueueScriptCount > 0);
 		$StatDialog.removeClass('modal-large').addClass('modal-mini');
 
 		if (Options.option('QuotaStartDay') != '1')
@@ -1222,6 +1222,12 @@ var StatDialog = (new function($)
 		var insertPos = $('#StatDialog_ServerMenuDivider', menu);
 
 		$('.volume-server', menu).remove();
+
+		if (!Status.status || !Status.status.NewsServers)
+		{
+			return;
+		}
+
 		for (var i=0; i < Status.status.NewsServers.length; i++)
 		{
 			var server = Status.status.NewsServers[i];
@@ -1246,7 +1252,8 @@ var StatDialog = (new function($)
 		if (curServer === 0) {
 			$('#StatDialog_ServerCap').attr('data-i18n', 'stat_all_news_servers').css('text-transform', 'capitalize');
 		} else {
-			$('#StatDialog_ServerCap').text(Status.serverName(Status.status.NewsServers[curServer-1])).removeAttr('data-i18n').css('text-transform', '');
+			var serverName = Status.status.NewsServers[curServer-1] ? Status.serverName(Status.status.NewsServers[curServer-1]) : '';
+			$('#StatDialog_ServerCap').text(serverName).removeAttr('data-i18n').css('text-transform', '');
 		}
 		I18n.translatePage($('#StatDialog_ServerCap').parent());
 
@@ -1425,6 +1432,9 @@ var StatDialog = (new function($)
 
 	function updateCounters()
 	{
+		if (!Status.status) {
+			return;
+		}
 		$StatDialog_TodaySize.html(Util.formatSizeMB(Status.status.DaySizeMB, Status.status.DaySizeLo));
 		$StatDialog_MonthSize.html(Util.formatSizeMB(Status.status.MonthSizeMB, Status.status.MonthSizeLo));
 		if (!servervolumes || !servervolumes[curServer]) {
@@ -1579,6 +1589,9 @@ var LimitDialog = (new function($)
 
 	function showModal()
 	{
+		if (!Status.status) {
+			return;
+		}
 		var rate = Util.round0(Status.status.DownloadLimit / 1024);
 		$LimitDialog_SpeedInput.val(rate > 0 ? rate : '');
 		updateTable();
@@ -1588,6 +1601,9 @@ var LimitDialog = (new function($)
 	function updateTable()
 	{
 		var data = [];
+		if (!Status.status || !Status.status.NewsServers) {
+			return;
+		}
 		for (var i=0; i < Status.status.NewsServers.length; i++)
 		{
 			var server = Status.status.NewsServers[i];
@@ -1608,6 +1624,9 @@ var LimitDialog = (new function($)
 
 	function save(e)
 	{
+		if (!Status.status || !Status.status.NewsServers) {
+			return;
+		}
 		var val = $LimitDialog_SpeedInput.val();
 		var rate = 0;
 		if (val == '')
@@ -1641,6 +1660,9 @@ var LimitDialog = (new function($)
 
 	function saveLimit(rate, servers)
 	{
+		if (!Status.status) {
+			return;
+		}
 		function saveServers()
 		{
 			if (servers.length > 0)
@@ -1686,6 +1708,9 @@ var LimitDialog = (new function($)
 
 	function toggleLimit()
 	{
+		if (!Status.status || !Status.status.NewsServers) {
+			return;
+		}
 		var limited = Status.status.DownloadLimit > 0;
 		for (var i=0; i < Status.status.NewsServers.length; i++)
 		{

--- a/webui/upload.js
+++ b/webui/upload.js
@@ -48,16 +48,22 @@ var Upload = (new function($)
 	this.init = function()
 	{
 		var target = $('#DownloadsTab')[0];
-		target.addEventListener('dragenter', bodyDragOver);
-		target.addEventListener('dragover', bodyDragOver);
-		target.addEventListener('dragleave', bodyDragLeave);
-		target.addEventListener('drop', bodyDrop, false);
+		if (target)
+		{
+			target.addEventListener('dragenter', bodyDragOver);
+			target.addEventListener('dragover', bodyDragOver);
+			target.addEventListener('dragleave', bodyDragLeave);
+			target.addEventListener('drop', bodyDrop, false);
+		}
 
 		target = $('#AddDialog_Target')[0];
-		target.addEventListener('dragenter', dialogDragOver);
-		target.addEventListener('dragover', dialogDragOver);
-		target.addEventListener('dragleave', dialogDragLeave);
-		target.addEventListener('drop', dialogDrop, false);
+		if (target)
+		{
+			target.addEventListener('dragenter', dialogDragOver);
+			target.addEventListener('dragover', dialogDragOver);
+			target.addEventListener('dragleave', dialogDragLeave);
+			target.addEventListener('drop', dialogDrop, false);
+		}
 
 		$AddDialog = $('#AddDialog');
 
@@ -94,7 +100,11 @@ var Upload = (new function($)
 
 		$('#AddDialog_Select').click(selectFiles);
 		$('#AddDialog_Submit').click(submit);
-		$('#AddDialog_Input')[0].addEventListener("change", fileSelectHandler, false);
+		var inp = $('#AddDialog_Input')[0];
+		if (inp)
+		{
+			inp.addEventListener("change", fileSelectHandler, false);
+		}
 		$('#AddDialog_Scan').click(scan);
 		
 		AddParamDialog.init();


### PR DESCRIPTION
## Description

Protect against two failure modes:
- addEventListener on undefined DOM elements when WebDir serves stale files after an incomplete update (upload.js, config.js)
- Status.status.TypeError race condition when status RPC arrives after page render (downloads.js, edit.js, history.js, status.js)

## Testing

- Chrome
- Firefox