### PR TITLE
Fix: JSON-RPC param reader

### DIFF
--- a/daemon/remote/XmlRpc.cpp
+++ b/daemon/remote/XmlRpc.cpp
@@ -48,13 +48,14 @@
 extern void ExitProc();
 extern void Reload();
 
-class SafeXmlCommand: public XmlCommand
+class SafeXmlCommand : public XmlCommand
 {
 public:
+	~SafeXmlCommand() override;
 	bool IsSafeMethod() override { return true; }
 };
 
-class ErrorXmlCommand: public XmlCommand
+class ErrorXmlCommand final : public XmlCommand
 {
 public:
 	ErrorXmlCommand(int errCode, const char* errText) :
@@ -67,7 +68,7 @@ private:
 	const char* m_errText;
 };
 
-class PauseUnpauseXmlCommand: public XmlCommand
+class PauseUnpauseXmlCommand final : public XmlCommand
 {
 public:
 	enum EPauseAction
@@ -86,55 +87,55 @@ private:
 	EPauseAction m_pauseAction;
 };
 
-class ScheduleResumeXmlCommand: public XmlCommand
+class ScheduleResumeXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ShutdownXmlCommand: public XmlCommand
+class ShutdownXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ReloadXmlCommand: public XmlCommand
+class ReloadXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class VersionXmlCommand: public SafeXmlCommand
+class VersionXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class DumpDebugXmlCommand: public SafeXmlCommand
+class DumpDebugXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class SetDownloadRateXmlCommand: public XmlCommand
+class SetDownloadRateXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class StatusXmlCommand: public SafeXmlCommand
+class StatusXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class SysInfoXmlCommand: public SafeXmlCommand
+class SysInfoXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class SystemHealthXmlCommand : public SafeXmlCommand
+class SystemHealthXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
@@ -143,6 +144,7 @@ public:
 class LogXmlCommand: public SafeXmlCommand
 {
 public:
+	~LogXmlCommand() override;
 	void Execute() override;
 
 protected:
@@ -153,18 +155,21 @@ protected:
 
 class NzbInfoXmlCommand: public SafeXmlCommand
 {
+public:
+	~NzbInfoXmlCommand() override;
+
 protected:
 	void AppendNzbInfoFields(NzbInfo* nzbInfo);
 	void AppendPostInfoFields(PostInfo* postInfo, int logEntries, bool postQueue);
 };
 
-class ListFilesXmlCommand: public SafeXmlCommand
+class ListFilesXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ListGroupsXmlCommand: public NzbInfoXmlCommand
+class ListGroupsXmlCommand final : public NzbInfoXmlCommand
 {
 public:
 	void Execute() override;
@@ -172,43 +177,43 @@ private:
 	const char* DetectStatus(NzbInfo* nzbInfo);
 };
 
-class EditQueueXmlCommand: public XmlCommand
+class EditQueueXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class DownloadXmlCommand: public XmlCommand
+class DownloadXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class PostQueueXmlCommand: public NzbInfoXmlCommand
+class PostQueueXmlCommand final : public NzbInfoXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class WriteLogXmlCommand: public XmlCommand
+class WriteLogXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ClearLogXmlCommand: public XmlCommand
+class ClearLogXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ScanXmlCommand: public XmlCommand
+class ScanXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class HistoryXmlCommand: public NzbInfoXmlCommand
+class HistoryXmlCommand final : public NzbInfoXmlCommand
 {
 public:
 	void Execute() override;
@@ -216,67 +221,67 @@ private:
 	const char* DetectStatus(HistoryInfo* historyInfo);
 };
 
-class UrlQueueXmlCommand: public SafeXmlCommand
+class UrlQueueXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ConfigXmlCommand: public SafeXmlCommand
+class ConfigXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class LoadConfigXmlCommand: public SafeXmlCommand
+class LoadConfigXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class LoadExtensionsXmlCommand : public SafeXmlCommand
+class LoadExtensionsXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class DownloadExtensionXmlCommand : public SafeXmlCommand
+class DownloadExtensionXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class UpdateExtensionXmlCommand : public SafeXmlCommand
+class UpdateExtensionXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class DeleteExtensionXmlCommand : public SafeXmlCommand
+class DeleteExtensionXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class TestExtensionXmlCommand : public SafeXmlCommand
+class TestExtensionXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class SaveConfigXmlCommand: public XmlCommand
+class SaveConfigXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ConfigTemplatesXmlCommand: public SafeXmlCommand
+class ConfigTemplatesXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ViewFeedXmlCommand: public XmlCommand
+class ViewFeedXmlCommand final : public XmlCommand
 {
 public:
 	ViewFeedXmlCommand(bool preview) : m_preview(preview) {}
@@ -285,59 +290,59 @@ private:
 	bool m_preview;
 };
 
-class FetchFeedXmlCommand: public XmlCommand
+class FetchFeedXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class EditServerXmlCommand: public XmlCommand
+class EditServerXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ReadUrlXmlCommand: public SafeXmlCommand
+class ReadUrlXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class CheckUpdatesXmlCommand: public XmlCommand
+class CheckUpdatesXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class StartUpdateXmlCommand: public XmlCommand
+class StartUpdateXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class LogUpdateXmlCommand: public LogXmlCommand
+class LogUpdateXmlCommand final : public LogXmlCommand
 {
 protected:
-	virtual GuardedMessageList GuardMessages();
+	GuardedMessageList GuardMessages() override;
 };
 
-class ServerVolumesXmlCommand: public SafeXmlCommand
+class ServerVolumesXmlCommand final : public SafeXmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class ResetServerVolumeXmlCommand: public XmlCommand
+class ResetServerVolumeXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class LoadLogXmlCommand: public LogXmlCommand
+class LoadLogXmlCommand final : public LogXmlCommand
 {
 protected:
 	void Execute() override;
-	virtual GuardedMessageList GuardMessages();
+	GuardedMessageList GuardMessages() override;
 private:
 	int m_nzbId;
 	NzbInfo* m_nzbInfo;
@@ -345,7 +350,7 @@ private:
 	std::unique_ptr<GuardedDownloadQueue> m_downloadQueue;
 };
 
-class TestServerXmlCommand : public XmlCommand
+class TestServerXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
@@ -365,7 +370,7 @@ public:
 private:
 	CString m_errText;
 
-	class TestConnection : public NntpConnection
+	class TestConnection final : public NntpConnection
 	{
 	public:
 		TestConnection(NewsServer* newsServer, TestServerXmlCommand* owner) :
@@ -373,7 +378,7 @@ private:
 		}
 	protected:
 		TestServerXmlCommand* m_owner;
-		virtual void PrintError(const char* errMsg) { m_owner->PrintError(errMsg); }
+		void PrintError(const char* errMsg) override { m_owner->PrintError(errMsg); }
 	};
 
 	void PrintError(const char* errMsg);
@@ -411,7 +416,7 @@ private:
 	}
 };
 
-class TestServerSpeedXmlCommand: public SafeXmlCommand
+class TestServerSpeedXmlCommand final: public SafeXmlCommand
 {
 public:
 	void Execute() override;
@@ -484,13 +489,13 @@ public:
 	}
 };
 
-class StartScriptXmlCommand : public XmlCommand
+class StartScriptXmlCommand final : public XmlCommand
 {
 public:
 	void Execute() override;
 };
 
-class LogScriptXmlCommand : public LogXmlCommand
+class LogScriptXmlCommand final : public LogXmlCommand
 {
 protected:
 	virtual GuardedMessageList GuardMessages();
@@ -973,9 +978,17 @@ std::unique_ptr<XmlCommand> XmlRpcProcessor::CreateCommand(const char* methodNam
 // Base command
 
 XmlCommand::XmlCommand()
+	: m_protocol(XmlRpcProcessor::rpUndefined)
+	, m_httpMethod(XmlRpcProcessor::hmPost)
+	, m_userAccess(XmlRpcProcessor::uaControl)
 {
 	m_response.Reserve(1024 * 10 - 1);
 }
+
+XmlCommand::~XmlCommand() = default;
+SafeXmlCommand::~SafeXmlCommand() = default;
+LogXmlCommand::~LogXmlCommand() = default;
+NzbInfoXmlCommand::~NzbInfoXmlCommand() = default;
 
 bool XmlCommand::IsJson()
 {
@@ -1089,6 +1102,12 @@ char* XmlCommand::XmlNextValue(char* xml, const char* tag, int* valueLength)
 	return nullptr;
 }
 
+int XmlCommand::JsonStep(const char* param, int len)
+{
+	char nextChar = *(param + len);
+	return (nextChar == ']' || nextChar == '\0') ? 0 : 1;
+}
+
 bool XmlCommand::NextParamAsInt(int* value)
 {
 	if (m_httpMethod == XmlRpcProcessor::hmGet)
@@ -1115,7 +1134,7 @@ bool XmlCommand::NextParamAsInt(int* value)
 			return false;
 		}
 		*value = atoi(param);
-		m_requestPtr = param + len + 1;
+		m_requestPtr = param + len + JsonStep(param, len);
 		return true;
 	}
 	else
@@ -1179,13 +1198,13 @@ bool XmlCommand::NextParamAsBool(bool* value)
 		if (len == 4 && !strncmp(param, "true", 4))
 		{
 			*value = true;
-			m_requestPtr = param + len + 1;
+			m_requestPtr = param + len + JsonStep(param, len);
 			return true;
 		}
 		else if (len == 5 && !strncmp(param, "false", 5))
 		{
 			*value = false;
-			m_requestPtr = param + len + 1;
+			m_requestPtr = param + len + JsonStep(param, len);
 			return true;
 		}
 		else
@@ -1240,9 +1259,9 @@ bool XmlCommand::NextParamAsStr(char** value)
 		{
 			return false;
 		}
+		m_requestPtr = param + len + JsonStep(param, len);
 		param++; // skip first '"'
 		param[len - 2] = '\0'; // skip last '"'
-		m_requestPtr = param + len;
 		*value = param;
 		return true;
 	}

--- a/daemon/remote/XmlRpc.h
+++ b/daemon/remote/XmlRpc.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2007-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2023-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -59,13 +60,13 @@ public:
 	const char* GetResponse() { return m_response; }
 	const char* GetContentType() { return m_contentType; }
 	static bool IsRpcRequest(const char* url);
-	bool IsSafeMethod() { return m_safeMethod; };
+	bool IsSafeMethod() { return m_safeMethod; }
 
 private:
 	char* m_request = nullptr;
 	const char* m_contentType = nullptr;
-	ERpcProtocol m_protocol = rpUndefined;
-	EHttpMethod m_httpMethod = hmPost;
+	ERpcProtocol m_protocol;
+	EHttpMethod m_httpMethod;
 	EUserAccess m_userAccess;
 	CString m_url;
 	StringBuilder m_response;
@@ -82,7 +83,7 @@ class XmlCommand
 {
 public:
 	XmlCommand();
-	virtual ~XmlCommand() {}
+	virtual ~XmlCommand();
 	virtual void Execute() = 0;
 	void PrepareParams();
 	void SetRequest(char* request) { m_request = request; m_requestPtr = m_request; }
@@ -119,6 +120,19 @@ protected:
 	const char* BoolToStr(bool value);
 	CString EncodeStr(const char* str);
 	void DecodeStr(char* str);
+
+	/**
+	 * @brief Determines the cursor step size after parsing a JSON value.
+	 *
+	 * Stops at the closing bracket ']' or end of string, but advances past
+	 * other delimiters like ',' or '}' to prepare for the next read.
+	 *
+	 * @param param  Pointer to the start of the parsed JSON value.
+	 * @param len    Length of the parsed JSON value.
+	 *
+	 * @return 0 if the next character is ']' or '\0', 1 otherwise.
+	 */
+	int JsonStep(const char* param, int len);
 };
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ include(nntp/nntp.cmake)
 include(system/system.cmake)
 include(postprocess/postprocess.cmake)
 include(systemhealth/systemhealth.cmake)
+include(remote/remote.cmake)
 
 add_executable(${TESTS_TARGET} ${TESTS_SRC})
 if(EXTERNAL_DEPS)
@@ -39,3 +40,4 @@ add_test(NAME NNTPTest         COMMAND ${TESTS_TARGET} --run_test=NNTPTest --log
 add_test(NAME SystemTest       COMMAND ${TESTS_TARGET} --run_test=SystemTest --log_level=message)
 add_test(NAME PostprocessTest  COMMAND ${TESTS_TARGET} --run_test=PostprocessTest --log_level=message)
 add_test(NAME SystemHealthTest COMMAND ${TESTS_TARGET} --run_test=SystemHealthTest --log_level=message)
+add_test(NAME RemoteTest       COMMAND ${TESTS_TARGET} --run_test=RemoteTest --log_level=message)

--- a/tests/remote/XmlRpc.cpp
+++ b/tests/remote/XmlRpc.cpp
@@ -1,0 +1,293 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+#include "XmlRpc.h"
+
+BOOST_AUTO_TEST_SUITE(RemoteTest)
+
+class MockXmlCommand : public XmlCommand
+{
+public:
+	void Execute() override {}
+	bool TestNextParamAsStr(char** value) { return NextParamAsStr(value); }
+};
+
+BOOST_AUTO_TEST_CASE(TestSaveConfig)
+{
+	std::string jsonInput = R"({
+	"method":"saveconfig",
+	"params":[[
+		{"Name":"OptionName1","Value":"OptionValue1"},
+		{"Name":"OptionName2","Value":"OptionValue2"}
+	]],
+	"id":1})";
+
+	MockXmlCommand cmd;
+	cmd.SetRequest(&jsonInput[0]);
+	cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+	cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+	cmd.PrepareParams();
+
+	char* dummy = nullptr;
+	char* name = nullptr;
+	char* value = nullptr;
+
+	BOOST_CHECK(cmd.TestNextParamAsStr(&dummy));
+	BOOST_CHECK(cmd.TestNextParamAsStr(&name));
+	BOOST_CHECK(cmd.TestNextParamAsStr(&dummy));
+	BOOST_CHECK(cmd.TestNextParamAsStr(&value));
+
+	BOOST_CHECK(cmd.TestNextParamAsStr(&dummy));
+	BOOST_CHECK(cmd.TestNextParamAsStr(&name));
+	BOOST_CHECK(cmd.TestNextParamAsStr(&dummy));
+	BOOST_CHECK(cmd.TestNextParamAsStr(&value));
+}
+
+class MockXmlCommandAll final : public XmlCommand
+{
+public:
+	void Execute() override {}
+	bool TestNextParamAsInt(int* value)   { return NextParamAsInt(value); }
+	bool TestNextParamAsBool(bool* value) { return NextParamAsBool(value); }
+	bool TestNextParamAsStr(char** value) { return NextParamAsStr(value); }
+};
+
+BOOST_AUTO_TEST_CASE(TestNextParamAsTypes)
+{
+	{
+		std::string jsonInput = R"({"params":[123,456]})";
+		MockXmlCommandAll cmd;
+		cmd.SetRequest(&jsonInput[0]);
+		cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+		cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+		cmd.PrepareParams();
+
+		int val1 = 0, val2 = 0;
+		BOOST_CHECK(cmd.TestNextParamAsInt(&val1));
+		BOOST_CHECK_EQUAL(val1, 123);
+		BOOST_CHECK(cmd.TestNextParamAsInt(&val2));
+		BOOST_CHECK_EQUAL(val2, 456);
+		BOOST_CHECK(!cmd.TestNextParamAsInt(&val1));
+	}
+
+	{
+		std::string jsonInput = R"({"params":[true,false]})";
+		MockXmlCommandAll cmd;
+		cmd.SetRequest(&jsonInput[0]);
+		cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+		cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+		cmd.PrepareParams();
+
+		bool val1 = false, val2 = true;
+		BOOST_CHECK(cmd.TestNextParamAsBool(&val1));
+		BOOST_CHECK_EQUAL(val1, true);
+		BOOST_CHECK(cmd.TestNextParamAsBool(&val2));
+		BOOST_CHECK_EQUAL(val2, false);
+		BOOST_CHECK(!cmd.TestNextParamAsBool(&val1));
+	}
+
+	{
+		std::string jsonInput = R"({"params":["abc","def"]})";
+		MockXmlCommandAll cmd;
+		cmd.SetRequest(&jsonInput[0]);
+		cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+		cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+		cmd.PrepareParams();
+
+		char* val1 = nullptr;
+		char* val2 = nullptr;
+		BOOST_CHECK(cmd.TestNextParamAsStr(&val1));
+		BOOST_CHECK_EQUAL(std::string(val1), "abc");
+		BOOST_CHECK(cmd.TestNextParamAsStr(&val2));
+		BOOST_CHECK_EQUAL(std::string(val2), "def");
+		BOOST_CHECK(!cmd.TestNextParamAsStr(&val1));
+	}
+}
+
+BOOST_AUTO_TEST_CASE(TestConfigCommandsParsing)
+{
+	{
+		std::string jsonInput = R"({"params":[true]})";
+		MockXmlCommandAll cmd;
+		cmd.SetRequest(&jsonInput[0]);
+		cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+		cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+		cmd.PrepareParams();
+
+		bool loadFromDisk = false;
+		BOOST_CHECK(cmd.TestNextParamAsBool(&loadFromDisk));
+		BOOST_CHECK_EQUAL(loadFromDisk, true);
+	}
+
+	{
+		std::string jsonInput = R"({"params":[]})";
+		MockXmlCommandAll cmd;
+		cmd.SetRequest(&jsonInput[0]);
+		cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+		cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+		cmd.PrepareParams();
+
+		bool loadFromDisk = false;
+		BOOST_CHECK(!cmd.TestNextParamAsBool(&loadFromDisk));
+		BOOST_CHECK_EQUAL(loadFromDisk, false);
+	}
+}
+
+BOOST_AUTO_TEST_CASE(TestAppendCommand)
+{
+	std::string jsonInput = R"({"method":"append","params":["test.nzb","PD94bWw...","",0,false,false,"",0,"FORCE"],"id":1})";
+
+	MockXmlCommandAll cmd;
+	cmd.SetRequest(&jsonInput[0]);
+	cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+	cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+	cmd.PrepareParams();
+
+	char* strVal = nullptr;
+	int intVal = 0;
+	bool boolVal = false;
+
+	// filename
+	BOOST_CHECK(cmd.TestNextParamAsStr(&strVal));
+	BOOST_CHECK_EQUAL(std::string(strVal), "test.nzb");
+
+	// content (base64)
+	BOOST_CHECK(cmd.TestNextParamAsStr(&strVal));
+	BOOST_CHECK_EQUAL(std::string(strVal), "PD94bWw...");
+
+	// category
+	BOOST_CHECK(cmd.TestNextParamAsStr(&strVal));
+	BOOST_CHECK_EQUAL(std::string(strVal), "");
+
+	// priority
+	BOOST_CHECK(cmd.TestNextParamAsInt(&intVal));
+	BOOST_CHECK_EQUAL(intVal, 0);
+
+	// addTop
+	BOOST_CHECK(cmd.TestNextParamAsBool(&boolVal));
+	BOOST_CHECK_EQUAL(boolVal, false);
+
+	// addPaused
+	BOOST_CHECK(cmd.TestNextParamAsBool(&boolVal));
+	BOOST_CHECK_EQUAL(boolVal, false);
+
+	// dupeKey
+	BOOST_CHECK(cmd.TestNextParamAsStr(&strVal));
+	BOOST_CHECK_EQUAL(std::string(strVal), "");
+
+	// dupeScore
+	BOOST_CHECK(cmd.TestNextParamAsInt(&intVal));
+	BOOST_CHECK_EQUAL(intVal, 0);
+
+	// dupeMode
+	BOOST_CHECK(cmd.TestNextParamAsStr(&strVal));
+	BOOST_CHECK_EQUAL(std::string(strVal), "FORCE");
+
+	// v13 Parameters loop - must be exhausted (cursor must not leak into "id")
+	BOOST_CHECK(!cmd.TestNextParamAsStr(&strVal));
+}
+
+BOOST_AUTO_TEST_CASE(TestEditQueueWithIdAfter)
+{
+	// Nested array as last param with "id" after "params"
+	std::string jsonInput = R"({"params":["PausePost", "", [123, 456]],"id":1})";
+
+	MockXmlCommandAll cmd;
+	cmd.SetRequest(&jsonInput[0]);
+	cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+	cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+	cmd.PrepareParams();
+
+	char* strVal = nullptr;
+	int intVal = 0;
+
+	// editCommand
+	BOOST_CHECK(cmd.TestNextParamAsStr(&strVal));
+	BOOST_CHECK_EQUAL(std::string(strVal), "PausePost");
+
+	// Optional offset (v17+) - reads "" which is not numeric
+	BOOST_CHECK(!cmd.TestNextParamAsInt(&intVal));
+
+	// args
+	BOOST_CHECK(cmd.TestNextParamAsStr(&strVal));
+	BOOST_CHECK_EQUAL(std::string(strVal), "");
+
+	// IDs from nested array
+	BOOST_CHECK(cmd.TestNextParamAsInt(&intVal));
+	BOOST_CHECK_EQUAL(intVal, 123);
+	BOOST_CHECK(cmd.TestNextParamAsInt(&intVal));
+	BOOST_CHECK_EQUAL(intVal, 456);
+
+	// No more IDs
+	BOOST_CHECK(!cmd.TestNextParamAsInt(&intVal));
+}
+
+BOOST_AUTO_TEST_CASE(TestWhitespaceAfterLastParam)
+{
+	// Space before closing bracket
+	{
+		std::string jsonInput = R"({"params":[123 ],"id":1})";
+		MockXmlCommandAll cmd;
+		cmd.SetRequest(&jsonInput[0]);
+		cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+		cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+		cmd.PrepareParams();
+
+		int val = 0;
+		BOOST_CHECK(cmd.TestNextParamAsInt(&val));
+		BOOST_CHECK_EQUAL(val, 123);
+		BOOST_CHECK(!cmd.TestNextParamAsInt(&val));
+	}
+
+	// Newline before closing bracket
+	{
+		std::string jsonInput = "{\"params\":[123\n],\"id\":1}";
+		MockXmlCommandAll cmd;
+		cmd.SetRequest(&jsonInput[0]);
+		cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+		cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+		cmd.PrepareParams();
+
+		int val = 0;
+		BOOST_CHECK(cmd.TestNextParamAsInt(&val));
+		BOOST_CHECK_EQUAL(val, 123);
+		BOOST_CHECK(!cmd.TestNextParamAsInt(&val));
+	}
+
+	// String with trailing space before closing bracket
+	{
+		std::string jsonInput = R"({"params":["abc" ],"id":1})";
+		MockXmlCommandAll cmd;
+		cmd.SetRequest(&jsonInput[0]);
+		cmd.SetProtocol(XmlRpcProcessor::rpJsonRpc);
+		cmd.SetHttpMethod(XmlRpcProcessor::hmPost);
+		cmd.PrepareParams();
+
+		char* val = nullptr;
+		BOOST_CHECK(cmd.TestNextParamAsStr(&val));
+		BOOST_CHECK_EQUAL(std::string(val), "abc");
+		BOOST_CHECK(!cmd.TestNextParamAsStr(&val));
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/remote/remote.cmake
+++ b/tests/remote/remote.cmake
@@ -1,0 +1,3 @@
+list(APPEND TESTS_SRC
+	${CMAKE_CURRENT_SOURCE_DIR}/remote/XmlRpc.cpp
+)


### PR DESCRIPTION
## Description

 - Fixes: JSON-RPC parser no longer fails when "id" appears after "params" in a request;
 - Resolves several compiler warnings.

## Testing
- macOS Tahoe

Co-authored-by: [@selmant](https://github.com/selmant)