### PR TITLE
Fix WebUI crash on startup with non-English languages

### DIFF
--- a/webui/status.js
+++ b/webui/status.js
@@ -208,11 +208,11 @@ var Status = (new function($)
 		}
 
 		var limit = status.DownloadLimit > 0;
-		if (!limit)
+		if (!limit && status.NewsServers)
 		{
-			for (var i=0; i < Status.status.NewsServers.length; i++)
+			for (var i=0; i < status.NewsServers.length; i++)
 			{
-				limit = !Status.status.NewsServers[i].Active;
+				limit = !status.NewsServers[i].Active;
 				if (limit)
 				{
 					break;


### PR DESCRIPTION
## Description

Fixes a race condition where the UI would try to show server status before the data had arrived

## Testing

- Goggle chrome
- Safari
- Firefox