### PR TITLE
Fix printf format specifiers for int64 and size_t

### DIFF
--- a/daemon/remote/WebServer.cpp
+++ b/daemon/remote/WebServer.cpp
@@ -472,7 +472,7 @@ void WebProcessor::SendBodyResponse(const char* body, int bodyLen, const char* c
 		BString<1024> newETag;
 
 		size_t hash = m_hasher(body);
-		newETag.Format("\"%x\"", hash);
+		newETag.Format("\"%zx\"", hash);
 
 		unchanged = m_oldETag && !strcmp(newETag, m_oldETag);
 		if (unchanged)

--- a/daemon/util/Util.cpp
+++ b/daemon/util/Util.cpp
@@ -373,7 +373,7 @@ CString Util::FormatSpeed(int64 bytesPerSecond)
 
 	if (bytesPerSecond >= 100ll * 1024 * 1024 * 1024)
 	{
-		result.Format("%li GB/s", bytesPerSecond / 1024 / 1024 / 1024);
+		result.Format("%" PRId64 " GB/s", bytesPerSecond / 1024 / 1024 / 1024);
 	}
 	else if (bytesPerSecond >= 10ll * 1024 * 1024 * 1024)
 	{
@@ -385,7 +385,7 @@ CString Util::FormatSpeed(int64 bytesPerSecond)
 	}
 	else if (bytesPerSecond >= 100 * 1024 * 1024)
 	{
-		result.Format("%li MB/s", bytesPerSecond / 1024 / 1024);
+		result.Format("%" PRId64 " MB/s", bytesPerSecond / 1024 / 1024);
 	}
 	else if (bytesPerSecond >= 10 * 1024 * 1024)
 	{
@@ -397,7 +397,7 @@ CString Util::FormatSpeed(int64 bytesPerSecond)
 	}
 	else
 	{
-		result.Format("%li KB/s", bytesPerSecond / 1024);
+		result.Format("%" PRId64 " KB/s", bytesPerSecond / 1024);
 	}
 
 	return result;


### PR DESCRIPTION
## Description

Fixes two pre-existing printf-format mismatches that clang reports with `-Wformat`:

- `daemon/util/Util.cpp` — `Util::FormatSpeed` used `%li` for `int64` in the three integer branches (`GB/s`, `MB/s`, `KB/s`). On LLP64 platforms (Windows) `%li` reads only 32 bits, so speeds displayed via these branches are garbage there. Switched to `"%" PRId64`, matching the existing usage in `FeedFilter.cpp` (with the fallback define already present in `nzbget.h`).
- `daemon/remote/WebServer.cpp` — the ETag was formatted with `%x` from a `size_t` hash, truncating it to 32 bits (and technically UB per the printf contract). Switched to `%zx`. Side effect: ETag values change once, so clients simply revalidate their cache one time.

No functional changes beyond the corrected formatting; `-Wformat` is now clean for these files.

## Testing

- macOS (arm64): Release build clean (no `-Wformat` warnings remain), all 10 ctest suites pass.
