### PR TITLE
Fix heap-buffer-overflow in FeedFilter::Term::Compile

### DIFF
--- a/daemon/feed/FeedFilter.cpp
+++ b/daemon/feed/FeedFilter.cpp
@@ -189,7 +189,10 @@ bool FeedFilter::Term::Compile(char* token)
 		ch = token[0];
 	}
 
-	char ch2= token[1];
+	// guard the second-char read: a term of just "-" or "+" leaves token at
+	// its '\0' after the increment above, so token[1] would read one byte past
+	// the buffer (harmless-looking without a sanitizer, a real heap overflow)
+	char ch2 = ch != '\0' ? token[1] : '\0';
 	if ((ch == '(' || ch == ')' || ch == '|') && (ch2 == ' ' || ch2 == '\0'))
 	{
 		switch (ch)

--- a/tests/feed/FeedFilter.cpp
+++ b/tests/feed/FeedFilter.cpp
@@ -85,6 +85,17 @@ BOOST_AUTO_TEST_CASE(FeedFilterTest)
 	TestFilter(&item, "A(k:series=GOT-${1}-${2}): Game of clowns S##E##", FeedItemInfo::msAccepted);
 	TestFilter(&item, "A(k:series=GOT-${1}-${2}): $.+S([0-9]{1,2})E([0-9]{1,2})", FeedItemInfo::msAccepted);
 	TestFilter(&item, "A(category:Series)", FeedItemInfo::msIgnored);
+
+	// a term of just "-" or "+" (the sign with no following text) leaves the
+	// token pointing at its '\0' after the sign is consumed; it must compile
+	// as an invalid term without reading past the buffer (regression for a
+	// heap-buffer-overflow in Term::Compile caught by AddressSanitizer). A
+	// lone "|" is a valid operator token and must not overflow either.
+	TestFilter(&item, "-", FeedItemInfo::msIgnored);
+	TestFilter(&item, "+", FeedItemInfo::msIgnored);
+	TestFilter(&item, "|", FeedItemInfo::msIgnored);
+	TestFilter(&item, "game -", FeedItemInfo::msIgnored);
+	TestFilter(&item, "-:game", FeedItemInfo::msIgnored);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Fix heap-buffer-overflow in `FeedFilter::Term::Compile`

`FeedFilter::Term::Compile` reads one byte past the end of the token buffer for an
RSS filter term that is just a sign (`-` or `+`) with no following text.

**Root cause.** After the leading `+`/`-` is consumed:

```cpp
m_positive = ch != '-';
if (ch == '-' || ch == '+')
{
    token++;          // for a "-" token, token now points at the '\0'
    ch = token[0];    // ch == '\0'
}

char ch2 = token[1];  // <-- reads one byte PAST the terminator
```

For a token of exactly `"-"` or `"+"`, the increment leaves `token` pointing at the
string's `'\0'`, so `token[1]` is one byte beyond the allocation — a heap read
overflow. It goes unnoticed on a normal build (it reads adjacent heap and the value
is discarded, since the following `if ((ch == '(' || ...))` is false when `ch` is
`'\0'`), but AddressSanitizer flags it:

```
==ERROR: AddressSanitizer: heap-buffer-overflow ... in FeedFilter::Term::Compile(char*)
```

**Fix.** Guard the second-character read so it is not performed when the token is
empty after the sign:

```cpp
char ch2 = ch != '\0' ? token[1] : '\0';
```

This is behavior-preserving: when `ch == '\0'` the subsequent operator check is
false regardless of `ch2`, so the term still compiles as invalid (`return false`) —
the change only removes the out-of-bounds read.

**Test.** `FeedFilterTest` gains cases for a lone `-`, `+`, `|`, a trailing `-`
(`"game -"`), and `-:game`. Under AddressSanitizer these reproduce the overflow
before the fix and pass after it.

Reproduce:

```
cmake -S . -B build -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_CXX_FLAGS="-fsanitize=address" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
cmake --build build --target nzbget_tests
build/tests/nzbget_tests --run_test=FeedTest
```

Found while running the test suite under AddressSanitizer.
