### PR TITLE
Fix: preserve category for compressed archives in NzbDir subdirectories

### DIFF
--- a/daemon/queue/ArchiveProcessor.cpp
+++ b/daemon/queue/ArchiveProcessor.cpp
@@ -69,7 +69,7 @@ std::optional<std::vector<fs::path>> ArchiveProcessor::Process(const fs::path& a
 		to.push_back(destDir / relPath);
 	}
 
-	MoveNzbFiles(from, to);
+	int moved = MoveNzbFiles(from, to);
 
 	fs::error_code ec;
 	fs::remove_all(unpackDir, ec);
@@ -83,8 +83,17 @@ std::optional<std::vector<fs::path>> ArchiveProcessor::Process(const fs::path& a
 		detail("%s Cleaned up temporary directory '%s'", LOG_PREFIX, fs::u8string(unpackDir).c_str());
 	}
 
+	if (moved > 0)
+	{
+		info("%s Moved %d NZB file(s) to '%s'", LOG_PREFIX, moved, fs::u8string(destDir).c_str());
+	}
+
 	DisposeArchive(archiveFile, scanResult.nonNzbFiles);
 
+	if (moved == 0)
+	{
+		to.clear();
+	}
 	return to;
 }
 
@@ -155,8 +164,9 @@ ArchiveProcessor::ScanResult ArchiveProcessor::ScanUnpackDir(const fs::path& unp
 	return result;
 }
 
-void ArchiveProcessor::MoveNzbFiles(const std::vector<fs::path>& from, const std::vector<fs::path>& to) const
+int ArchiveProcessor::MoveNzbFiles(const std::vector<fs::path>& from, const std::vector<fs::path>& to) const
 {
+	int moved = 0;
 	fs::error_code ec;
 	for (size_t i = 0; i < from.size(); ++i)
 	{
@@ -169,7 +179,12 @@ void ArchiveProcessor::MoveNzbFiles(const std::vector<fs::path>& from, const std
 			error("%s Failed to move NZB '%s': %s", LOG_PREFIX,
 				  fs::u8string(from[i].filename()).c_str(), ec.message().c_str());
 		}
+		else
+		{
+			++moved;
+		}
 	}
+	return moved;
 }
 
 void ArchiveProcessor::DisposeArchive(const fs::path& archiveFile, int nonNzbFileCount) const

--- a/daemon/queue/ArchiveProcessor.cpp
+++ b/daemon/queue/ArchiveProcessor.cpp
@@ -32,10 +32,10 @@ namespace
 	const char* LOG_PREFIX = "ArchiveProcessor:";
 }
 
-std::optional<std::vector<fs::path>> ArchiveProcessor::Process(const fs::path& archiveFile) const
+std::optional<std::vector<fs::path>> ArchiveProcessor::Process(const fs::path& archiveFile, const fs::path& destDir) const
 {
 	const std::string filenameStr = fs::u8string(archiveFile.filename());
-	info("Extracting '%s'", filenameStr.c_str());
+	info("%s Extracting '%s'", LOG_PREFIX, filenameStr.c_str());
 
 	const auto unpackDir = m_config.unpackDir / fs::make_unique_filename();
 	
@@ -44,30 +44,48 @@ std::optional<std::vector<fs::path>> ArchiveProcessor::Process(const fs::path& a
 		return std::nullopt;
 	}
 
-	ScanResult scanResult = ScanUnpackDir(unpackDir);
+	detail("%s Extraction of '%s' completed", LOG_PREFIX, filenameStr.c_str());
 
-	MoveNzbFiles(scanResult.from, scanResult.to);
+	auto scanResult = ScanUnpackDir(unpackDir);
+
+	if (scanResult.nzbFiles.empty())
+	{
+		info("%s Skipped '%s': No NZB files were found inside", LOG_PREFIX, filenameStr.c_str());
+	}
+	else
+	{
+		info("%s Successfully extracted %zu NZB file(s) (and %d non-NZB file(s)) from '%s'",
+			 LOG_PREFIX, scanResult.nzbFiles.size(), scanResult.nonNzbFiles, filenameStr.c_str());
+	}
+
+	std::vector<fs::path> from;
+	std::vector<fs::path> to;
+	from.reserve(scanResult.nzbFiles.size());
+	to.reserve(scanResult.nzbFiles.size());
+
+	for (const auto& relPath : scanResult.nzbFiles)
+	{
+		from.push_back(unpackDir / relPath);
+		to.push_back(destDir / relPath);
+	}
+
+	MoveNzbFiles(from, to);
 
 	fs::error_code ec;
 	fs::remove_all(unpackDir, ec);
 	if (ec)
 	{
-		warn("Failed to clean up temp dir '%s': %s (code: %d)", 
-			 fs::u8string(unpackDir).c_str(), ec.message().c_str(), ec.value());
+		warn("%s Failed to clean up temp dir '%s': %s (code: %d)", 
+			 LOG_PREFIX, fs::u8string(unpackDir).c_str(), ec.message().c_str(), ec.value());
+	}
+	else
+	{
+		detail("%s Cleaned up temporary directory '%s'", LOG_PREFIX, fs::u8string(unpackDir).c_str());
 	}
 
 	DisposeArchive(archiveFile, scanResult.nonNzbFiles);
 
-	if (scanResult.to.empty())
-	{
-		info("Skipped '%s': No NZB files were found inside", filenameStr.c_str());
-	}
-	else
-	{
-		info("Successfully extracted %zu NZB file(s) from '%s'", scanResult.to.size(), filenameStr.c_str());
-	}
-	
-	return std::move(scanResult.to);
+	return to;
 }
 
 bool ArchiveProcessor::Extract(const fs::path& archiveFile, const fs::path& unpackDir) const
@@ -82,7 +100,7 @@ bool ArchiveProcessor::Extract(const fs::path& archiveFile, const fs::path& unpa
 	{
 		const std::string archiveName = fs::u8string(archiveFile.filename());
 		const std::string brokenDirName = fs::u8string(m_config.brokenDir.filename());
-		error("Failed to extract '%s'. Moving to '%s'", archiveName.c_str(), brokenDirName.c_str());
+		error("%s Failed to extract '%s'. Moving to '%s'", LOG_PREFIX, archiveName.c_str(), brokenDirName.c_str());
 
 		fs::error_code ec;
 		fs::remove_all(unpackDir, ec);
@@ -120,7 +138,7 @@ ArchiveProcessor::ScanResult ArchiveProcessor::ScanUnpackDir(const fs::path& unp
 
 		if (!IsNzbFile(filename))
 		{
-			debug("%s Found non-NZB file '%s'", LOG_PREFIX, filenameStr.c_str());
+			detail("%s Found non-NZB file '%s' in the archive", LOG_PREFIX, filenameStr.c_str());
 			++result.nonNzbFiles;
 			continue;
 		}
@@ -128,13 +146,12 @@ ArchiveProcessor::ScanResult ArchiveProcessor::ScanUnpackDir(const fs::path& unp
 		auto relativePath = fs::relative(file, unpackDir, ec);
 		if (ec) continue;
 
-		auto finalDestPath = m_config.destDir / relativePath;
-		result.from.push_back(file);
-		result.to.push_back(std::move(finalDestPath));
+		detail("%s Found NZB file '%s' in the archive", LOG_PREFIX, fs::u8string(relativePath).c_str());
+
+		result.nzbFiles.push_back(std::move(relativePath));
 	}
 	
-	result.from.shrink_to_fit();
-	result.to.shrink_to_fit();
+	result.nzbFiles.shrink_to_fit();
 	return result;
 }
 
@@ -143,11 +160,14 @@ void ArchiveProcessor::MoveNzbFiles(const std::vector<fs::path>& from, const std
 	fs::error_code ec;
 	for (size_t i = 0; i < from.size(); ++i)
 	{
+		detail("%s Moving '%s' to '%s'", LOG_PREFIX,
+			   fs::u8string(from[i].filename()).c_str(), fs::u8string(to[i]).c_str());
 		fs::create_directories(to[i].parent_path(), ec);
 		fs::move_file(from[i], to[i], ec); 
 		if (ec)
 		{
-			error("Failed to move NZB '%s': %s", fs::u8string(from[i].filename()).c_str(), ec.message().c_str());
+			error("%s Failed to move NZB '%s': %s", LOG_PREFIX,
+				  fs::u8string(from[i].filename()).c_str(), ec.message().c_str());
 		}
 	}
 }
@@ -163,39 +183,39 @@ void ArchiveProcessor::DisposeArchive(const fs::path& archiveFile, int nonNzbFil
 	{
 		if (nonNzbFileCount > 0)
 		{
-			info("Archive '%s' contains %d non-NZB file(s). Moving to '%s' instead of deleting to prevent data loss", 
-				 filenameStr.c_str(), nonNzbFileCount, processedDirName.c_str());
+			info("%s Archive '%s' contains %d non-NZB file(s). Moving to '%s' instead of deleting to prevent data loss", 
+				 LOG_PREFIX, filenameStr.c_str(), nonNzbFileCount, processedDirName.c_str());
 			
 			fs::create_directories(m_config.processedDir, ec);
 			fs::move_file(archiveFile, fs::make_unique_filename(m_config.processedDir / archiveFile.filename()), ec);
 			if (ec)
 			{
-				warn("Failed to move archive '%s' to '%s': %s (code: %d)", 
-					 filenameStr.c_str(), processedDirName.c_str(), ec.message().c_str(), ec.value());
+				warn("%s Failed to move archive '%s' to '%s': %s (code: %d)", 
+					 LOG_PREFIX, filenameStr.c_str(), processedDirName.c_str(), ec.message().c_str(), ec.value());
 			}
 		}
 		else
 		{
 			if (fs::remove(archiveFile, ec) && !ec)
 			{
-				info("Deleted archive '%s'", filenameStr.c_str());
+				info("%s Deleted archive '%s'", LOG_PREFIX, filenameStr.c_str());
 			}
 			else if (ec)
 			{
-				warn("Failed to delete archive '%s': %s (code: %d)", 
-					 filenameStr.c_str(), ec.message().c_str(), ec.value());
+				warn("%s Failed to delete archive '%s': %s (code: %d)", 
+					 LOG_PREFIX, filenameStr.c_str(), ec.message().c_str(), ec.value());
 			}
 		}
 	}
 	else
 	{
-		info("Moving archive '%s' to '%s'", filenameStr.c_str(), processedDirName.c_str());
+		info("%s Moving archive '%s' to '%s'", LOG_PREFIX, filenameStr.c_str(), processedDirName.c_str());
 		fs::create_directories(m_config.processedDir, ec);
 		fs::move_file(archiveFile, fs::make_unique_filename(m_config.processedDir / archiveFile.filename()), ec);
 		if (ec)
 		{
-			warn("Failed to move archive '%s' to '%s': %s (code: %d)", 
-				 filenameStr.c_str(), processedDirName.c_str(), ec.message().c_str(), ec.value());
+			warn("%s Failed to move archive '%s' to '%s': %s (code: %d)", 
+				 LOG_PREFIX, filenameStr.c_str(), processedDirName.c_str(), ec.message().c_str(), ec.value());
 		}
 	}
 }

--- a/daemon/queue/ArchiveProcessor.h
+++ b/daemon/queue/ArchiveProcessor.h
@@ -54,7 +54,7 @@ private:
 	bool Extract(const fs::path& archiveFile, const fs::path& unpackDir) const;
 	bool IsNzbFile(const fs::path& filename) const;
 	ScanResult ScanUnpackDir(const fs::path& unpackDir) const;
-	void MoveNzbFiles(const std::vector<fs::path>& from, const std::vector<fs::path>& to) const;
+	int MoveNzbFiles(const std::vector<fs::path>& from, const std::vector<fs::path>& to) const;
 	void DisposeArchive(const fs::path& archiveFile, int nonNzbFileCount) const;
 	const Config m_config;
 };

--- a/daemon/queue/ArchiveProcessor.h
+++ b/daemon/queue/ArchiveProcessor.h
@@ -32,7 +32,6 @@ namespace Incoming
 struct Config
 {
 	fs::path unpackDir;
-	fs::path destDir;
 	fs::path processedDir;
 	fs::path brokenDir;
 	Options::ENzbDirArchiveAction action;
@@ -43,13 +42,12 @@ class ArchiveProcessor final
 public:
 	explicit ArchiveProcessor(Config config) : m_config(std::move(config))
 	{}
-	std::optional<std::vector<fs::path>> Process(const fs::path& archiveFile) const;
+	std::optional<std::vector<fs::path>> Process(const fs::path& archiveFile, const fs::path& destDir) const;
 
 private:
 	struct ScanResult
 	{
-		std::vector<fs::path> from;
-		std::vector<fs::path> to;
+		std::vector<fs::path> nzbFiles;
 		int nonNzbFiles{};
 	};
 
@@ -57,7 +55,7 @@ private:
 	bool IsNzbFile(const fs::path& filename) const;
 	ScanResult ScanUnpackDir(const fs::path& unpackDir) const;
 	void MoveNzbFiles(const std::vector<fs::path>& from, const std::vector<fs::path>& to) const;
-	void DisposeArchive(const fs::path& archiveFilePath, int nonNzbFileCount) const;
+	void DisposeArchive(const fs::path& archiveFile, int nonNzbFileCount) const;
 	const Config m_config;
 };
 

--- a/daemon/queue/Scanner.cpp
+++ b/daemon/queue/Scanner.cpp
@@ -216,7 +216,6 @@ void Scanner::UnpackArchives(const std::vector<fs::path>& archives)
 
 	const auto processor = Incoming::ArchiveProcessor({
 		g_Options->GetTempDirPath() / UNPACK_DIR,
-		g_Options->GetNzbDirPath(),
 		g_Options->GetNzbDirPath() / PROCESSED_DIR,
 		g_Options->GetNzbDirPath() / BROKEN_DIR,
 		g_Options->GetNzbDirArchiveAction()
@@ -224,7 +223,7 @@ void Scanner::UnpackArchives(const std::vector<fs::path>& archives)
 
 	for (const auto& archive : archives)
 	{
-		processor.Process(archive);
+		processor.Process(archive, archive.parent_path());
 	}
 }
 
@@ -786,13 +785,12 @@ Scanner::EAddStatus Scanner::AddArchive(const char* filename, const char* catego
 
 		const auto processor = Incoming::ArchiveProcessor({
 			g_Options->GetTempDirPath() / UNPACK_DIR,
-			g_Options->GetNzbDirPath(),
 			g_Options->GetNzbDirPath() / PROCESSED_DIR,
 			g_Options->GetNzbDirPath() / BROKEN_DIR,
 			g_Options->GetNzbDirArchiveAction()
 		});
 
-		auto nzbFiles = processor.Process(archiveFilePath);
+		auto nzbFiles = processor.Process(archiveFilePath, g_Options->GetNzbDirPath());
 		if (!nzbFiles)
 		{
 			return EAddStatus::asFailed;

--- a/tests/queue/ArchiveProcessor.cpp
+++ b/tests/queue/ArchiveProcessor.cpp
@@ -1,0 +1,141 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+#include <fstream>
+#include <sstream>
+#include "ArchiveProcessor.h"
+#include "FileSystem.h"
+#include "Options.h"
+#include "Util.h"
+
+BOOST_AUTO_TEST_SUITE(QueueTest)
+
+void RunArchiveTest(const fs::path& archivePath, const fs::path& destDir)
+{
+	fs::error_code ec;
+
+	fs::path processedDir = destDir.parent_path() / "_processed";
+	fs::path brokenDir = destDir.parent_path() / "_broken";
+
+	Incoming::Config config = {
+		destDir.parent_path() / "unpack",
+		processedDir,
+		brokenDir,
+		Options::ENzbDirArchiveAction::Delete
+	};
+
+	Incoming::ArchiveProcessor processor(config);
+	auto result = processor.Process(archivePath, destDir);
+
+	BOOST_REQUIRE(result.has_value());
+	BOOST_REQUIRE_EQUAL(result->size(), 1);
+
+	fs::path expectedPath = destDir / "test.nzb";
+	BOOST_CHECK_EQUAL(result->at(0), expectedPath);
+	BOOST_CHECK(fs::exists(expectedPath, ec));
+
+	fs::remove_all(destDir.parent_path(), ec);
+}
+
+BOOST_AUTO_TEST_CASE(ArchiveCategoryPreservationTest)
+{
+	if (!Util::ResolvePathFromEnv("7z"))
+	{
+		BOOST_TEST_MESSAGE("This test requires a working '7z' executable.");
+		return;
+	}
+
+	fs::error_code ec;
+
+	fs::path baseDir = fs::temp_directory_path(ec) / fs::make_unique_filename();
+	BOOST_REQUIRE_MESSAGE(!ec, "Failed to create temp directory");
+
+	fs::path categoryDir = baseDir / "nzbdir" / "TV";
+	fs::create_directories(categoryDir, ec);
+	BOOST_REQUIRE_MESSAGE(!ec, "Failed to create subdirectories");
+
+	fs::path nzbSource = baseDir / "test.nzb";
+	{
+		std::ofstream ofs(fs::u8string(nzbSource));
+		BOOST_REQUIRE(ofs);
+		ofs << "<?xml version=\"1.0\"?>\n"
+		       "<nzb xmlns=\"http://www.newzbin.com/DTD/2003/nzb\">\n"
+		       "</nzb>\n";
+	}
+
+	fs::path archivePath = categoryDir / "test.nzb.gz";
+	{
+		std::ostringstream cmd;
+		cmd << "cd \"" << fs::u8string(baseDir) << "\" && "
+		    << "7z a -tgzip \"" << fs::u8string(archivePath) << "\" \"test.nzb\" >/dev/null";
+		int ret = std::system(cmd.str().c_str());
+		BOOST_REQUIRE_MESSAGE(ret == 0, "Failed to create archive with 7z");
+	}
+	BOOST_REQUIRE(fs::exists(archivePath, ec));
+
+	RunArchiveTest(archivePath, categoryDir);
+}
+
+BOOST_AUTO_TEST_CASE(ArchiveSubdirEscapeTest)
+{
+	if (!Util::ResolvePathFromEnv("7z"))
+	{
+		BOOST_TEST_MESSAGE("This test requires a working '7z' executable.");
+		return;
+	}
+
+	fs::error_code ec;
+
+	fs::path baseDir = fs::temp_directory_path(ec) / fs::make_unique_filename();
+	BOOST_REQUIRE_MESSAGE(!ec, "Failed to create temp directory");
+
+	fs::path nzbDir = baseDir / "nzbdir";
+	fs::path outsideDir = baseDir / "tmp";
+
+	fs::create_directories(nzbDir, ec);
+	fs::create_directories(outsideDir, ec);
+	BOOST_REQUIRE_MESSAGE(!ec, "Failed to create subdirectories");
+
+	fs::path nzbSource = baseDir / "test.nzb";
+	{
+		std::ofstream ofs(fs::u8string(nzbSource));
+		BOOST_REQUIRE(ofs);
+		ofs << "<?xml version=\"1.0\"?>\n"
+		       "<nzb xmlns=\"http://www.newzbin.com/DTD/2003/nzb\">\n"
+		       "</nzb>\n";
+	}
+
+	fs::path archivePath = outsideDir / "test.nzb.gz";
+	{
+		std::ostringstream cmd;
+		cmd << "cd \"" << fs::u8string(baseDir) << "\" && "
+		    << "7z a -tgzip \"" << fs::u8string(archivePath) << "\" \"test.nzb\" >/dev/null";
+		int ret = std::system(cmd.str().c_str());
+		BOOST_REQUIRE_MESSAGE(ret == 0, "Failed to create archive with 7z");
+	}
+	BOOST_REQUIRE(fs::exists(archivePath, ec));
+
+	RunArchiveTest(archivePath, nzbDir);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/queue/NzbFile.cpp
+++ b/tests/queue/NzbFile.cpp
@@ -83,9 +83,6 @@ void TestNzb(std::string testFilename, std::string expectedCategory)
 
 BOOST_AUTO_TEST_CASE(NZBParserTest)
 {
-	Options::CmdOptList cmdOpts;
-	Options options(&cmdOpts, nullptr);
-
 	TestNzb("dotless", "Movies");
 	TestNzb("plain", "TV>4K");
 	TestNzb("literal_gt", "TV > 4K");

--- a/tests/queue/queue.cmake
+++ b/tests/queue/queue.cmake
@@ -1,6 +1,7 @@
 list(APPEND TESTS_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/queue/NzbFile.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/queue/Deobfuscation.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/queue/ArchiveProcessor.cpp
 )
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/testdata/nzbfile DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
## Description

Archives placed in NzbDir subdirectories (e.g. /nzbdir/TV/show.nzb.gz) now extract the .nzb file into the same subdirectory instead of the NzbDir root. This ensures the category derived from the directory structure is preserved.

## Testing

- macOS Tahoe
- Windows 10/11