### PR TITLE
Fix error message for OS release retrieval on Linux

### DIFF
--- a/daemon/system/OS.cpp
+++ b/daemon/system/OS.cpp
@@ -148,7 +148,7 @@ namespace System
 			}
 			else
 			{
-				detail("Failed to get OS name. Couldn't read 'uname -o'");
+				detail("Failed to get OS release. Couldn't read 'uname -r'");
 			}
 		}
 


### PR DESCRIPTION
## Description

If the `uname -r` command failed the message logged would be `Failed to get OS name. Couldn't read 'uname -o'`. This pull request only changes the log output to `Failed to get OS release. Couldn't read 'uname -r'` when the `uname -r` command fails.

## Lib changes

None

## Testing

Minor log string change, no testing changes