### PR TITLE
Fix WebDir visibility in Windows WebUI

### DIFF
--- a/windows/build-nzbget.ps1
+++ b/windows/build-nzbget.ps1
@@ -152,7 +152,7 @@ Function PrepareFiles {
     & $Sed -e 's|DirectRename=.*|DirectRename=yes|' -i $Config
     & $Sed -e 's|DirectUnpack=.*|DirectUnpack=yes|' -i $Config
     # Hide certain options from web-interface settings page
-    & $Sed -e 's|WebDir=.*|# WebDir=${AppDir}\\webui|' -i $Config
+    & $Sed -e 's|WebDir=.*|WebDir=${AppDir}\\webui|' -i $Config
     & $Sed -e 's|LockFile=.*|# LockFile=|' -i $Config
     & $Sed -e 's|ConfigTemplate=.*|# ConfigTemplate=${AppDir}\\nzbget.conf.template|' -i $Config
     & $Sed -e 's|DaemonUsername=.*|# DaemonUsername=|' -i $Config


### PR DESCRIPTION
## Description

Fixes #649.

The Windows packaging script writes `WebDir` as a commented assignment in `nzbget.conf.template`. The WebUI treats `# ` lines as description text, so the option is missing from Settings on Windows.

Emit `WebDir=${AppDir}\webui` as an active template option instead. This preserves the existing Windows runtime default while allowing the option to be customized. The other intentionally hidden Windows options remain unchanged.

## Lib changes

None.

## Testing

- Generated-template regression: the old rule produces `# WebDir=${AppDir}\webui`; the new rule produces active `WebDir=${AppDir}\webui`.
- `cmake -S . -B build -DBUILD_ONLY_TESTS=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target nzbget_tests -j 8`
- `ctest --test-dir build --output-on-failure` (10/10 passed)
- `git diff --check`