### PR TITLE
Remove about_caption from generate_locales and EXTENSIONS.md

### DIFF
--- a/docs/extensions/EXTENSIONS.md
+++ b/docs/extensions/EXTENSIONS.md
@@ -378,13 +378,9 @@ Create `locales.source.json` in the extension root directory with English source
 
 ```json
 {
-    "about_caption": {
-        "message": "About EMail",
-        "description": "Section heading for extension description in settings"
-    },
     "about": {
-        "message": "Sends E-Mail notification.",
-        "description": "Short description shown in the extension manager table"
+        "message": "About EMail",
+        "description": "Section heading for extension description in settings. DO NOT translate 'EMail'."
     },
     "description": {
         "message": "This script sends E-Mail notification when the job is done.",
@@ -413,8 +409,7 @@ Create `locales.source.json` in the extension root directory with English source
 
 | Key pattern | Scope | Example |
 |---|---|---|
-| `about` | Short description in the extension manager table | `about` → "Sends E-Mail notification." |
-| `about_caption` | Section heading above the extension description in settings | `about_caption` → "About EMail" |
+| `about` | Section heading above the extension description in settings | `about` → "About EMail" |
 | `description` | Full description shown in settings | `description` → "This script sends..." |
 | `requirements` | System requirements displayed to the user | `requirements` → "Requires Python3.8+" |
 | `{optionname}_desc` | Option help text | `server_desc` → "SMTP server host." |

--- a/scripts/generate_locales.py
+++ b/scripts/generate_locales.py
@@ -109,13 +109,8 @@ def extract_from_manifest(manifest):
         if re.search(r"\bNZBGet\b", about_text):
             do_not_translate += " DO NOT translate 'NZBGet'."
         entries["about"] = {
-            "message": about_text,
-            "description": f"Short description of the extension shown as a heading in the About section." + do_not_translate,
-        }
-        about_caption_text = f"About {ext_name}"
-        entries["about_caption"] = {
-            "message": about_caption_text,
-            "description": f"Section heading for extension description in settings. DO NOT translate '{ext_name}'.",
+            "message": f"About {ext_name}",
+            "description": f"Section heading for extension description in settings. DO NOT translate '{ext_name}'." + do_not_translate,
         }
 
     desc = manifest.get("description", [])


### PR DESCRIPTION
## Description

Removed the redundant about_caption from generate_locales and EXTENSIONS.md.

## Testing

- macOS Tahoe/Chrome