### PR TITLE
Fix tests skipping without assertions when unrar/7z unavailable

### DIFF
--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -82,18 +82,18 @@ void ExitProc(){}
 
 struct InitGlobals
 {
+	Options::CmdOptList m_cmdOpts;
+
 	InitGlobals()
 	{
 		rapidyenc_decode_init();
 		rapidyenc_crc_init();
 
+		m_cmdOpts.push_back("SevenZipCmd=7z");
+		m_cmdOpts.push_back("UnrarCmd=unrar");
+
 		g_Log = new Log();
-
-		Options::CmdOptList cmdOpts;
-		cmdOpts.push_back("SevenZipCmd=7z");
-		cmdOpts.push_back("UnrarCmd=unrar");
-
-		g_Options = new Options(&cmdOpts, nullptr);
+		g_Options = new Options(&m_cmdOpts, nullptr);
 		g_EnvironmentVariables = (char*(*)[])environ;
 		g_ArgumentCount = 0;
 		g_Arguments = nullptr;

--- a/tests/postprocess/DirectUnpack.cpp
+++ b/tests/postprocess/DirectUnpack.cpp
@@ -70,6 +70,7 @@ BOOST_AUTO_TEST_CASE(DirectUnpackSimpleTest)
 
 	DirectUnpackDownloadQueueMock downloadQueue;
 
+	fs::remove_all(WORKING_DIR);
 	BOOST_REQUIRE(fs::create_directory(WORKING_DIR));
 
 	const fs::path part01 = TEST_DATA_DIR / "testfile3.part01.rar";
@@ -133,6 +134,7 @@ BOOST_AUTO_TEST_CASE(DirectUnpackTwoArchives)
 
 	DirectUnpackDownloadQueueMock downloadQueue;
 
+	fs::remove_all(WORKING_DIR);
 	BOOST_REQUIRE(FileSystem::CreateDirectory(WORKING_DIR.string().c_str()));
 
 	const fs::path part01 = TEST_DATA_DIR / "testfile3.part01.rar";

--- a/tests/postprocess/DirectUnpack.cpp
+++ b/tests/postprocess/DirectUnpack.cpp
@@ -27,13 +27,14 @@
 #include "Options.h"
 #include "DiskState.h"
 #include "FileSystem.h"
+#include "Util.h"
 
 BOOST_AUTO_TEST_SUITE(PostprocessTest)
 
 const fs::path CURR_DIR = fs::current_path();
 const fs::path TEST_DATA_DIR = CURR_DIR / "rarrenamer";
 const fs::path WORKING_DIR = TEST_DATA_DIR / "empty";
-static const char* UNRAR_PATH = std::getenv("unrar");
+static const auto UNRAR_PATH = Util::ResolvePathFromEnv("unrar");
 
 class DirectUnpackDownloadQueueMock final : public DownloadQueue
 {
@@ -60,7 +61,7 @@ BOOST_AUTO_TEST_CASE(DirectUnpackSimpleTest)
 		return;
 	}
 
-	const std::string unrarCmd = std::string("UnrarCmd=") + UNRAR_PATH;
+	const std::string unrarCmd = std::string("UnrarCmd=") + fs::u8string(UNRAR_PATH.value());
 	Options::CmdOptList cmdOpts;
 	cmdOpts.push_back("WriteLog=none");
 	cmdOpts.push_back("NzbLog=no");
@@ -123,7 +124,7 @@ BOOST_AUTO_TEST_CASE(DirectUnpackTwoArchives)
 		return;
 	}
 
-	const std::string unrarCmd = std::string("UnrarCmd=") + UNRAR_PATH;
+	const std::string unrarCmd = std::string("UnrarCmd=") + UNRAR_PATH->string();
 	Options::CmdOptList cmdOpts;
 	cmdOpts.push_back("WriteLog=none");
 	cmdOpts.push_back("NzbLog=no");

--- a/tests/postprocess/DirectUnpack.cpp
+++ b/tests/postprocess/DirectUnpack.cpp
@@ -55,8 +55,8 @@ BOOST_AUTO_TEST_CASE(DirectUnpackSimpleTest)
 {
 	if (!UNRAR_PATH)
 	{
-		BOOST_TEST_MESSAGE("This test requires a working 'unrar' executable.");
-		BOOST_TEST_MESSAGE("The 'unrar' command was not found in your system's PATH.");
+		BOOST_TEST_MESSAGE("unrar not available - skipping test");
+		BOOST_CHECK(true);
 		return;
 	}
 
@@ -118,8 +118,8 @@ BOOST_AUTO_TEST_CASE(DirectUnpackTwoArchives)
 {
 	if (!UNRAR_PATH)
 	{
-		BOOST_TEST_MESSAGE("This test requires a working 'unrar' executable.");
-		BOOST_TEST_MESSAGE("The 'unrar' command was not found in your system's PATH.");
+		BOOST_TEST_MESSAGE("unrar not available - skipping test");
+		BOOST_CHECK(true);
 		return;
 	}
 

--- a/tests/postprocess/DupeMatcher.cpp
+++ b/tests/postprocess/DupeMatcher.cpp
@@ -22,14 +22,18 @@
 #include "nzbget.h"
 
 #include <boost/test/unit_test.hpp>
+#include "Options.h"
 #include "DupeMatcher.h"
 #include "FileSystem.h"
+#include "Util.h"
 
 BOOST_AUTO_TEST_SUITE(PostprocessTest)
 
 BOOST_AUTO_TEST_CASE(DupeMatcherTest)
 {
-	static const char* UNRAR_PATH = std::getenv("unrar");
+	const fs::path CURR_DIR = fs::current_path();
+
+	auto UNRAR_PATH = Util::ResolvePathFromEnv("unrar");
 	if (!UNRAR_PATH)
 	{
 		BOOST_TEST_MESSAGE("unrar not available - skipping test");
@@ -37,7 +41,13 @@ BOOST_AUTO_TEST_CASE(DupeMatcherTest)
 		return;
 	}
 
-	const fs::path CURR_DIR = fs::current_path();
+	const std::string unrarCmd = std::string("UnrarCmd=") + fs::u8string(UNRAR_PATH.value());
+	Options::CmdOptList cmdOpts;
+	cmdOpts.push_back("WriteLog=none");
+	cmdOpts.push_back("NzbLog=no");
+	cmdOpts.push_back(unrarCmd.c_str());
+	Options options(&cmdOpts, nullptr);
+
 	const fs::path workingDir = CURR_DIR / "DupeMatcher";
 	fs::remove_all(workingDir);
 	BOOST_REQUIRE(fs::create_directories(workingDir));

--- a/tests/postprocess/DupeMatcher.cpp
+++ b/tests/postprocess/DupeMatcher.cpp
@@ -29,6 +29,14 @@ BOOST_AUTO_TEST_SUITE(PostprocessTest)
 
 BOOST_AUTO_TEST_CASE(DupeMatcherTest)
 {
+	static const char* UNRAR_PATH = std::getenv("unrar");
+	if (!UNRAR_PATH)
+	{
+		BOOST_TEST_MESSAGE("unrar not available - skipping test");
+		BOOST_CHECK(true);
+		return;
+	}
+
 	const fs::path CURR_DIR = fs::current_path();
 	const fs::path workingDir = CURR_DIR / "DupeMatcher";
 	fs::remove_all(workingDir);
@@ -51,10 +59,7 @@ BOOST_AUTO_TEST_CASE(DupeMatcherTest)
 	fs::copy(CURR_DIR / "parchecker", nondupe, fs::copy_options::recursive);
 	fs::remove(nondupe / "testfile.dat");
 
-
 	int64 expectedSize = static_cast<int64>(fs::file_size(dupe1 / "testfile.dat"));
-
-	BOOST_TEST_MESSAGE("This test requires working unrar 5 in search path");
 
 	DupeMatcher dupe1Matcher(dupe1.string().c_str(), expectedSize);
 	BOOST_CHECK(dupe1Matcher.Prepare());
@@ -80,7 +85,7 @@ BOOST_AUTO_TEST_CASE(DupeMatcherTest)
 	DupeMatcher rardupe1matcher(rardupe1.string().c_str(), expectedSize);
 	BOOST_CHECK(rardupe1matcher.Prepare());
 	BOOST_CHECK(rardupe1matcher.MatchDupeContent(dupe1.string().c_str()));
-	BOOST_CHECK(rardupe1matcher.MatchDupeContent(dupe2.string().c_str()));		    
+	BOOST_CHECK(rardupe1matcher.MatchDupeContent(dupe2.string().c_str()));
 	BOOST_CHECK(rardupe1matcher.MatchDupeContent(rardupe2.string().c_str()));
 	BOOST_CHECK(rardupe1matcher.MatchDupeContent(nondupe.string().c_str()) == false);
 

--- a/tests/postprocess/ParChecker.cpp
+++ b/tests/postprocess/ParChecker.cpp
@@ -54,6 +54,7 @@ private:
 ParCheckerMock::ParCheckerMock(const fs::path& workingDir) : m_workingDir(workingDir)
 {
 	SetDestDir(m_workingDir.string().c_str());
+	fs::remove_all(m_workingDir);
 	fs::copy(TEST_DATA_DIR, m_workingDir);
 }
 

--- a/tests/postprocess/ParRenamer.cpp
+++ b/tests/postprocess/ParRenamer.cpp
@@ -51,6 +51,7 @@ ParRenamerMock::ParRenamerMock(const fs::path& workingDir, const fs::path& testD
 	, m_testDataDir(testDataDir)
 {
 	SetDestDir(m_workingDir.string().c_str());
+	fs::remove_all(m_workingDir);
 	fs::copy(m_testDataDir, m_workingDir);
 }
 

--- a/tests/postprocess/RarRenamer.cpp
+++ b/tests/postprocess/RarRenamer.cpp
@@ -45,6 +45,7 @@ private:
 RarRenamerMock::RarRenamerMock(const fs::path& workingDir) : m_workingDir(workingDir)
 {
 	SetDestDir(m_workingDir.string().c_str());
+	fs::remove_all(m_workingDir);
 	fs::copy(TEST_DATA_DIR, m_workingDir);
 }
 

--- a/tests/queue/ArchiveProcessor.cpp
+++ b/tests/queue/ArchiveProcessor.cpp
@@ -61,7 +61,8 @@ BOOST_AUTO_TEST_CASE(ArchiveCategoryPreservationTest)
 {
 	if (!Util::ResolvePathFromEnv("7z"))
 	{
-		BOOST_TEST_MESSAGE("This test requires a working '7z' executable.");
+		BOOST_TEST_MESSAGE("7z not available - skipping test");
+		BOOST_CHECK(true);
 		return;
 	}
 
@@ -100,7 +101,8 @@ BOOST_AUTO_TEST_CASE(ArchiveSubdirEscapeTest)
 {
 	if (!Util::ResolvePathFromEnv("7z"))
 	{
-		BOOST_TEST_MESSAGE("This test requires a working '7z' executable.");
+		BOOST_TEST_MESSAGE("7z not available - skipping test");
+		BOOST_CHECK(true);
 		return;
 	}
 

--- a/tests/system/SystemInfo.cpp
+++ b/tests/system/SystemInfo.cpp
@@ -168,18 +168,6 @@ BOOST_AUTO_TEST_CASE(SystemInfoTest)
 		GetLibrariesXmlStr(sysInfo->GetLibraries()) +
 		"</struct></value>";
 
-	BOOST_TEST_MESSAGE("EXPECTED JSON STR: ");
-	BOOST_TEST_MESSAGE(jsonStrExpected);
-
-	BOOST_TEST_MESSAGE("RESULT JSON STR: ");
-	BOOST_TEST_MESSAGE(jsonStrResult);
-
-	BOOST_TEST_MESSAGE("EXPECTED XML STR: ");
-	BOOST_TEST_MESSAGE(xmlStrExpected);
-
-	BOOST_TEST_MESSAGE("RESULT XML STR: ");
-	BOOST_TEST_MESSAGE(xmlStrResult);
-
 	BOOST_CHECK(jsonStrResult == jsonStrExpected);
 	BOOST_CHECK(xmlStrResult == xmlStrExpected);
 


### PR DESCRIPTION
## Description

Fixed: tests skipping without assertions when unrar/7z unavailable

## Testing

- macOS Tahoe