### PR TITLE
Close inherited file descriptors in forked child processes

### DIFF
--- a/daemon/util/ScriptController.cpp
+++ b/daemon/util/ScriptController.cpp
@@ -579,6 +579,15 @@ void ScriptController::StartProcess(int* pipein, int* pipeout)
 	}
 #endif
 
+	// Determine the highest fd we might need to close in the child, before
+	// forking - sysconf() is not guaranteed async-signal-safe, so it must
+	// not be called after fork() in the child branch below.
+	long openMax = sysconf(_SC_OPEN_MAX);
+	if (openMax < 0)
+	{
+		openMax = 1024;
+	}
+
 	debug("forking");
 	pid_t pid = fork();
 
@@ -617,6 +626,18 @@ void ScriptController::StartProcess(int* pipein, int* pipeout)
 			dup2(pout[0], 0);
 			close(pout[0]);
 			close(pout[1]);
+		}
+
+		// Close all other inherited file descriptors. Without this, any
+		// handle the parent process happens to have open at the moment of
+		// fork() - e.g. a file mid-rename during download post-processing -
+		// leaks into this child and keeps that unrelated file "busy" for as
+		// long as the child runs, causing spurious EBUSY / NFS "Resource
+		// busy" failures on the parent's operation. close() is
+		// async-signal-safe so this is safe to do here.
+		for (int fd = 3; fd < (int)openMax; fd++)
+		{
+			close(fd);
 		}
 
 #ifdef CHILD_WATCHDOG


### PR DESCRIPTION
## Description

When downloading multiple files at a time over a 100GbE local LAN connection to an NVMe RAID10 pool on a TrueNAS box, I noticed that sometimes — like when `unrar` is running for one download and one of the rename/flatten extension scripts runs for another — NZBGet would lock a previously-opened file that it isn't even touching.

I was initially thinking this was a TrueNAS or Ubuntu issue, but with the assistance of Claude Code, we wrote a small monitoring tool to catch it happening live, and the logs showed it's actually a behavior in how NZBGet handles its extension scripts: when NZBGet launches `unrar` or any of its other scripts to work on a second download, it locks the previously-opened file from a completely unrelated download even though the new process never touches it. On NFS this shows up as `.nfs0000...` silly-rename files, and it's a real problem downstream — Sonarr/Radarr don't see the actual file until the hung process finally times out.

Root cause: `ScriptController::StartProcess()` forks a child to run `unrar`/`7z` or an extension/post-processing script, but only closes the pipe fds it created itself before calling `execvp()`. Any other file descriptor the main process happens to have open at that exact moment (e.g. mid-rename on an unrelated queue item) is inherited unchanged into the child, since `execvp()` does not close fds unless they're marked close-on-exec.

Fix: compute the process's open-fd ceiling via `sysconf(_SC_OPEN_MAX)` before `fork()` (since `sysconf` is not async-signal-safe and can't be called in the child), then in the child, after stdin/stdout/stderr are wired up to the pipes, close every other fd before `execvp()`.

## AI assistance

- [x] This PR involved AI assistance

Claude did the investigation (building the monitoring tooling, tracing the root cause to the exact code) and wrote the patch. I verified the diagnosis and the fix, and worked through the testing with it.

## Lib changes

N/A — no vendored libraries changed.

## Testing

With Claude Code's help, we built both the original code and the patched code on a Linux machine and ran NZBGet's automated test suite (10 test groups) against both — no regressions. We also wrote a short standalone program that copies the exact clone-and-take-over process from the real code, and ran it both unpatched and patched: the patched version closed the file handles correctly and didn't hold files open longer than necessary, while the unpatched version reproduced the leak.
