### PR TITLE
Harden web auth token generation and unpack-dir symlink handling

### DIFF
--- a/daemon/queue/ArchiveProcessor.cpp
+++ b/daemon/queue/ArchiveProcessor.cpp
@@ -137,7 +137,8 @@ ArchiveProcessor::ScanResult ArchiveProcessor::ScanUnpackDir(const fs::path& unp
 		!ec && it != fs::recursive_directory_iterator(); 
 		it.increment(ec))
 	{
-		if (!fs::is_regular_file(it->path(), ec)) continue;
+		fs::file_status status = fs::symlink_status(it->path(), ec); 
+		if (ec || !fs::is_regular_file(status)) continue;
 
 		const auto& file = it->path();
 		const auto& filename = file.filename();

--- a/daemon/remote/WebServer.cpp
+++ b/daemon/remote/WebServer.cpp
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2012-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024-2025 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -27,6 +27,10 @@
 #include "Util.h"
 #include "FileSystem.h"
 
+#ifndef DISABLE_TLS
+#include <openssl/rand.h>
+#endif
+
 static const char* ERR_HTTP_OK = "200 OK";
 static const char* ERR_HTTP_NOT_MODIFIED = "304 Not Modified";
 static const char* ERR_HTTP_BAD_REQUEST = "400 Bad Request";
@@ -34,7 +38,44 @@ static const char* ERR_HTTP_NOT_FOUND = "404 Not Found";
 static const char* ERR_HTTP_SERVICE_UNAVAILABLE = "503 Service Unavailable";
 
 static const int MAX_UNCOMPRESSED_SIZE = 500;
-char WebProcessor::m_serverAuthToken[3][49];
+char WebProcessor::m_serverAuthToken[3][TOKEN_SIZE];
+
+static void GenerateSecureToken(char* token)
+{
+	// 1 byte = 2 hex characters.
+	// For a token string of size TOKEN_SIZE (including \0), we need half that many random bytes.
+	constexpr size_t BYTES_NEEDED = (TOKEN_SIZE - 1) / 2;
+
+#ifndef DISABLE_TLS
+	unsigned char randBytes[BYTES_NEEDED];
+	if (RAND_bytes(randBytes, static_cast<int>(BYTES_NEEDED)) == 1)
+	{
+		for (size_t i = 0; i < BYTES_NEEDED; ++i)
+		{
+			sprintf(&token[i * 2], "%02x", randBytes[i]);
+		}
+
+		token[TOKEN_SIZE - 1] = '\0';
+		return;
+	}
+#endif
+
+	try
+	{
+		std::random_device rd;
+		std::uniform_int_distribution<unsigned int> dist(0, 0xFF);
+		for (size_t i = 0; i < BYTES_NEEDED; ++i)
+		{
+			sprintf(&token[i * 2], "%02x", dist(rd));
+		}
+	}
+	catch (const std::exception& ex)
+	{
+		error("Could not generate secure authentication token: %s", ex.what());
+		std::exit(1);
+	}
+	token[TOKEN_SIZE - 1] = '\0';
+}
 
 //*****************************************************************
 // WebProcessor
@@ -47,26 +88,9 @@ void WebProcessor::Init()
 		return;
 	}
 
-	for (int j = uaControl; j <= uaAdd; j++)
+	for (size_t j = uaControl; j <= uaAdd; ++j)
 	{
-		for (size_t i = 0; i < sizeof(m_serverAuthToken[j]) - 1; i++)
-		{
-			int ch = rand() % (10 + 26 + 26);
-			if (0 <= ch && ch < 10)
-			{
-				m_serverAuthToken[j][i] = '0' + ch;
-			}
-			else if (10 <= ch && ch < 10 + 26)
-			{
-				m_serverAuthToken[j][i] = 'a' + ch - 10;
-			}
-			else
-			{
-				m_serverAuthToken[j][i] = 'A' + ch - 10 - 26;
-			}
-		}
-		m_serverAuthToken[j][sizeof(m_serverAuthToken[j]) - 1] = '\0';
-		debug("X-Auth-Token[%i]: %s", j, m_serverAuthToken[j]);
+		GenerateSecureToken(m_serverAuthToken[j]);
 	}
 }
 
@@ -192,8 +216,6 @@ void WebProcessor::ParseHeaders()
 	}
 
 	debug("URL=%s", *m_url);
-	debug("Authorization=%s", m_authInfo);
-	debug("Auth-Token=%s", m_authToken);
 }
 
 void WebProcessor::ParseUrl()

--- a/daemon/remote/WebServer.h
+++ b/daemon/remote/WebServer.h
@@ -2,7 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2012-2017 Andrey Prygunkov <hugbug@users.sourceforge.net>
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,6 +24,8 @@
 
 #include "NString.h"
 #include "Connection.h"
+
+inline constexpr int TOKEN_SIZE = 48 + 1;
 
 class WebProcessor
 {
@@ -61,8 +63,8 @@ private:
 	CString m_origin;
 	int m_contentLen;
 	char m_authInfo[256+1];
-	char m_authToken[48+1];
-	static char m_serverAuthToken[3][48+1];
+	char m_authToken[TOKEN_SIZE];
+	static char m_serverAuthToken[3][TOKEN_SIZE];
 	CString m_forwardedFor;
 	CString m_oldETag;
 	bool m_keepAlive = false;


### PR DESCRIPTION
## Description

- Generate X-Auth-Token with OpenSSL RAND_bytes instead of rand()
- Stop logging Authorization and Auth-Token headers
- Skip symlinks when scanning the unpack directory

## Testing

- macOS Tahoe