### PR TITLE
Use POSIX uname(2) and add container detection 

### DIFF
--- a/daemon/system/CPU.cpp
+++ b/daemon/system/CPU.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,10 +20,13 @@
 
 #include "nzbget.h"
 
+#ifndef WIN32
+#include <sys/utsname.h>
+#endif
+
 #include "CPU.h"
-#include "Util.h"
 #include "Log.h"
-#include "FileSystem.h"
+#include "Util.h"
 
 namespace System
 {
@@ -73,7 +76,7 @@ namespace System
 		}
 		else
 		{
-			detail("Failed to get CPU model. Couldn't read Windows Registry");
+			debug("Failed to get CPU model from Windows Registry");
 		}
 
 		result = GetCPUArch();
@@ -83,7 +86,7 @@ namespace System
 		}
 		else
 		{
-			detail("Failed to get CPU arch. Couldn't read Windows Registry");
+			debug("Failed to get CPU arch from Windows Registry");
 		}
 	}
 
@@ -135,24 +138,20 @@ namespace System
 		{
 			m_arch = std::move(result.value());
 		}
+		else
+		{
+			debug("Failed to get CPU arch from uname(2)");
+		}
 
 		result = GetCPUModelFromCPUInfo();
 		if (result.has_value())
 		{
 			m_model = std::move(result.value());
-			return;
 		}
-
-		detail("Failed to get CPU model from '/proc/cpuinfo'");
-
-		result = GetCPUModelFromLSCPU();
-		if (result.has_value())
+		else
 		{
-			m_model = std::move(result.value());
-			return;
+			debug("Failed to get CPU model from /proc/cpuinfo");
 		}
-
-		detail("Failed to get CPU model from 'lscpu'");
 	}
 
 	std::optional<std::string> CPU::GetCPUModelFromCPUInfo() const
@@ -168,33 +167,21 @@ namespace System
 		{
 			if (line.find("model name") != std::string::npos ||
 				line.find("Processor") != std::string::npos ||
-				line.find("cpu model") != std::string::npos)
+				line.find("cpu model") != std::string::npos ||
+				line.find("Hardware") != std::string::npos ||
+				line.find("system type") != std::string::npos)
 			{
-				line = line.substr(line.find(":") + 1);
-				Util::Trim(line);
-				return line;
+				auto colonPos = line.find(":");
+				if (colonPos != std::string::npos)
+				{
+					std::string model = line.substr(colonPos + 1);
+					Util::Trim(model);
+					if (!model.empty())
+					{
+						return model;
+					}
+				}
 			}
-		}
-
-		return std::nullopt;
-	}
-
-	std::optional<std::string> CPU::GetCPUModelFromLSCPU() const
-	{
-		std::string cmd = "lscpu | grep \"Model name\"";
-		auto pipe = Util::MakePipe(cmd);
-		if (!pipe)
-		{
-			return std::nullopt;
-		}
-
-		char buffer[BUFFER_SIZE];
-		if (fgets(buffer, BUFFER_SIZE, pipe.get()))
-		{
-			std::string model{ buffer };
-			model = model.substr(model.find(":") + 1);
-			Util::Trim(model);
-			return model;
 		}
 
 		return std::nullopt;
@@ -217,7 +204,7 @@ namespace System
 		}
 		else
 		{
-			detail("Failed to get CPU model. Couldn't read 'hw.model'");
+			debug("Failed to get CPU model from sysctl(2): HW_MODEL");
 		}
 
 		auto result = GetCPUArch();
@@ -226,7 +213,6 @@ namespace System
 			m_arch = std::move(result.value());
 		}
 	}
-
 #endif
 
 #ifdef __APPLE__
@@ -241,7 +227,7 @@ namespace System
 		}
 		else
 		{
-			detail("Failed to get CPU model. Couldn't read 'machdep.cpu.brand_string'");
+			debug("Failed to get CPU model from sysctlbyname: machdep.cpu.brand_string");
 		}
 
 		auto result = GetCPUArch();
@@ -255,15 +241,13 @@ namespace System
 #ifndef WIN32
 	std::optional<std::string> CPU::GetCPUArch() const
 	{
-		auto res = Util::Uname("-m");
-		if (!res.has_value())
+		struct utsname uts;
+		if (uname(&uts) == 0 && uts.machine[0] != '\0')
 		{
-			detail("Failed to get CPU arch from 'uname-m'");
-
-			return std::nullopt;
+			return GetCanonicalCPUArch(uts.machine);
 		}
 
-		return GetCanonicalCPUArch(res.value());
+		return std::nullopt;
 	}
 #endif
 }

--- a/daemon/system/CPU.h
+++ b/daemon/system/CPU.h
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -40,7 +40,6 @@ namespace System
 
 #ifndef WIN32
 		std::optional<std::string> GetCPUModelFromCPUInfo() const;
-		std::optional<std::string> GetCPUModelFromLSCPU() const;
 #endif
 
 		std::string m_model;

--- a/daemon/system/OS.cpp
+++ b/daemon/system/OS.cpp
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,9 +21,8 @@
 #include "nzbget.h"
 
 #include "OS.h"
-#include "Util.h"
 #include "Log.h"
-#include "FileSystem.h"
+#include "Util.h"
 
 namespace System
 {
@@ -58,16 +57,14 @@ namespace System
 			buildBuffer,
 			&len))
 		{
-			detail("Failed to get OS version. Couldn't read from Windows Registry");
-
+			debug("Failed to get OS version: couldn't read CurrentBuild from Windows Registry");
 			return;
 		}
 
 		long buildNum = std::atol(buildBuffer);
 		if (buildNum == 0)
 		{
-			detail("Got invalid Windows version: %s", buildBuffer);
-
+			debug("Got invalid Windows build number: %s", buildBuffer);
 			return;
 		}
 
@@ -78,7 +75,7 @@ namespace System
 		else if (buildNum >= m_winXPBuildVersion) m_version = "XP";
 		else
 		{
-			detail("Unsupported Windows version");
+			debug("Unsupported Windows build number: %ld", buildNum);
 			return;
 		}
 
@@ -95,7 +92,7 @@ namespace System
 		}
 		else
 		{
-			detail("Failed to get OS update version. Couldn't read from Windows Registry");
+			debug("Failed to get OS display version from Windows Registry");
 		}
 
 		m_version += std::string(" (") + buildBuffer + ")";
@@ -104,9 +101,16 @@ namespace System
 
 #ifdef __linux__
 #include <fstream>
+#include <sys/utsname.h>
+
 	bool OS::IsRunningInDocker() const
 	{
 		return FileSystem::FileExists("/.dockerenv");
+	}
+
+	bool OS::IsRunningInContainer() const
+	{
+		return FileSystem::FileExists("/run/.containerenv");
 	}
 
 	void OS::TrimQuotes(std::string& str) const
@@ -126,35 +130,34 @@ namespace System
 	{
 		InitOSInfoFromOSRelease();
 
-		if (m_name.empty())
+		if (m_name.empty() || m_version.empty())
 		{
-			auto res = Util::Uname("-o");
-			if (res.has_value())
+			struct utsname uts;
+			if (uname(&uts) == 0)
 			{
-				m_name = std::move(res.value());
-			}
-			else
-			{
-				detail("Failed to get OS name. Couldn't read 'uname -o'");
-			}
-		}
+				if (m_name.empty() && uts.sysname[0] != '\0')
+				{
+					m_name = uts.sysname;
+				}
 
-		if (m_version.empty())
-		{
-			auto res = Util::Uname("-r");
-			if (res.has_value())
-			{
-				m_version = std::move(res.value());
+				if (m_version.empty() && uts.release[0] != '\0')
+				{
+					m_version = uts.release;
+				}
 			}
 			else
 			{
-				detail("Failed to get OS release. Couldn't read 'uname -r'");
+				debug("Failed to get OS info from uname(2)");
 			}
 		}
 
 		if (IsRunningInDocker())
 		{
 			m_version += " (Running in Docker)";
+		}
+		else if (IsRunningInContainer())
+		{
+			m_version += " (Running in Container)";
 		}
 	}
 
@@ -215,12 +218,12 @@ namespace System
 		auto pipe = Util::MakePipe(cmd);
 		if (!pipe)
 		{
-			detail("Failed to get OS info. Couldn't read 'sw_vers'");
+			debug("Failed to get OS info: couldn't run 'sw_vers'");
 			return;
 		}
 
 		char buffer[BUFFER_SIZE];
-		std::string result = "";
+		std::string result;
 		while (!feof(pipe.get()))
 		{
 			if (fgets(buffer, BUFFER_SIZE, pipe.get()))
@@ -239,7 +242,7 @@ namespace System
 		}
 		else
 		{
-			detail("Failed to get OS name. Couldn't find 'ProductName'");
+			debug("Failed to get OS name: 'ProductName' not found in sw_vers output");
 		}
 
 		std::string productVersion = "ProductVersion:";
@@ -252,7 +255,7 @@ namespace System
 		}
 		else
 		{
-			detail("Failed to get OS version. Couldn't find 'ProductVersion'");
+			debug("Failed to get OS version: 'ProductVersion' not found in sw_vers output");
 		}
 	}
 #endif
@@ -273,7 +276,7 @@ namespace System
 		}
 		else
 		{
-			detail("Failed to get OS name. Couldn't read 'kern.ostype'");
+			debug("Failed to get OS name from sysctl(2): KERN_OSTYPE");
 		}
 
 		len = BUFFER_SIZE;
@@ -286,7 +289,7 @@ namespace System
 		}
 		else
 		{
-			detail("Failed to get OS version. Couldn't to read 'kern.osrelease'");
+			debug("Failed to get OS version from sysctl(2): KERN_OSRELEASE");
 		}
 	}
 #endif

--- a/daemon/system/OS.cpp
+++ b/daemon/system/OS.cpp
@@ -110,7 +110,17 @@ namespace System
 
 	bool OS::IsRunningInContainer() const
 	{
-		return FileSystem::FileExists("/run/.containerenv");
+		if (std::getenv("container") != nullptr)
+		{
+			return true;
+		}
+
+		if (FileSystem::FileExists("/run/systemd/container") || FileSystem::FileExists("/run/.containerenv"))
+		{
+			return true;
+		}
+
+		return false;
 	}
 
 	void OS::TrimQuotes(std::string& str) const

--- a/daemon/system/OS.h
+++ b/daemon/system/OS.h
@@ -1,7 +1,7 @@
 /*
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
- *  Copyright (C) 2024 Denis <denis@nzbget.com>
+ *  Copyright (C) 2024-2026 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,7 +21,6 @@
 #define OS_H
 
 #include <string>
-#include <optional>
 
 namespace System
 {
@@ -39,6 +38,7 @@ namespace System
 
 #ifdef __linux__
 		bool IsRunningInDocker() const;
+		bool IsRunningInContainer() const;
 		void TrimQuotes(std::string& str) const;
 		void InitOSInfoFromOSRelease();
 #endif

--- a/daemon/util/Util.cpp
+++ b/daemon/util/Util.cpp
@@ -750,23 +750,6 @@ bool Util::RegReadStr(HKEY keyRoot, const char* keyName, const char* valueName, 
 	}
 	return false;
 }
-#else
-std::optional<std::string> Util::Uname(const char* key)
-{
-	std::string cmd = std::string("uname ") + key;
-
-	const size_t BUFFER_SIZE = 256;
-	auto pipe = Util::MakePipe(cmd);
-	char buffer[BUFFER_SIZE];
-	if (pipe && fgets(buffer, BUFFER_SIZE, pipe.get()))
-	{
-		std::string res{ buffer };
-		Util::Trim(res);
-		return res;
-	}
-
-	return std::nullopt;
-}
 #endif
 
 time_t Util::CurrentTime()

--- a/daemon/util/Util.h
+++ b/daemon/util/Util.h
@@ -219,8 +219,6 @@ public:
 
 #ifdef WIN32
 	static bool RegReadStr(HKEY keyRoot, const char* keyName, const char* valueName, char* buffer, int* bufLen);
-#else
-	static std::optional<std::string> Uname(const char* key);
 #endif
 
 	static void SetStandByMode(bool standBy);

--- a/tests/system/SystemInfo.cpp
+++ b/tests/system/SystemInfo.cpp
@@ -170,6 +170,9 @@ BOOST_AUTO_TEST_CASE(SystemInfoTest)
 
 	BOOST_CHECK(jsonStrResult == jsonStrExpected);
 	BOOST_CHECK(xmlStrResult == xmlStrExpected);
+	BOOST_CHECK(!sysInfo->GetOSInfo().GetName().empty());
+	BOOST_CHECK(!sysInfo->GetOSInfo().GetVersion().empty());
+	BOOST_CHECK(!sysInfo->GetCPUInfo().GetArch().empty());
 
 	xmlCleanupParser();
 }


### PR DESCRIPTION
## Description

- Replaced popen-based uname calls with POSIX uname(2), 
- Added a container detection
- Removed lscpu dependency
- Downgraded the logs to debug-level

## Testing
- macOS Tahoe
- Linux