### PR TITLE
CI: fix unrar install for macos tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Install dependencies
       run: |
         brew install --formula boost sevenzip
-        brew install --cask rar
+        curl -L https://github.com/nzbgetcom/unrar/releases/download/v7.23/unrar-7.23-macos-universal.tar.gz | sudo tar -xzf - -C /usr/local/bin
 
     - name: Checkout
       uses: actions/checkout@v6


### PR DESCRIPTION
## Description

Homebrew disabled the `rar` cask because it does not pass the macOS Gatekeeper check.
This PR replaces the installation of `unrar` via the `rar` cask with a direct download and extraction of the macOS `unrar` archive.
