### PR TITLE
Add FileTypes module for centralized file extension classification

### DIFF
--- a/daemon/main/nzbget.h
+++ b/daemon/main/nzbget.h
@@ -179,6 +179,7 @@
 #include <random>
 #include <exception>
 #include <iomanip>
+#include <span>
 
 #include <libxml/parser.h>
 #include <libxml/xmlreader.h>

--- a/daemon/postprocess/DirectUnpack.cpp
+++ b/daemon/postprocess/DirectUnpack.cpp
@@ -24,6 +24,7 @@
 #include "Log.h"
 #include "Util.h"
 #include "FileSystem.h"
+#include "FileTypes.h"
 #include "Options.h"
 
 void DirectUnpack::StartJob(NzbInfo* nzbInfo)
@@ -280,10 +281,19 @@ void DirectUnpack::FindArchiveFiles()
 
 bool DirectUnpack::IsMainArchive(const char* filename)
 {
+	if (!filename)
+	{
+		return false;
+	}
+
+	auto ext = FileSystem::GetFileExtension(filename);
+	if (!ext || !FileTypes::IsRarExt(*ext))
+	{
+		return false;
+	}
+
 	RegEx regExRarPart(".*\\.part([0-9]+)\\.rar$");
-	bool mainPart = Util::EndsWith(filename, ".rar", false) &&
-		(!regExRarPart.Match(filename) || atoi(filename + regExRarPart.GetMatchStart(1)) == 1);
-	return mainPart;
+	return !regExRarPart.Match(filename) || atoi(filename + regExRarPart.GetMatchStart(1)) == 1;
 }
 
 /**
@@ -567,11 +577,10 @@ void DirectUnpack::AddExtraTime(NzbInfo* nzbInfo)
 
 bool DirectUnpack::IsArchiveFilename(const char* filename)
 {
-	if (Util::EndsWith(filename, ".rar", false))
+	if (!filename)
 	{
-		return true;
+		return false;
 	}
 
-	RegEx regExRarMultiSeq(".*\\.[r-z][0-9][0-9]$");
-	return regExRarMultiSeq.Match(filename);
+	return FileTypes::IsRarFile(filename);
 }

--- a/daemon/sources.cmake
+++ b/daemon/sources.cmake
@@ -85,6 +85,7 @@ set(SRC
 	${CMAKE_SOURCE_DIR}/daemon/remote/MessageBase.h
 
 	${CMAKE_SOURCE_DIR}/daemon/util/FileSystem.cpp
+	${CMAKE_SOURCE_DIR}/daemon/util/FileTypes.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/Log.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/NString.cpp
 	${CMAKE_SOURCE_DIR}/daemon/util/Observer.cpp

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -713,13 +713,13 @@ std::string FileSystem::EscapePathForShell(const std::string& path)
 	return "\"" + path + "\"";
 }
 
-std::optional<std::string> FileSystem::GetFileExtension(const std::string& filename)
+std::optional<std::string> FileSystem::GetFileExtension(std::string_view filename)
 {
 	size_t extIdx = filename.rfind(".");
-	if (extIdx == std::string::npos)
+	if (extIdx == std::string_view::npos)
 		return std::nullopt;
 
-	return filename.substr(extIdx);
+	return std::string(filename.substr(extIdx));
 }
 
 /* Delete directory which is empty or contains only hidden files or directories (whose names start with dot) */

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -139,7 +139,7 @@ public:
 	static bool CreateDirectory(const char* dirFilename);
 	static std::string ExtractFilePathFromCmd(const std::string& path);
 	static std::string EscapePathForShell(const std::string& path);
-	static std::optional<std::string> GetFileExtension(const std::string& filename);
+	static std::optional<std::string> GetFileExtension(std::string_view filename);
 
 	/* Delete empty directory */
 	static bool RemoveDirectory(const char* dirFilename);

--- a/daemon/util/FileTypes.cpp
+++ b/daemon/util/FileTypes.cpp
@@ -1,0 +1,226 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "nzbget.h"
+
+#include "FileTypes.h"
+#include "Util.h"
+
+namespace
+{
+	bool MatchesAnyExt(std::string_view ext, std::span<const std::string_view> formats)
+	{
+		if (ext.empty() || ext[0] != '.')
+		{
+			return false;
+		}
+		return std::any_of(std::begin(formats), std::end(formats),
+			[&](std::string_view fmt) { return Util::StrCaseCmp(ext, fmt); });
+	}
+
+	std::string_view Basename(std::string_view path)
+	{
+		auto pos = path.find_last_of("/\\");
+		return pos == std::string_view::npos ? path : path.substr(pos + 1);
+	}
+
+	std::string_view StripLastExt(std::string_view filename)
+	{
+		auto pos = filename.rfind('.');
+		if (pos == std::string_view::npos || pos == 0)
+		{
+			return filename;
+		}
+		return filename.substr(0, pos);
+	}
+}
+
+namespace FileTypes
+{
+
+bool IsSevenZipExt(std::string_view ext)
+{
+	static constexpr std::string_view formats[] = {
+		".7z", ".zip", ".tar", ".gz", ".bz", ".bz2", ".tgz", ".txz", ".xz"
+	};
+	return MatchesAnyExt(ext, formats);
+}
+
+bool IsRarExt(std::string_view ext)
+{
+	return Util::StrCaseCmp(ext, ".rar");
+}
+
+bool IsRarVolumeExt(std::string_view ext)
+{
+	if (ext.size() != 4 || ext[0] != '.')
+	{
+		return false;
+	}
+	return std::tolower(static_cast<unsigned char>(ext[1])) >= 'r' &&
+		std::tolower(static_cast<unsigned char>(ext[1])) <= 'z' &&
+		std::isdigit(static_cast<unsigned char>(ext[2])) &&
+		std::isdigit(static_cast<unsigned char>(ext[3]));
+}
+
+bool IsAllDigitsExt(std::string_view ext)
+{
+	if (ext.size() < 2 || ext[0] != '.')
+	{
+		return false;
+	}
+	return std::all_of(ext.begin() + 1, ext.end(),
+		[](unsigned char c) { return std::isdigit(c); });
+}
+
+bool IsNumericVolumeExt(std::string_view ext)
+{
+	if (ext.size() != 4)
+	{
+		return false;
+	}
+	return IsAllDigitsExt(ext);
+}
+
+bool IsArchiveExt(std::string_view ext)
+{
+	return IsSevenZipExt(ext) || IsRarExt(ext) ||
+		IsRarVolumeExt(ext) || IsNumericVolumeExt(ext);
+}
+
+bool IsDiscStructureExt(std::string_view ext)
+{
+	static constexpr std::string_view formats[] = {
+		".vob", ".bdmv", ".mpls", ".mpl", ".clpi", ".cpi", ".bdm",
+		".ifo", ".bup",
+		".mts", ".m2ts"
+	};
+	return MatchesAnyExt(ext, formats);
+}
+
+bool IsParityExt(std::string_view ext)
+{
+	return Util::StrCaseCmp(ext, ".par2") || Util::StrCaseCmp(ext, ".sfv");
+}
+
+bool IsVideoExt(std::string_view ext)
+{
+	static constexpr std::string_view formats[] = {
+		".mkv", ".mp4", ".avi", ".mov", ".m2ts", ".mts", ".ts",
+		".m4v", ".webm", ".flv", ".wmv", ".divx", ".xvid"
+	};
+	return MatchesAnyExt(ext, formats);
+}
+
+bool IsAudioExt(std::string_view ext)
+{
+	static constexpr std::string_view formats[] = {
+		".mp3", ".flac", ".aac", ".ogg", ".wav", ".dts", ".ac3",
+		".mka", ".opus", ".wma", ".eac3"
+	};
+	return MatchesAnyExt(ext, formats);
+}
+
+bool IsSubtitleExt(std::string_view ext)
+{
+	static constexpr std::string_view formats[] = {
+		".srt", ".sub", ".idx", ".ass", ".ssa", ".smi", ".sup", ".pgs", ".vtt"
+	};
+	return MatchesAnyExt(ext, formats);
+}
+
+bool IsSampleStem(std::string_view stem)
+{
+	if (Util::StrCaseCmp(stem, "sample"))
+	{
+		return true;
+	}
+	if (stem.size() < 7)
+	{
+		return false;
+	}
+	std::string_view suffix = stem.substr(stem.size() - 7);
+	return Util::StrCaseCmp(suffix, "-sample") ||
+		   Util::StrCaseCmp(suffix, ".sample") ||
+		   Util::StrCaseCmp(suffix, "_sample");
+}
+
+bool IsSevenZipFile(std::string_view filename)
+{
+	auto bare = Basename(filename);
+	auto ext = FileSystem::GetFileExtension(bare).value_or("");
+	if (ext.empty())
+	{
+		return false;
+	}
+
+	if (Util::StrCaseCmp(ext, ".001") || Util::StrCaseCmp(ext, ".gz") ||
+		Util::StrCaseCmp(ext, ".bz2") || Util::StrCaseCmp(ext, ".xz"))
+	{
+		auto inner = StripLastExt(bare);
+		auto innerExt = FileSystem::GetFileExtension(inner).value_or("");
+		if (!innerExt.empty() && IsSevenZipExt(innerExt))
+		{
+			return true;
+		}
+	}
+
+	return IsSevenZipExt(ext);
+}
+
+bool IsRarFile(std::string_view filename)
+{
+	auto bare = Basename(filename);
+	auto ext = FileSystem::GetFileExtension(bare).value_or("");
+	if (ext.empty())
+	{
+		return false;
+	}
+
+	if (IsRarExt(ext) || IsRarVolumeExt(ext))
+	{
+		return true;
+	}
+
+	if (IsNumericVolumeExt(ext))
+	{
+		auto nested = FileSystem::GetFileExtension(StripLastExt(bare)).value_or("");
+		if (!nested.empty() && IsRarExt(nested))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool IsArchiveFile(std::string_view filename)
+{
+	return IsSevenZipFile(filename) || IsRarFile(filename);
+}
+
+bool IsSampleFile(std::string_view filename)
+{
+	auto bare = Basename(filename);
+	auto stem = StripLastExt(bare);
+	return IsSampleStem(stem);
+}
+
+}

--- a/daemon/util/FileTypes.h
+++ b/daemon/util/FileTypes.h
@@ -1,0 +1,49 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef FILETYPES_H
+#define FILETYPES_H
+
+#include <string_view>
+
+/**
+ * @brief Centralized utility functions for classifying file extensions.
+ */
+namespace FileTypes
+{
+	bool IsSevenZipExt(std::string_view ext);
+	bool IsRarExt(std::string_view ext);
+	bool IsRarVolumeExt(std::string_view ext);
+	bool IsNumericVolumeExt(std::string_view ext);
+	bool IsAllDigitsExt(std::string_view ext);
+	bool IsArchiveExt(std::string_view ext);
+	bool IsDiscStructureExt(std::string_view ext);
+	bool IsParityExt(std::string_view ext);
+	bool IsVideoExt(std::string_view ext);
+	bool IsAudioExt(std::string_view ext);
+	bool IsSubtitleExt(std::string_view ext);
+	bool IsSampleStem(std::string_view stem);
+	bool IsSevenZipFile(std::string_view filename);
+	bool IsRarFile(std::string_view filename);
+	bool IsArchiveFile(std::string_view filename);
+	bool IsSampleFile(std::string_view filename);
+}
+
+#endif

--- a/daemon/util/SevenZip.cpp
+++ b/daemon/util/SevenZip.cpp
@@ -20,6 +20,7 @@
 #include "nzbget.h"
 
 #include "Unpack.h"
+#include "FileTypes.h"
 #include "Util.h"
 
 using namespace Unpack;
@@ -65,14 +66,7 @@ bool SevenZip::IsSupported(const fs::path& path)
 {
 	if (!path.has_filename() || !path.has_extension()) return false;
 
-	auto filename = fs::u8string(path.filename());
-	std::transform(filename.begin(), filename.end(), filename.begin(),
-				   [](auto c) { return std::tolower(c); });
-	const static std::array<std::string_view, 9> formats{".7z", ".zip", ".7z.001", ".tar", ".gz",
-														 ".bz", ".bz2", ".tgz",	   ".txz"};
-
-	return std::any_of(formats.cbegin(), formats.cend(), [&](auto ext)
-					   { return Util::EndsWith(filename.c_str(), ext.data(), false); });
+	return FileTypes::IsSevenZipFile(fs::u8string(path.filename()));
 }
 
 bool SevenZip::DecodeExitCode(int ec) const

--- a/daemon/util/Unrar.cpp
+++ b/daemon/util/Unrar.cpp
@@ -20,9 +20,11 @@
 
 #include "nzbget.h"
 
+#include <algorithm>
 #include <regex>
 
 #include "Unpack.h"
+#include "FileTypes.h"
 #include "Util.h"
 
 using namespace Unpack;
@@ -70,17 +72,24 @@ bool Unrar::IsSupported(const fs::path& path)
 	if (!path.has_filename()) return false;
 
 	auto filename = fs::u8string(path.filename());
-	static const std::regex part1Rar("\\.part0*1\\.rar$", std::regex_constants::icase);
-	if (std::regex_search(filename, part1Rar)) return true;
+	auto ext = fs::u8string(path.extension());
 
-	std::transform(filename.begin(), filename.end(), filename.begin(), ::tolower);
-	if (filename.find(".part") == std::string::npos &&
-		Util::EndsWith(filename.c_str(), ".rar", false))
+	if (!FileTypes::IsRarExt(ext))
 	{
-		return true;
+		return false;
 	}
 
-	return false;
+	static const std::regex part1Rar("\\.part0*1\\.rar$", std::regex_constants::icase);
+
+	std::string lowerFilename = filename;
+	std::transform(lowerFilename.begin(), lowerFilename.end(), lowerFilename.begin(),
+		[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+	if (lowerFilename.find(".part") != std::string::npos)
+	{
+		return std::regex_search(filename, part1Rar);
+	}
+
+	return true;
 }
 
 bool Unrar::DecodeExitCode(int ec) const

--- a/daemon/util/Util.cpp
+++ b/daemon/util/Util.cpp
@@ -602,34 +602,34 @@ std::vector<CString> Util::SplitStr(const char* str, const char* separators)
 	return result;
 }
 
+bool Util::EndsWith(std::string_view str, std::string_view suffix, bool caseSensitive)
+{
+	if (suffix.empty())
+	{
+		return true;
+	}
+	if (str.size() < suffix.size())
+	{
+		return false;
+	}
+	if (caseSensitive)
+	{
+		return str.ends_with(suffix);
+	}
+	return StrCaseCmp(str.substr(str.size() - suffix.size()), suffix);
+}
+
 bool Util::EndsWith(const char* str, const char* suffix, bool caseSensitive)
 {
 	if (!str)
 	{
 		return false;
 	}
-
 	if (EmptyStr(suffix))
 	{
 		return true;
 	}
-
-	int lenStr = strlen(str);
-	int lenSuf = strlen(suffix);
-
-	if (lenSuf > lenStr)
-	{
-		return false;
-	}
-
-	if (caseSensitive)
-	{
-		return !strcmp(str + lenStr - lenSuf, suffix);
-	}
-	else
-	{
-		return !strcasecmp(str + lenStr - lenSuf, suffix);
-	}
+	return EndsWith(std::string_view(str), std::string_view(suffix), caseSensitive);
 }
 
 bool Util::AlphaNum(const char* str)
@@ -836,14 +836,14 @@ time_t Util::Timegm(tm const *t)
 	return internal_timegm(t);
 }
 
-bool Util::StrCaseCmp(const std::string& a, const std::string& b)
+bool Util::StrCaseCmp(std::string_view a, std::string_view b)
 {
-	auto comparator = [](unsigned char a, unsigned char b)
-	{
-		return std::tolower(a) == std::tolower(b);
-	};
-
-    return std::equal(a.begin(), a.end(), b.begin(), b.end(), comparator);
+	return std::equal(a.begin(), a.end(), b.begin(), b.end(),
+		[](unsigned char ca, unsigned char cb)
+		{
+			return std::tolower(ca) == std::tolower(cb);
+		}
+	);
 }
 
 // prevent PC from going to sleep

--- a/daemon/util/Util.h
+++ b/daemon/util/Util.h
@@ -112,6 +112,7 @@ public:
 	static void Trim(std::string& str);
 	static bool EmptyStr(const char* str) { return !str || !*str; }
 	static std::vector<CString> SplitStr(const char* str, const char* separators);
+	static bool EndsWith(std::string_view str, std::string_view suffix, bool caseSensitive);
 	static bool EndsWith(const char* str, const char* suffix, bool caseSensitive);
 	static bool AlphaNum(const char* str);
 
@@ -230,7 +231,7 @@ public:
 	/* cross platform version of GNU timegm, which is similar to mktime but takes an UTC time as parameter */
 	static time_t Timegm(tm const *t);
 
-	static bool StrCaseCmp(const std::string& a, const std::string& b);
+	static bool StrCaseCmp(std::string_view a, std::string_view b);
 
 	static void FormatTime(time_t timeSec, char* buffer, int bufsize);
 	static CString FormatTime(time_t timeSec);

--- a/tests/util/FileTypes.cpp
+++ b/tests/util/FileTypes.cpp
@@ -1,0 +1,308 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+#include "FileTypes.h"
+
+BOOST_AUTO_TEST_SUITE(UtilTest)
+
+BOOST_AUTO_TEST_CASE(IsSevenZipExtTest)
+{
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".7z"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".7Z"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".zip"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".ZIP"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".tar"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".gz"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".bz"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".bz2"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".tgz"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".txz"));
+	BOOST_CHECK(FileTypes::IsSevenZipExt(".xz"));
+
+	BOOST_CHECK(!FileTypes::IsSevenZipExt(".rar"));
+	BOOST_CHECK(!FileTypes::IsSevenZipExt(".r00"));
+	BOOST_CHECK(!FileTypes::IsSevenZipExt(".001"));
+	BOOST_CHECK(!FileTypes::IsSevenZipExt(""));
+	BOOST_CHECK(!FileTypes::IsSevenZipExt(".7z.001"));
+}
+
+BOOST_AUTO_TEST_CASE(IsRarExtTest)
+{
+	BOOST_CHECK(FileTypes::IsRarExt(".rar"));
+	BOOST_CHECK(FileTypes::IsRarExt(".RAR"));
+
+	BOOST_CHECK(!FileTypes::IsRarExt(".r00"));
+	BOOST_CHECK(!FileTypes::IsRarExt(".zip"));
+	BOOST_CHECK(!FileTypes::IsRarExt(".7z"));
+	BOOST_CHECK(!FileTypes::IsRarExt(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsRarVolumeExtTest)
+{
+	BOOST_CHECK(FileTypes::IsRarVolumeExt(".r00"));
+	BOOST_CHECK(FileTypes::IsRarVolumeExt(".r99"));
+	BOOST_CHECK(FileTypes::IsRarVolumeExt(".z00"));
+	BOOST_CHECK(FileTypes::IsRarVolumeExt(".z99"));
+	BOOST_CHECK(FileTypes::IsRarVolumeExt(".R00"));
+	BOOST_CHECK(FileTypes::IsRarVolumeExt(".s00"));
+
+	BOOST_CHECK(!FileTypes::IsRarVolumeExt(".rar"));
+	BOOST_CHECK(!FileTypes::IsRarVolumeExt(".000"));
+	BOOST_CHECK(!FileTypes::IsRarVolumeExt(".a00"));
+	BOOST_CHECK(!FileTypes::IsRarVolumeExt(".r0"));
+	BOOST_CHECK(!FileTypes::IsRarVolumeExt(".r000"));
+	BOOST_CHECK(!FileTypes::IsRarVolumeExt(".r0000"));
+	BOOST_CHECK(!FileTypes::IsRarVolumeExt(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsNumericVolumeExtTest)
+{
+	BOOST_CHECK(FileTypes::IsNumericVolumeExt(".000"));
+	BOOST_CHECK(FileTypes::IsNumericVolumeExt(".001"));
+	BOOST_CHECK(FileTypes::IsNumericVolumeExt(".999"));
+
+	BOOST_CHECK(!FileTypes::IsNumericVolumeExt(".0000"));
+	BOOST_CHECK(!FileTypes::IsNumericVolumeExt(".00"));
+	BOOST_CHECK(!FileTypes::IsNumericVolumeExt(".00000"));
+	BOOST_CHECK(!FileTypes::IsNumericVolumeExt(".r00"));
+	BOOST_CHECK(!FileTypes::IsNumericVolumeExt(".abc"));
+	BOOST_CHECK(!FileTypes::IsNumericVolumeExt(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsAllDigitsExtTest)
+{
+	BOOST_CHECK(FileTypes::IsAllDigitsExt(".1"));
+	BOOST_CHECK(FileTypes::IsAllDigitsExt(".15"));
+	BOOST_CHECK(FileTypes::IsAllDigitsExt(".001"));
+	BOOST_CHECK(FileTypes::IsAllDigitsExt(".0000"));
+	BOOST_CHECK(FileTypes::IsAllDigitsExt(".999"));
+
+	BOOST_CHECK(!FileTypes::IsAllDigitsExt("."));
+	BOOST_CHECK(!FileTypes::IsAllDigitsExt(""));
+	BOOST_CHECK(!FileTypes::IsAllDigitsExt(".abc"));
+	BOOST_CHECK(!FileTypes::IsAllDigitsExt(".1a"));
+}
+
+BOOST_AUTO_TEST_CASE(IsArchiveExtTest)
+{
+	BOOST_CHECK(FileTypes::IsArchiveExt(".rar"));
+	BOOST_CHECK(FileTypes::IsArchiveExt(".7z"));
+	BOOST_CHECK(FileTypes::IsArchiveExt(".zip"));
+	BOOST_CHECK(FileTypes::IsArchiveExt(".r00"));
+	BOOST_CHECK(FileTypes::IsArchiveExt(".001"));
+
+	BOOST_CHECK(!FileTypes::IsArchiveExt(".mkv"));
+	BOOST_CHECK(!FileTypes::IsArchiveExt(".mp4"));
+	BOOST_CHECK(!FileTypes::IsArchiveExt(".par2"));
+	BOOST_CHECK(!FileTypes::IsArchiveExt(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsDiscStructureExtTest)
+{
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".vob"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".bdmv"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".mpls"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".mpl"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".clpi"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".cpi"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".bdm"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".ifo"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".bup"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".mts"));
+	BOOST_CHECK(FileTypes::IsDiscStructureExt(".m2ts"));
+
+	BOOST_CHECK(!FileTypes::IsDiscStructureExt(".rar"));
+	BOOST_CHECK(!FileTypes::IsDiscStructureExt(".mkv"));
+	BOOST_CHECK(!FileTypes::IsDiscStructureExt(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsParityExtTest)
+{
+	BOOST_CHECK(FileTypes::IsParityExt(".par2"));
+	BOOST_CHECK(FileTypes::IsParityExt(".PAR2"));
+	BOOST_CHECK(FileTypes::IsParityExt(".sfv"));
+	BOOST_CHECK(FileTypes::IsParityExt(".SFV"));
+
+	BOOST_CHECK(!FileTypes::IsParityExt(".rar"));
+	BOOST_CHECK(!FileTypes::IsParityExt(".par"));
+	BOOST_CHECK(!FileTypes::IsParityExt(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsVideoExtTest)
+{
+	BOOST_CHECK(FileTypes::IsVideoExt(".mkv"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".mp4"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".avi"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".mov"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".m2ts"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".ts"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".m4v"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".webm"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".flv"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".wmv"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".divx"));
+	BOOST_CHECK(FileTypes::IsVideoExt(".xvid"));
+
+	BOOST_CHECK(!FileTypes::IsVideoExt(".rar"));
+	BOOST_CHECK(!FileTypes::IsVideoExt(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsAudioExtTest)
+{
+	BOOST_CHECK(FileTypes::IsAudioExt(".mp3"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".flac"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".aac"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".ogg"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".wav"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".dts"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".ac3"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".mka"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".opus"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".wma"));
+	BOOST_CHECK(FileTypes::IsAudioExt(".eac3"));
+
+	BOOST_CHECK(!FileTypes::IsAudioExt(".rar"));
+	BOOST_CHECK(!FileTypes::IsAudioExt(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsSubtitleExtTest)
+{
+	BOOST_CHECK(FileTypes::IsSubtitleExt(".srt"));
+	BOOST_CHECK(FileTypes::IsSubtitleExt(".sub"));
+	BOOST_CHECK(FileTypes::IsSubtitleExt(".idx"));
+	BOOST_CHECK(FileTypes::IsSubtitleExt(".ass"));
+	BOOST_CHECK(FileTypes::IsSubtitleExt(".ssa"));
+	BOOST_CHECK(FileTypes::IsSubtitleExt(".smi"));
+	BOOST_CHECK(FileTypes::IsSubtitleExt(".sup"));
+	BOOST_CHECK(FileTypes::IsSubtitleExt(".pgs"));
+	BOOST_CHECK(FileTypes::IsSubtitleExt(".vtt"));
+
+	BOOST_CHECK(!FileTypes::IsSubtitleExt(".rar"));
+	BOOST_CHECK(!FileTypes::IsSubtitleExt(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsSampleStemTest)
+{
+	BOOST_CHECK(FileTypes::IsSampleStem("sample"));
+	BOOST_CHECK(FileTypes::IsSampleStem("SAMPLE"));
+	BOOST_CHECK(FileTypes::IsSampleStem("Sample"));
+	BOOST_CHECK(FileTypes::IsSampleStem("file-sample"));
+	BOOST_CHECK(FileTypes::IsSampleStem("file.sample"));
+	BOOST_CHECK(FileTypes::IsSampleStem("file_sample"));
+	BOOST_CHECK(FileTypes::IsSampleStem("not-a-sample"));
+	BOOST_CHECK(FileTypes::IsSampleStem("Movie.Name.2020.1080p.BluRay.x264-Group-sample"));
+
+	BOOST_CHECK(!FileTypes::IsSampleStem("samples"));
+	BOOST_CHECK(!FileTypes::IsSampleStem("mysample"));
+	BOOST_CHECK(!FileTypes::IsSampleStem("sam"));
+	BOOST_CHECK(!FileTypes::IsSampleStem(""));
+}
+
+BOOST_AUTO_TEST_CASE(IsSevenZipFileTest)
+{
+	// Simple extensions
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.7z"));
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.zip"));
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.tar"));
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.tgz"));
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.txz"));
+
+	// Compound: .tar.gz, .tar.bz2, .tar.xz
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.tar.gz"));
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.tar.bz2"));
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.tar.xz"));
+
+	// Split 7z
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.7z.001"));
+
+	// Case insensitive
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.ZIP"));
+	BOOST_CHECK(FileTypes::IsSevenZipFile("archive.TAR.GZ"));
+
+	// With path
+	BOOST_CHECK(FileTypes::IsSevenZipFile("/tmp/archive.7z"));
+	BOOST_CHECK(FileTypes::IsSevenZipFile("/home/user/my archive.zip"));
+
+	// Not 7z
+	BOOST_CHECK(!FileTypes::IsSevenZipFile("archive.rar"));
+	BOOST_CHECK(!FileTypes::IsSevenZipFile("archive.mkv"));
+	BOOST_CHECK(!FileTypes::IsSevenZipFile("archive.7z.002"));
+	BOOST_CHECK(!FileTypes::IsSevenZipFile("noextension"));
+}
+
+BOOST_AUTO_TEST_CASE(IsRarFileTest)
+{
+	// Simple .rar
+	BOOST_CHECK(FileTypes::IsRarFile("archive.rar"));
+	BOOST_CHECK(FileTypes::IsRarFile("archive.RAR"));
+
+	// RAR volumes
+	BOOST_CHECK(FileTypes::IsRarFile("archive.r00"));
+	BOOST_CHECK(FileTypes::IsRarFile("archive.z99"));
+	BOOST_CHECK(FileTypes::IsRarFile("archive.R00"));
+
+	// Split .rar
+	BOOST_CHECK(FileTypes::IsRarFile("archive.part01.rar"));
+	BOOST_CHECK(FileTypes::IsRarFile("archive.part1.rar"));
+	BOOST_CHECK(FileTypes::IsRarFile("archive.part001.rar"));
+
+	// With path
+	BOOST_CHECK(FileTypes::IsRarFile("/tmp/archive.rar"));
+
+	// Not RAR
+	BOOST_CHECK(!FileTypes::IsRarFile("archive.7z"));
+	BOOST_CHECK(!FileTypes::IsRarFile("archive.zip"));
+	BOOST_CHECK(!FileTypes::IsRarFile("archive.mkv"));
+	BOOST_CHECK(!FileTypes::IsRarFile("archive.001"));
+	BOOST_CHECK(!FileTypes::IsRarFile("noextension"));
+}
+
+BOOST_AUTO_TEST_CASE(IsArchiveFileTest)
+{
+	BOOST_CHECK(FileTypes::IsArchiveFile("archive.rar"));
+	BOOST_CHECK(FileTypes::IsArchiveFile("archive.7z"));
+	BOOST_CHECK(FileTypes::IsArchiveFile("archive.zip"));
+	BOOST_CHECK(FileTypes::IsArchiveFile("archive.r00"));
+	BOOST_CHECK(FileTypes::IsArchiveFile("archive.7z.001"));
+
+	BOOST_CHECK(!FileTypes::IsArchiveFile("file.mkv"));
+	BOOST_CHECK(!FileTypes::IsArchiveFile("file.par2"));
+	BOOST_CHECK(!FileTypes::IsArchiveFile("noextension"));
+}
+
+BOOST_AUTO_TEST_CASE(IsSampleFileTest)
+{
+	BOOST_CHECK(FileTypes::IsSampleFile("sample.mkv"));
+	BOOST_CHECK(FileTypes::IsSampleFile("SAMPLE.avi"));
+	BOOST_CHECK(FileTypes::IsSampleFile("file-sample.mkv"));
+	BOOST_CHECK(FileTypes::IsSampleFile("file.sample.mkv"));
+	BOOST_CHECK(FileTypes::IsSampleFile("file_sample.mkv"));
+	// With path
+	BOOST_CHECK(FileTypes::IsSampleFile("/tmp/sample.mkv"));
+
+	BOOST_CHECK(!FileTypes::IsSampleFile("samples.mkv"));
+	BOOST_CHECK(!FileTypes::IsSampleFile("mysample.mkv"));
+	BOOST_CHECK(!FileTypes::IsSampleFile("file.mkv"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/util/util.cmake
+++ b/tests/util/util.cmake
@@ -1,5 +1,6 @@
 list(APPEND TESTS_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/util/FileSystem.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/util/FileTypes.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/util/Util.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/util/NString.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/util/Json.cpp


### PR DESCRIPTION
## Description

Replaces scattered extension checks in DirectUnpack, SevenZip, and Unrar with a unified FileTypes API.

## Testing

- macOS Tahoe