### PR TITLE
Add HTTP proxy support for URL downloads

### DIFF
--- a/daemon/connect/Connection.cpp
+++ b/daemon/connect/Connection.cpp
@@ -984,11 +984,12 @@ void Connection::PrintError(const char* errMsg)
 }
 
 #ifndef DISABLE_TLS
-bool Connection::StartTls(bool isClient, const char* certFile, const char* keyFile)
+bool Connection::StartTls(bool isClient, const char* certFile, const char* keyFile, const char* host)
 {
 	debug("Starting TLS");
 
-	m_tlsSocket = std::make_unique<TlsSocket>(m_socket, isClient, m_host.c_str(), certFile, keyFile, m_cipher.c_str(), m_certVerifLevel);
+	const char* tlsHost = host && *host ? host : m_host.c_str();
+	m_tlsSocket = std::make_unique<TlsSocket>(m_socket, isClient, tlsHost, certFile, keyFile, m_cipher.c_str(), m_certVerifLevel);
 	m_tlsSocket->SetSuppressErrors(m_suppressErrors);
 
 	return m_tlsSocket->Start();

--- a/daemon/connect/Connection.h
+++ b/daemon/connect/Connection.h
@@ -80,7 +80,7 @@ public:
 	void SetGracefull(bool gracefull) { m_gracefull = gracefull; }
 	void SetForceClose(bool forceClose) { m_forceClose = forceClose; }
 #ifndef DISABLE_TLS
-	bool StartTls(bool isClient, const char* certFile, const char* keyFile);
+	bool StartTls(bool isClient, const char* certFile, const char* keyFile, const char* host = nullptr);
 	void SetCertVerifLevel(unsigned int level) { m_certVerifLevel = level; }
 #endif
 	int FetchTotalBytesRead();

--- a/daemon/connect/WebDownloader.cpp
+++ b/daemon/connect/WebDownloader.cpp
@@ -19,6 +19,8 @@
  */
 
 
+#include <cstdint>
+
 #include "nzbget.h"
 #include "WebDownloader.h"
 #include "Log.h"
@@ -26,6 +28,210 @@
 #include "WorkState.h"
 #include "Util.h"
 #include "FileSystem.h"
+
+namespace
+{
+std::string Base64Encode(const std::string& input)
+{
+	static constexpr char alphabet[] =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+	std::string output;
+	output.reserve(((input.size() + 2) / 3) * 4);
+
+	for (size_t i = 0; i < input.size(); i += 3)
+	{
+		unsigned int value = static_cast<unsigned char>(input[i]) << 16;
+		bool hasSecond = i + 1 < input.size();
+		bool hasThird = i + 2 < input.size();
+		if (hasSecond)
+		{
+			value |= static_cast<unsigned char>(input[i + 1]) << 8;
+		}
+		if (hasThird)
+		{
+			value |= static_cast<unsigned char>(input[i + 2]);
+		}
+
+		output.push_back(alphabet[(value >> 18) & 0x3f]);
+		output.push_back(alphabet[(value >> 12) & 0x3f]);
+		output.push_back(hasSecond ? alphabet[(value >> 6) & 0x3f] : '=');
+		output.push_back(hasThird ? alphabet[value & 0x3f] : '=');
+	}
+
+	return output;
+}
+
+std::string TrimProxyBypassRule(const std::string& value)
+{
+	size_t first = value.find_first_not_of(" \t");
+	if (first == std::string::npos)
+	{
+		return {};
+	}
+
+	size_t last = value.find_last_not_of(" \t");
+	return value.substr(first, last - first + 1);
+}
+
+bool ParseIpv4Address(const std::string& value, std::uint32_t& address)
+{
+	address = 0;
+	size_t pos = 0;
+
+	for (int part = 0; part < 4; part++)
+	{
+		if (pos >= value.size())
+		{
+			return false;
+		}
+
+		unsigned int octet = 0;
+		int digits = 0;
+		while (pos < value.size() && value[pos] >= '0' && value[pos] <= '9')
+		{
+			octet = octet * 10 + static_cast<unsigned int>(value[pos] - '0');
+			if (octet > 255)
+			{
+				return false;
+			}
+			pos++;
+			digits++;
+		}
+
+		if (digits == 0)
+		{
+			return false;
+		}
+
+		address = (address << 8) | octet;
+		if (part < 3)
+		{
+			if (pos >= value.size() || value[pos] != '.')
+			{
+				return false;
+			}
+			pos++;
+		}
+	}
+
+	return pos == value.size();
+}
+
+bool ParseCidrPrefix(const std::string& value, unsigned int& prefix)
+{
+	if (value.empty())
+	{
+		return false;
+	}
+
+	prefix = 0;
+	for (char ch : value)
+	{
+		if (ch < '0' || ch > '9')
+		{
+			return false;
+		}
+		prefix = prefix * 10 + static_cast<unsigned int>(ch - '0');
+		if (prefix > 32)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool EndsWithNoCase(const std::string& value, const std::string& suffix)
+{
+	return value.size() >= suffix.size() &&
+		!strcasecmp(value.c_str() + value.size() - suffix.size(), suffix.c_str());
+}
+
+bool MatchesIpv4Cidr(const char* host, const std::string& rule)
+{
+	size_t slash = rule.find('/');
+	if (slash == std::string::npos || rule.find('/', slash + 1) != std::string::npos)
+	{
+		return false;
+	}
+
+	std::uint32_t hostAddress = 0;
+	std::uint32_t networkAddress = 0;
+	unsigned int prefix = 0;
+	if (!ParseIpv4Address(host ? host : "", hostAddress) ||
+		!ParseIpv4Address(rule.substr(0, slash), networkAddress) ||
+		!ParseCidrPrefix(rule.substr(slash + 1), prefix))
+	{
+		return false;
+	}
+
+	std::uint32_t mask = prefix == 0 ? 0 : 0xffffffffu << (32 - prefix);
+	return (hostAddress & mask) == (networkAddress & mask);
+}
+
+bool MatchesProxyBypassRule(const char* host, const std::string& rule)
+{
+	if (!host || !*host || rule.empty())
+	{
+		return false;
+	}
+
+	if (rule.find('/') != std::string::npos)
+	{
+		return MatchesIpv4Cidr(host, rule);
+	}
+
+	if (!strcasecmp(host, rule.c_str()))
+	{
+		return true;
+	}
+
+	std::string hostName(host);
+	if (rule.size() > 2 && rule[0] == '*' && rule[1] == '.')
+	{
+		std::string suffix = rule.substr(1);
+		return hostName.size() > suffix.size() && EndsWithNoCase(hostName, suffix);
+	}
+
+	if (rule.size() > 1 && rule[0] == '.')
+	{
+		return !strcasecmp(host, rule.c_str() + 1) || EndsWithNoCase(hostName, rule);
+	}
+
+	return false;
+}
+
+bool IsProxyBypassed(const char* host, const char* bypassList)
+{
+	if (!host || !*host || Util::EmptyStr(bypassList))
+	{
+		return false;
+	}
+
+	std::string rules(bypassList);
+	size_t start = 0;
+	while (start <= rules.size())
+	{
+		size_t end = rules.find_first_of(",;", start);
+		std::string rule = TrimProxyBypassRule(rules.substr(
+			start, end == std::string::npos ? std::string::npos : end - start));
+		if (!rule.empty() && MatchesProxyBypassRule(host, rule))
+		{
+			return true;
+		}
+
+		if (end == std::string::npos)
+		{
+			break;
+		}
+		start = end + 1;
+	}
+
+	return false;
+}
+
+}
 
 WebDownloader::WebDownloader()
 	: m_contentLen(0)
@@ -161,6 +367,16 @@ WebDownloader::EStatus WebDownloader::Download()
 		return adConnectError;
 	}
 
+	if (m_proxy && !strcasecmp(url.GetProtocol(), "https"))
+	{
+		Status = CreateProxyTunnel(&url);
+		if (Status != adRunning || IsStopped())
+		{
+			FreeConnection();
+			return Status == adRunning ? adConnectError : Status;
+		}
+	}
+
 	// Okay, we got a Connection. Now start downloading.
 	detail("Downloading %s", *m_infoName);
 
@@ -241,8 +457,21 @@ WebDownloader::EStatus WebDownloader::CreateConnection(URL *url)
 #endif
 
 	bool tls = !strcasecmp(url->GetProtocol(), "https");
+	m_proxy = !Util::EmptyStr(g_Options->GetUrlProxyHost());
+	if (m_proxy && IsProxyBypassed(url->GetHost(), g_Options->GetUrlProxyBypass()))
+	{
+		debug("Bypassing URL proxy for host %s", url->GetHost());
+		m_proxy = false;
+	}
 
-	m_connection = std::make_unique<Connection>(url->GetHost(), port, tls);
+	if (m_proxy)
+	{
+		m_connection = std::make_unique<Connection>(g_Options->GetUrlProxyHost(), g_Options->GetUrlProxyPort(), false);
+	}
+	else
+	{
+		m_connection = std::make_unique<Connection>(url->GetHost(), port, tls);
+	}
 
 #ifndef DISABLE_TLS
 	m_connection->SetCertVerifLevel(m_certVerifLevel);
@@ -254,8 +483,29 @@ WebDownloader::EStatus WebDownloader::CreateConnection(URL *url)
 void WebDownloader::SendHeaders(URL *url)
 {
 	// retrieve file
-	m_connection->WriteLine(BString<1024>("GET %s HTTP/1.0\r\n", url->GetResource()));
+	if (m_proxy && !strcasecmp(url->GetProtocol(), "http"))
+	{
+		std::string request = "GET http://";
+		request += url->GetHost();
+		if (url->GetPort() != 80 && url->GetPort() != 0)
+		{
+			request += ':';
+			request += std::to_string(url->GetPort());
+		}
+		request += url->GetResource();
+		request += " HTTP/1.0\r\n";
+		m_connection->WriteLine(request.c_str());
+	}
+	else
+	{
+		m_connection->WriteLine(BString<1024>("GET %s HTTP/1.0\r\n", url->GetResource()));
+	}
 	m_connection->WriteLine(BString<1024>("User-Agent: nzbget/%s\r\n", Util::VersionRevision()));
+
+	if (m_proxy && !strcasecmp(url->GetProtocol(), "http"))
+	{
+		SendProxyAuthorization();
+	}
 
 	if ((!strcasecmp(url->GetProtocol(), "http") && (url->GetPort() == 80 || url->GetPort() == 0)) ||
 		(!strcasecmp(url->GetProtocol(), "https") && (url->GetPort() == 443 || url->GetPort() == 0)))
@@ -273,6 +523,81 @@ void WebDownloader::SendHeaders(URL *url)
 #endif
 	m_connection->WriteLine("Connection: close\r\n");
 	m_connection->WriteLine("\r\n");
+}
+
+void WebDownloader::SendProxyAuthorization()
+{
+	const char* username = g_Options->GetUrlProxyUsername();
+	const char* password = g_Options->GetUrlProxyPassword();
+	if (Util::EmptyStr(username) && Util::EmptyStr(password))
+	{
+		return;
+	}
+
+	std::string credentials = username ? username : "";
+	credentials += ':';
+	credentials += password ? password : "";
+	std::string encoded = Base64Encode(credentials);
+	std::string header = "Proxy-Authorization: Basic ";
+	header += encoded;
+	header += "\r\n";
+	m_connection->WriteLine(header.c_str());
+}
+
+WebDownloader::EStatus WebDownloader::CreateProxyTunnel(URL *url)
+{
+	int port = url->GetPort() == 0 ? 443 : url->GetPort();
+	m_connection->WriteLine(BString<1024>("CONNECT %s:%i HTTP/1.1\r\n", url->GetHost(), port));
+	m_connection->WriteLine(BString<1024>("Host: %s:%i\r\n", url->GetHost(), port));
+	m_connection->WriteLine(BString<1024>("User-Agent: nzbget/%s\r\n", Util::VersionRevision()));
+	SendProxyAuthorization();
+	m_connection->WriteLine("\r\n");
+
+	CharBuffer lineBuf(1024 * 10);
+	int len = 0;
+	char* line = m_connection->ReadLine(lineBuf, lineBuf.Size(), &len);
+	if (!line)
+	{
+		warn("URL %s: proxy closed connection while creating tunnel", *m_infoName);
+		return adConnectError;
+	}
+
+	Util::TrimRight(line);
+	const char* status = strchr(line, ' ');
+	if (strncmp(line, "HTTP/", 5) || !status || status[1] != '2')
+	{
+		warn("URL %s: proxy tunnel failed: %s", *m_infoName, line);
+		return adConnectError;
+	}
+
+	while (!IsStopped())
+	{
+		line = m_connection->ReadLine(lineBuf, lineBuf.Size(), &len);
+		if (!line)
+		{
+			warn("URL %s: proxy closed connection while creating tunnel", *m_infoName);
+			return adConnectError;
+		}
+		if (*line == '\r' || *line == '\n')
+		{
+			break;
+		}
+	}
+
+	if (IsStopped())
+	{
+		return adConnectError;
+	}
+
+#ifndef DISABLE_TLS
+	if (!m_connection->StartTls(true, "", "", url->GetHost()))
+	{
+		warn("URL %s: TLS handshake through proxy failed", *m_infoName);
+		return adConnectError;
+	}
+#endif
+
+	return adRunning;
 }
 
 WebDownloader::EStatus WebDownloader::DownloadHeaders()

--- a/daemon/connect/WebDownloader.h
+++ b/daemon/connect/WebDownloader.h
@@ -89,6 +89,7 @@ private:
 	bool m_redirected;
 	bool m_gzip;
 	bool m_retry = true;
+	bool m_proxy = false;
 #ifndef DISABLE_TLS
 	unsigned int m_certVerifLevel = Options::ECertVerifLevel::cvStrict;
 #endif
@@ -102,8 +103,10 @@ private:
 	void FreeConnection();
 	EStatus CheckResponse(const char* response);
 	EStatus CreateConnection(URL *url);
+	EStatus CreateProxyTunnel(URL *url);
 	void ParseFilename(const char* contentDisposition);
 	void SendHeaders(URL *url);
+	void SendProxyAuthorization();
 	EStatus DownloadHeaders();
 	EStatus DownloadBody();
 	void ParseRedirect(const char* location);

--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -316,6 +316,11 @@ void Options::InitDefaults()
 	SetOption(ARTICLETIMEOUT.data(), "60");
 	SetOption(ARTICLEREADCHUNKSIZE.data(), "4");
 	SetOption(URLTIMEOUT.data(), "60");
+	SetOption(URLPROXYHOST.data(), "");
+	SetOption(URLPROXYPORT.data(), "8080");
+	SetOption(URLPROXYUSERNAME.data(), "");
+	SetOption(URLPROXYPASSWORD.data(), "");
+	SetOption(URLPROXYBYPASS.data(), "");
 	SetOption(REMOTETIMEOUT.data(), "90");
 	SetOption(FLUSHQUEUE.data(), "yes");
 	SetOption(SYSTEMHEALTHCHECK.data(), "yes");
@@ -592,6 +597,10 @@ void Options::InitOptions()
 	m_secureCert			= GetOption(SECURECERT.data());
 	m_secureKey				= GetOption(SECUREKEY.data());
 	m_certStore				= GetOption(CERTSTORE.data());
+	m_urlProxyHost			= GetOption(URLPROXYHOST.data());
+	m_urlProxyUsername		= GetOption(URLPROXYUSERNAME.data());
+	m_urlProxyPassword		= GetOption(URLPROXYPASSWORD.data());
+	m_urlProxyBypass			= GetOption(URLPROXYBYPASS.data());
 	m_authorizedIp			= GetOption(AUTHORIZEDIP.data());
 	m_lockFile				= GetOption(LOCKFILE.data());
 	m_daemonUsername		= GetOption(DAEMONUSERNAME.data());
@@ -622,6 +631,7 @@ void Options::InitOptions()
 	m_articleTimeout		= ParseIntValue(ARTICLETIMEOUT.data(), 10);
 	m_articleReadChunkSize  = ParseIntValue(ARTICLEREADCHUNKSIZE.data(), 10) * 1024;
 	m_urlTimeout			= ParseIntValue(URLTIMEOUT.data(), 10);
+	m_urlProxyPort			= ParseIntValue(URLPROXYPORT.data(), 10);
 	m_remoteTimeout			= ParseIntValue(REMOTETIMEOUT.data(), 10);
 	m_articleRetries		= ParseIntValue(ARTICLERETRIES.data(), 10);
 	m_articleInterval		= ParseIntValue(ARTICLEINTERVAL.data(), 10);

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -76,6 +76,11 @@ public:
 	static constexpr std::string_view ARTICLETIMEOUT = "ArticleTimeout";
 	static constexpr std::string_view ARTICLEREADCHUNKSIZE = "ArticleReadChunkSize";
 	static constexpr std::string_view URLTIMEOUT = "UrlTimeout";
+	static constexpr std::string_view URLPROXYHOST = "UrlProxyHost";
+	static constexpr std::string_view URLPROXYPORT = "UrlProxyPort";
+	static constexpr std::string_view URLPROXYUSERNAME = "UrlProxyUsername";
+	static constexpr std::string_view URLPROXYPASSWORD = "UrlProxyPassword";
+	static constexpr std::string_view URLPROXYBYPASS = "UrlProxyBypass";
 	static constexpr std::string_view REMOTETIMEOUT = "RemoteTimeout";
 	static constexpr std::string_view FLUSHQUEUE = "FlushQueue";
 	static constexpr std::string_view SYSTEMHEALTHCHECK = "SystemHealthCheck";
@@ -415,6 +420,11 @@ public:
 	int GetArticleTimeout() const { return m_articleTimeout; }
 	int GetArticleReadChunkSize() const { return m_articleReadChunkSize; }
 	int GetUrlTimeout() const { return m_urlTimeout; }
+	const char* GetUrlProxyHost() const { return m_urlProxyHost; }
+	int GetUrlProxyPort() const { return m_urlProxyPort; }
+	const char* GetUrlProxyUsername() const { return m_urlProxyUsername; }
+	const char* GetUrlProxyPassword() const { return m_urlProxyPassword; }
+	const char* GetUrlProxyBypass() const { return m_urlProxyBypass; }
 	int GetRemoteTimeout() const { return m_remoteTimeout; }
 	bool GetRawArticle() const { return m_rawArticle; }
 	bool GetSkipWrite() const { return m_skipWrite; }
@@ -603,6 +613,11 @@ private:
 	int m_articleTimeout = 0;
 	int m_articleReadChunkSize = 4;
 	int m_urlTimeout = 0;
+	CString m_urlProxyHost;
+	int m_urlProxyPort = 0;
+	CString m_urlProxyUsername;
+	CString m_urlProxyPassword;
+	CString m_urlProxyBypass;
 	int m_remoteTimeout = 0;
 	bool m_appendCategoryDir = false;
 	bool m_continuePartial = false;

--- a/daemon/systemhealth/ConnectionValidator.cpp
+++ b/daemon/systemhealth/ConnectionValidator.cpp
@@ -26,7 +26,7 @@ namespace SystemHealth::Connection
 {
 ConnectionValidator::ConnectionValidator(const Options& options) : m_options(options)
 {
-	m_validators.reserve(14);
+	m_validators.reserve(15);
 	m_validators.push_back(std::make_unique<ArticleRetriesValidator>(options));
 	m_validators.push_back(std::make_unique<ArticleIntervalValidator>(options));
 	m_validators.push_back(std::make_unique<ArticleTimeoutValidator>(options));
@@ -34,6 +34,7 @@ ConnectionValidator::ConnectionValidator(const Options& options) : m_options(opt
 	m_validators.push_back(std::make_unique<UrlRetriesValidator>(options));
 	m_validators.push_back(std::make_unique<UrlIntervalValidator>(options));
 	m_validators.push_back(std::make_unique<UrlTimeoutValidator>(options));
+	m_validators.push_back(std::make_unique<UrlProxyPortValidator>(options));
 	m_validators.push_back(std::make_unique<UrlConnectionsValidator>(options));
 	m_validators.push_back(std::make_unique<UrlForceValidator>(options));
 	m_validators.push_back(std::make_unique<RemoteTimeoutValidator>(options));
@@ -139,6 +140,24 @@ Status UrlTimeoutValidator::Validate() const
 			"'" + std::string(Options::URLTIMEOUT) + "' is set to " + std::to_string(val) +
 			" seconds. "
 			"RSS feeds and external URL fetches may fail if the remote server is slow");
+	}
+
+	return Status::Ok();
+}
+
+Status UrlProxyPortValidator::Validate() const
+{
+	const char* host = m_options.GetUrlProxyHost();
+	if (!host || !*host)
+	{
+		return Status::Ok();
+	}
+
+	int val = m_options.GetUrlProxyPort();
+	if (val < 1 || val > 65535)
+	{
+		return Status::Error("'" + std::string(Options::URLPROXYPORT) +
+			"' must be between 1 and 65535 when '" + std::string(Options::URLPROXYHOST) + "' is set");
 	}
 
 	return Status::Ok();

--- a/daemon/systemhealth/ConnectionValidator.h
+++ b/daemon/systemhealth/ConnectionValidator.h
@@ -112,6 +112,17 @@ private:
 	const Options& m_options;
 };
 
+class UrlProxyPortValidator : public Validator
+{
+public:
+	explicit UrlProxyPortValidator(const Options& options) : m_options(options) {}
+	std::string_view GetName() const override { return Options::URLPROXYPORT; }
+	Status Validate() const override;
+
+private:
+	const Options& m_options;
+};
+
 class RemoteTimeoutValidator : public Validator
 {
 public:

--- a/nzbget.conf
+++ b/nzbget.conf
@@ -1088,6 +1088,42 @@ UrlInterval=10
 # Connection timeout when fetching nzb-files via URLs and fetching RSS feeds.
 UrlTimeout=60
 
+# HTTP proxy host for URL fetching.
+#
+# When set, outbound HTTP and HTTPS requests made by the URL downloader are
+# routed through this HTTP proxy. This includes fetching nzb-files via URLs
+# and fetching RSS feeds. Connections to Usenet news servers are not affected.
+#
+# HTTPS destinations are tunneled through the proxy using the HTTP CONNECT
+# method. Leave empty to connect directly.
+UrlProxyHost=
+
+# HTTP proxy port (1-65535).
+#
+# This option is used only when <UrlProxyHost> is set.
+UrlProxyPort=8080
+
+# User name for HTTP proxy authentication.
+#
+# Leave empty together with <UrlProxyPassword> if the proxy does not require
+# authentication. HTTP Basic proxy authentication is supported.
+UrlProxyUsername=
+
+# Password for HTTP proxy authentication.
+UrlProxyPassword=
+
+# Hosts and networks that bypass the HTTP proxy for URL fetching.
+#
+# Separate multiple rules with commas or semicolons. Rules may be exact host
+# names or IP addresses, domain suffixes beginning with a dot (for example
+# ".example.com"), wildcard domain suffixes (for example "*.example.com"),
+# or IPv4 networks in CIDR notation (for example "192.168.0.0/16").
+#
+# CIDR rules are matched only against literal IPv4 addresses in URLs. Host
+# names are not resolved while evaluating bypass rules, avoiding DNS lookups
+# solely for proxy selection. Leave empty to proxy all URL/RSS requests.
+UrlProxyBypass=
+
 # Timeout for incoming connections (seconds).
 #
 # Set timeout for connections from clients (web-browsers and API clients).

--- a/webui/locales.source.json
+++ b/webui/locales.source.json
@@ -4278,6 +4278,26 @@
     "message": "Certificate verification level.\n\nNone - NO certificate signing check, NO certificate hostname check\n\nMinimal - certificate signing check, NO certificate hostname check\n\nStrict - certificate signing check, certificate hostname check",
     "description": "Description for the option Feed1.CertVerification DO NOT translate configuration option values (Minimal, None, Strict) as they are fixed configuration values."
   },
+  "config_desc_urlproxyhost": {
+    "message": "HTTP proxy host for URL fetching.\n\nWhen set, outbound HTTP and HTTPS requests made by the URL downloader are\nrouted through this HTTP proxy. This includes fetching nzb-files via URLs\nand fetching RSS feeds. Connections to Usenet news servers are not affected.\n\nHTTPS destinations are tunneled through the proxy using the HTTP CONNECT\nmethod. Leave empty to connect directly.",
+    "description": "Description for the option UrlProxyHost If 'News server' sounds like 'Newspaper' in your language, use 'Usenet server'."
+  },
+  "config_desc_urlproxyport": {
+    "message": "HTTP proxy port.\n\nThis option is used only when <UrlProxyHost> is set.",
+    "description": "Description for the option UrlProxyPort DO NOT translate option names enclosed in angle brackets (e.g., <OptionName>)."
+  },
+  "config_desc_urlproxyusername": {
+    "message": "User name for HTTP proxy authentication.\n\nLeave empty together with <UrlProxyPassword> if the proxy does not require\nauthentication. HTTP Basic proxy authentication is supported.",
+    "description": "Description for the option UrlProxyUsername DO NOT translate option names enclosed in angle brackets (e.g., <OptionName>)."
+  },
+  "config_desc_urlproxypassword": {
+    "message": "Password for HTTP proxy authentication.",
+    "description": "Description for the option UrlProxyPassword"
+  },
+  "config_desc_urlproxybypass": {
+    "message": "Hosts and networks that bypass the HTTP proxy for URL fetching.\n\nSeparate multiple rules with commas or semicolons. Rules may be exact host\nnames or IP addresses, domain suffixes beginning with a dot (for example\n\".example.com\"), wildcard domain suffixes (for example \"*.example.com\"),\nor IPv4 networks in CIDR notation (for example \"192.168.0.0/16\").\n\nCIDR rules are matched only against literal IPv4 addresses in URLs. Host\nnames are not resolved while evaluating bypass rules, avoiding DNS lookups\nsolely for proxy selection. Leave empty to proxy all URL/RSS requests.",
+    "description": "Description for the option UrlProxyBypass DO NOT translate technical values enclosed in quotes."
+  },
   "help_feed_filter_options_def": {
     "message": "Definition of an option: $1name:value$2",
     "description": "Definition of an option in feed filter. Used to show option syntax format."


### PR DESCRIPTION
## Description
Add configurable HTTP forward-proxy support to WebDownloader. 
NNTP/news-server connections stay completely unchanged and direct.

Some indexers do not allow NZB files to be downloaded and handed over to the download client. They only permit passing a URL, so the client has to follow the link (often via a local meta-search like NZBHydra2 that then redirects to the external indexer). The new proxy options make that flow work cleanly: local/Hydra URLs can be bypassed while the redirected external request goes through the HTTP proxy.

- Add UrlProxyHost, UrlProxyPort, UrlProxyUsername, UrlProxyPassword and UrlProxyBypass configuration options.
- Route HTTP URL downloads through the proxy using absolute-form request targets.
- Route HTTPS downloads through an HTTP CONNECT tunnel and start TLS against the original target host (correct SNI and certificate verification).
- Support HTTP Basic proxy authentication. Proxy-Authorization is only sent to the proxy, never forwarded to the origin after the tunnel is established.
- Re-evaluate proxy and bypass selection for every URL, including redirects.
- Bypass rules: exact hostnames, literal IP addresses, .domain suffixes, *.domain wildcards and IPv4 CIDR networks.
- Accept comma- or semicolon-separated bypass rules; surrounding whitespace is ignored.
- No local DNS resolution solely for bypass matching – external hostnames can still be resolved by the proxy.
- Validate the configured proxy port when a proxy host is set.
- Add configuration documentation and generated WebUI locale metadata for the new settings.

The proxy only applies to WebDownloader traffic (URL, RSS and NZB HTTP/HTTPS fetches). NNTP is not routed through it.


## AI assistance

- [x] This PR involved AI assistance (see [AI Policy](https://github.com/nzbgetcom/nzbget/blob/develop/docs/AI_POLICY.md))

Tool: ChatGPT  
Used for: design discussion, implementation help, test planning/automation, code review and commit preparation


## Lib changes
None.


## Testing

### Testing during development / build and afterwards
- Linux build with existing test suite
- Windows test build
- Windows ctest
- Linux build with precompiled headers disabled
- cppcheck (upstream project configuration)
- HTTP WebDownloader request through the configured proxy
- HTTP request through a proxy with Basic authentication
- HTTPS request through an HTTP CONNECT tunnel
- HTTPS proxy authentication via CONNECT
- TLS SNI and certificate/hostname verification against the original destination (not the proxy)
- Proxy-Authorization is not forwarded to the tunneled origin
- Proxy-side DNS resolution (hostname that does not resolve locally)
- Downloaded response content check
- Proxy bypass for exact/literal IP target
- Bypassed target is contacted directly and does not appear in the proxy log
- Redirect from a bypassed/direct URL to a proxied external URL
- Proxy/bypass selection is re-evaluated after redirects
- Redirected HTTP request uses absolute-form proxy request URI
- Negative test with unreachable/invalid proxy port
- Direct vs. proxied public egress-IP check
- Real NZBHydra2 link/redirect flow through Privoxy to an external indexer
- NZB fetch through the external indexer succeeds
- NNTP/news-server traffic remains direct (nothing in the HTTP proxy log)
- Installation and startup of the final test build on QNAP TS-670 / QTS 4.3.6
- New proxy options are available in the WebUI/config template

### QA Instructions / acceptance notes
- Configure UrlProxyHost and UrlProxyPort with a reachable HTTP forward proxy
- Leave UrlProxyHost empty → URL downloads still use the direct path
- Fetch a plain HTTP URL → request goes through the proxy
- Fetch an HTTPS URL → proxy receives a CONNECT host:port request
- HTTPS still validates the certificate against the original destination host
- TLS SNI contains the original destination hostname, not the proxy
- Configure UrlProxyUsername / UrlProxyPassword → HTTP Basic proxy authentication works
- Proxy-Authorization is only sent to the proxy, never to the HTTPS origin after the tunnel
- External hostname that is not resolvable locally still works (proxy-side DNS)
- Invalid or unreachable proxy port → URL download fails (no silent fallback to direct)
- Redirects continue to work through the proxy
- Proxy/bypass rules are re-evaluated after every redirect

### For UrlProxyBypass
- Exact hostname bypass
- Exact literal IPv4 address bypass
- .example.com suffix rule
- *.example.com wildcard suffix rule
- IPv4 CIDR rule (e.g. 192.168.0.0/16)
- Comma-separated rules
- Semicolon-separated rules
- Surrounding spaces/tabs are ignored
- Bypassed target is contacted directly and does not appear in the proxy log
- Non-bypassed target still goes through the proxy
- Redirect from a bypassed local URL to an external URL switches from direct to proxied
- No IPv6 CIDR matching (IPv4 only)

### NZBGet-specific acceptance
- RSS feeds load through the configured proxy
- NZB URL downloads load through the configured proxy
- NZBHydra2 local URL can be bypassed while the redirected external indexer URL goes through the proxy
- NZB is successfully imported after the redirect
- Start a Usenet download → NNTP connections do not appear in the HTTP proxy log
- NewsServer/NNTP traffic remains direct
- New settings are visible in the WebUI:
  - UrlProxyHost
  - UrlProxyPort
  - UrlProxyUsername
  - UrlProxyPassword
  - UrlProxyBypass
- Invalid proxy-port values are rejected by configuration validation
- Empty UrlProxyHost disables the feature cleanly

### NZBHydra2 test scenario
NZBHydra2 must be set to send NZBGet a link (not the NZB contents) and use access type Redirect:

1. NZBGet requests the local Hydra `/getnzb/...` URL  
2. Hydra answers with a redirect  
3. NZBGet follows it to the external indexer  

Hydra should advertise a reachable LAN URL (prefer IP over a local-only hostname), e.g. `http://192.168.x.x:5076`.  
In NZBGet put that network into `UrlProxyBypass`, e.g. `192.168.0.0/16`. The external indexer must **not** match the bypass list so the redirected request goes through the proxy.

Hydra’s own outbound proxy settings are independent. If Hydra itself uses a proxy, exclude local addresses there as well (`proxyIgnoreLocal: true` is typical).

Expected flow:

    NZBGet
      → Hydra LAN URL          direct (UrlProxyBypass)
      → HTTP redirect
      → external indexer       via UrlProxyHost / UrlProxyPort

Proxy log should contain the external indexer request but not the local Hydra request.

### Platform/build acceptance already covered
- Linux build and existing tests
- Windows test build
- Windows ctest
- Linux build without precompiled headers
- cppcheck
- QNAP TS-670 / QTS 4.3.6 installation and runtime smoke test


### For final acceptance, the most important manual check is
On the final build, set a LAN/Hydra bypass rule and verify the local Hydra request is absent from the proxy log while the redirected external indexer request is present.