### PR TITLE
Preserve nested par-rename paths and shorten rename logs

### DIFF
--- a/daemon/postprocess/ParRenamer.cpp
+++ b/daemon/postprocess/ParRenamer.cpp
@@ -458,7 +458,23 @@ void ParRenamer::RenameFile(const char* srcFilename, const char* destFileName)
 	++m_renamedCount;
 
 	// notify about new file name
-	RegisterRenamedFile(oldName.c_str(), newName.c_str());
+	std::string oldRelName = MakeRelativeName(srcFilename);
+	std::string newRelName = MakeRelativeName(destFileName);
+	RegisterRenamedFile(oldRelName.c_str(), newRelName.c_str());
+}
+
+std::string ParRenamer::MakeRelativeName(const char* fullFilename)
+{
+	fs::path canonicalDest = fs::weakly_canonical(fs::u8path(m_destDir.Str()));
+	fs::path canonicalFile = fs::weakly_canonical(fs::u8path(fullFilename));
+	fs::path rel = canonicalFile.lexically_relative(canonicalDest);
+
+	if (rel.empty() || *rel.begin() == "..")
+	{
+		return fs::u8string(canonicalFile.filename());
+	}
+
+	return fs::u8string(rel);
 }
 
 void ParRenamer::RenameBadParFiles()

--- a/daemon/postprocess/ParRenamer.h
+++ b/daemon/postprocess/ParRenamer.h
@@ -115,6 +115,7 @@ private:
 	bool NeedRenameParFiles();
 	void RenameFile(const char* srcFilename, const char* destFileName);
 	void RenameBadParFiles();
+	std::string MakeRelativeName(const char* fullFilename);
 };
 
 #endif

--- a/daemon/postprocess/Rename.cpp
+++ b/daemon/postprocess/Rename.cpp
@@ -211,17 +211,11 @@ void RenameController::UpdateRarRenameProgress()
 */
 void RenameController::RegisterRenamedFile(const char* oldFilename, const char* newFilename)
 {
-	for (CompletedFile& completedFile : m_postInfo->GetNzbInfo()->GetCompletedFiles())
+	if (!m_postInfo->GetNzbInfo()->RenameCompletedFile(oldFilename, newFilename))
 	{
-		if (!strcasecmp(completedFile.GetFilename(), oldFilename))
-		{
-			if (Util::EmptyStr(completedFile.GetOrigname()))
-			{
-				completedFile.SetOrigname(completedFile.GetFilename());
-			}
-			completedFile.SetFilename(newFilename);
-			break;
-		}
+		PrintMessage(Message::mkWarning,
+			"Could not find completed-file entry for %s while renaming to %s",
+			oldFilename, newFilename);
 	}
-	m_renamedCount++;
+	++m_renamedCount;
 }

--- a/daemon/queue/DirectRenamer.cpp
+++ b/daemon/queue/DirectRenamer.cpp
@@ -432,14 +432,13 @@ int DirectRenamer::RenameFilesInProgress(NzbInfo* nzbInfo, FileHashList* parHash
 
 		const std::string& currOutputFilename = fileInfo->GetOutputFilename();
 		const std::string nzbDestDir = fileInfo->GetNzbInfo()->GetDestDir();
-		const std::string newOutputFilename = nzbDestDir + PATH_SEPARATOR + newName;
 		const std::string oldOutputFilename = currOutputFilename.empty()
 			? nzbDestDir + PATH_SEPARATOR + fileInfo->GetFilename()
 			: currOutputFilename;
 
 		nzbInfo->PrintMessage(Message::mkInfo,
 			"Renaming in-progress file %s to %s",
-			oldOutputFilename.c_str(), newOutputFilename.c_str()
+			fileInfo->GetFilename(), newName.c_str()
 		);
 
 		// Create hardlink and save the path in fileInfo
@@ -450,7 +449,7 @@ int DirectRenamer::RenameFilesInProgress(NzbInfo* nzbInfo, FileHashList* parHash
 			{
 				nzbInfo->PrintMessage(Message::mkDetail,
 					"Skipping hardlink for %s: file not assembled yet",
-					oldOutputFilename.c_str()
+					fileInfo->GetFilename()
 				);
 			}
 			else
@@ -460,7 +459,7 @@ int DirectRenamer::RenameFilesInProgress(NzbInfo* nzbInfo, FileHashList* parHash
 
 				nzbInfo->PrintMessage(Message::mkInfo,
 					"HardLinking in-progress file %s to %s",
-					oldOutputFilename.c_str(), finalOutputFilename.c_str()
+					fileInfo->GetFilename(), newName.c_str()
 				);
 
 				CString errmsg;
@@ -473,7 +472,7 @@ int DirectRenamer::RenameFilesInProgress(NzbInfo* nzbInfo, FileHashList* parHash
 				{
 					nzbInfo->PrintMessage(Message::mkError,
 						"Could not create hardlink %s to %s: %s",
-						oldOutputFilename.c_str(), finalOutputFilename.c_str(), *errmsg
+						fileInfo->GetFilename(), newName.c_str(), *errmsg
 					);
 				}				
 			}
@@ -525,7 +524,7 @@ int DirectRenamer::RenameCompletedFiles(NzbInfo* nzbInfo, FileHashList* parHashe
 
 		nzbInfo->PrintMessage(Message::mkInfo,
 			"Renaming completed file %s to %s",
-			oldOutputFilename.c_str(), outputFilename.c_str()
+			completedFile.GetFilename(), newName.c_str()
 		);
 
 		if (!Util::EmptyStr(g_Options->GetInterDir()) && g_Options->GetHardLinking() && !Util::MatchFileExt(newName.c_str(), g_Options->GetHardLinkingIgnoreExt(), ","))
@@ -535,7 +534,7 @@ int DirectRenamer::RenameCompletedFiles(NzbInfo* nzbInfo, FileHashList* parHashe
 			{
 				nzbInfo->PrintMessage(Message::mkDetail,
 					"Skipping hardlink for %s: file not assembled yet",
-					oldOutputFilename.c_str()
+					completedFile.GetFilename()
 				);
 			}
 			else
@@ -545,7 +544,7 @@ int DirectRenamer::RenameCompletedFiles(NzbInfo* nzbInfo, FileHashList* parHashe
 
 				nzbInfo->PrintMessage(Message::mkInfo,
 					"HardLinking completed file %s to %s",
-					oldOutputFilename.c_str(), finalOutputFilename.c_str()
+					completedFile.GetFilename(), newName.c_str()
 				);
 
 				CString errmsg;
@@ -553,7 +552,7 @@ int DirectRenamer::RenameCompletedFiles(NzbInfo* nzbInfo, FileHashList* parHashe
 				{
 					nzbInfo->PrintMessage(Message::mkError,
 						"Could not create hardlink %s to %s: %s",
-						oldOutputFilename.c_str(), finalOutputFilename.c_str(), *errmsg
+						completedFile.GetFilename(), newName.c_str(), *errmsg
 					);
 				}				
 			}

--- a/daemon/queue/DownloadInfo.cpp
+++ b/daemon/queue/DownloadInfo.cpp
@@ -286,6 +286,29 @@ int NzbInfo::CalcHealth()
 	return health;
 }
 
+bool NzbInfo::RenameCompletedFile(const char* oldName, const char* newAbsoluteOrRelativePath)
+{
+	if (Util::EmptyStr(oldName) || Util::EmptyStr(newAbsoluteOrRelativePath))
+	{
+		return false;
+	}
+
+	for (CompletedFile& cf : m_completedFiles)
+	{
+		if (cf.SameFilename(oldName))
+		{
+			if (Util::EmptyStr(cf.GetOrigname()))
+			{
+				cf.SetOrigname(cf.GetFilename());
+			}
+
+			cf.SetFilename(newAbsoluteOrRelativePath);
+			return true;
+		}
+	}
+	return false;
+}
+
 int NzbInfo::CalcCriticalHealth(bool allowEstimation)
 {
 	if (m_size == 0)
@@ -861,6 +884,22 @@ CompletedFile::CompletedFile(int id, std::string filename, std::string origname,
 	}
 }
 
+bool CompletedFile::SameFilename(const char* name) const
+{
+	if (!name) return false;
+
+	std::string_view s1 = m_filename;
+	std::string_view s2 = name;
+	if (s1.size() != s2.size())
+		return false;
+
+	return std::equal(s1.begin(), s1.end(), s2.begin(), [](char c1, char c2)
+	{
+		if (c1 == '\\') c1 = '/';
+		if (c2 == '\\') c2 = '/';
+		return std::tolower(static_cast<unsigned char>(c1)) == std::tolower(static_cast<unsigned char>(c2));
+	});
+}
 
 void DupInfo::SetId(int id)
 {

--- a/daemon/queue/DownloadInfo.h
+++ b/daemon/queue/DownloadInfo.h
@@ -286,6 +286,7 @@ public:
 	void SetHash16k(std::string hash16k) { m_hash16k = std::move(hash16k); }
 	const char* GetParSetId() { return m_parSetId.c_str(); }
 	void SetParSetId(std::string parSetId) { m_parSetId = std::move(parSetId); }
+	bool SameFilename(const char* name) const;
 
 private:
 	int m_id;
@@ -556,6 +557,7 @@ public:
 	void BuildDestDirName();
 	CString BuildFinalDirName();
 	CompletedFileList* GetCompletedFiles() { return &m_completedFiles; }
+	bool RenameCompletedFile(const char* oldName, const char* newName);
 	void SetDirectRenameStatus(EDirectRenameStatus renameStatus) { m_directRenameStatus = renameStatus; }
 	EDirectRenameStatus GetDirectRenameStatus() { return m_directRenameStatus; }
 	EPostRenameStatus GetParRenameStatus() { return m_parRenameStatus; }


### PR DESCRIPTION
## Description

Preserves nested par-rename paths and shorten rename logs

## Testing

- macOS Tahoe