### PR TITLE
Fix file move collisions 

### DIFF
--- a/daemon/postprocess/Cleanup.cpp
+++ b/daemon/postprocess/Cleanup.cpp
@@ -60,13 +60,17 @@ void MoveController::Run()
 
 	infoName[0] = 'M'; // uppercase
 
+	if (ok)
+	{
+		RemoveStaleHardlinks(*m_postInfo->GetNzbInfo(), m_destDir);
+	}
+
 	{
 		GuardedDownloadQueue guard = DownloadQueue::Guard();
 		if (m_postInfo && m_postInfo->GetNzbInfo())
 		{
 			if (ok)
 			{
-				RemoveStaleHardlinks(*m_postInfo->GetNzbInfo(), m_destDir);
 				PrintMessage(Message::mkInfo, "%s successful", *infoName);
 				m_postInfo->GetNzbInfo()->SetDestDir(fs::u8string(m_destDir).c_str());
 				m_postInfo->GetNzbInfo()->SetFinalDir("");
@@ -125,6 +129,13 @@ bool MoveController::MoveFiles(const fs::path& src, const fs::path& dest)
 	fs::error_code ec;
 	auto it = fs::recursive_directory_iterator(src, fs::directory_options::skip_permission_denied, ec);
 	auto end = fs::recursive_directory_iterator();
+
+	if (ec)
+	{
+		PrintMessage(Message::mkError, "Could not open directory %s: %s",
+			fs::u8string(src).c_str(), ec.message().c_str());
+		return false;
+	}
 
 	while (it != end)
 	{
@@ -200,6 +211,18 @@ bool MoveController::MoveFiles(const fs::path& src, const fs::path& dest)
 		}
 
 		it.increment(ec);
+	}
+
+	if (ec)
+	{
+		PrintMessage(Message::mkError, "Could not read directory %s: %s",
+			fs::u8string(src).c_str(), ec.message().c_str());
+		return false;
+	}
+
+	if (IsStopped())
+	{
+		return false;
 	}
 
 	return true;

--- a/daemon/postprocess/Cleanup.cpp
+++ b/daemon/postprocess/Cleanup.cpp
@@ -207,10 +207,7 @@ bool MoveController::MoveFiles(const fs::path& src, const fs::path& dest)
 
 void MoveController::AddMessage(Message::EKind kind, const char* text)
 {
-	if (m_postInfo && m_postInfo->GetNzbInfo())
-	{
-		m_postInfo->GetNzbInfo()->AddMessage(kind, text);
-	}
+	m_postInfo->GetNzbInfo()->AddMessage(kind, text);
 }
 
 void CleanupController::StartJob(PostInfo* postInfo)

--- a/daemon/postprocess/Cleanup.cpp
+++ b/daemon/postprocess/Cleanup.cpp
@@ -40,46 +40,46 @@ void MoveController::StartJob(PostInfo* postInfo)
 
 void MoveController::Run()
 {
-	std::string nzbName;
+	BString<1024> nzbName;
 	{
 		GuardedDownloadQueue guard = DownloadQueue::Guard();
 		nzbName = m_postInfo->GetNzbInfo()->GetName();
-		m_interDir = m_postInfo->GetNzbInfo()->GetDestDir();
-		m_destDir = m_postInfo->GetNzbInfo()->GetFinalDir();
+		m_interDir = fs::u8path(m_postInfo->GetNzbInfo()->GetDestDir());
+		m_destDir = fs::u8path(m_postInfo->GetNzbInfo()->GetFinalDir());
+		if (m_destDir.empty())
+		{
+			m_destDir = fs::u8path(m_postInfo->GetNzbInfo()->BuildFinalDirName().Str());
+		}
 	}
 
-	std::string infoName = "move for " + nzbName;
-	SetInfoName(infoName.c_str());
-
-	if (m_destDir.empty())
-	{
-		m_destDir = m_postInfo->GetNzbInfo()->BuildFinalDirName();
-	}
-
-	PrintMessage(Message::mkInfo, "Moving completed files for %s", nzbName.c_str());
+	BString<1024> infoName("move for %s", *nzbName);
+	SetInfoName(*infoName);
+	PrintMessage(Message::mkInfo, "Moving completed files for %s", *nzbName);
 
 	bool ok = MoveFiles();
 
-	RemoveStaleHardlinks(*m_postInfo->GetNzbInfo(), m_destDir);
-
 	infoName[0] = 'M'; // uppercase
 
-	if (ok)
 	{
-		PrintMessage(Message::mkInfo, "%s successful", infoName.c_str());
-		// save new dest dir
 		GuardedDownloadQueue guard = DownloadQueue::Guard();
-		m_postInfo->GetNzbInfo()->SetDestDir(m_destDir.c_str());
-		m_postInfo->GetNzbInfo()->SetFinalDir("");
-		m_postInfo->GetNzbInfo()->SetMoveStatus(NzbInfo::msSuccess);
+		if (m_postInfo && m_postInfo->GetNzbInfo())
+		{
+			if (ok)
+			{
+				RemoveStaleHardlinks(*m_postInfo->GetNzbInfo(), m_destDir);
+				PrintMessage(Message::mkInfo, "%s successful", *infoName);
+				m_postInfo->GetNzbInfo()->SetDestDir(fs::u8string(m_destDir).c_str());
+				m_postInfo->GetNzbInfo()->SetFinalDir("");
+				m_postInfo->GetNzbInfo()->SetMoveStatus(NzbInfo::msSuccess);
+			}
+			else
+			{
+				PrintMessage(Message::mkError, "%s failed", *infoName);
+				m_postInfo->GetNzbInfo()->SetMoveStatus(NzbInfo::msFailure);
+			}
+			m_postInfo->SetWorking(false);
+		}
 	}
-	else
-	{
-		PrintMessage(Message::mkError, "%s failed", infoName.c_str());
-		m_postInfo->GetNzbInfo()->SetMoveStatus(NzbInfo::msFailure);
-	}
-
-	m_postInfo->SetWorking(false);
 }
 
 bool MoveController::MoveFiles()
@@ -87,66 +87,130 @@ bool MoveController::MoveFiles()
 	if (m_interDir == m_destDir)
 		return true;
 
-	CString errmsg;
-	if (!FileSystem::ForceDirectories(m_destDir.c_str(), errmsg))
+	fs::error_code ec;
+	if (fs::exists(m_interDir, ec) && fs::exists(m_destDir, ec))
 	{
-		PrintMessage(Message::mkError, "Could not create directory %s: %s", m_destDir.c_str(), *errmsg);
+		if (fs::equivalent(m_interDir, m_destDir, ec))
+			return true;
+	}
+
+	ec.clear();
+
+	fs::create_directories(m_destDir, ec);
+	if (ec)
+	{
+		PrintMessage(Message::mkError, "Could not create directory %s: %s",
+			fs::u8string(m_destDir).c_str(), ec.message().c_str());
 		return false;
 	}
 
-	bool ok = true;
-	MoveFiles(m_interDir, m_destDir, ok);
-	
-	if (ok && FileSystem::DirectoryExists(m_interDir.c_str()) &&
-		!FileSystem::DeleteDirectoryWithContent(m_interDir.c_str(), errmsg))
+	if (!MoveFiles(m_interDir, m_destDir))
+		return false;
+
+	if (fs::exists(m_interDir, ec) && !ec)
 	{
-		PrintMessage(Message::mkWarning, "Could not delete intermediate directory %s: %s", m_interDir.c_str(), *errmsg);
+		fs::remove_all(m_interDir, ec);
+		if (ec)
+		{
+			PrintMessage(Message::mkWarning, "Could not delete intermediate directory %s: %s",
+				fs::u8string(m_interDir).c_str(), ec.message().c_str());
+		}
 	}
 
-	return ok;
+	return true;
 }
 
-void MoveController::MoveFiles(const std::string& src, const std::string& dest, bool& isOk)
+bool MoveController::MoveFiles(const fs::path& src, const fs::path& dest)
 {
-	DirBrowser dir(src.c_str());
-	while (const char* filename = dir.Next())
+	fs::error_code ec;
+	auto it = fs::recursive_directory_iterator(src, fs::directory_options::skip_permission_denied, ec);
+	auto end = fs::recursive_directory_iterator();
+
+	while (it != end)
 	{
-		const std::string srcFile = src + PATH_SEPARATOR + filename;
-		const std::string dstFile = dest + PATH_SEPARATOR + filename;
-		if (FileSystem::DirectoryExists(srcFile.c_str()))
+		if (IsStopped() || ec) return false;
+
+		const auto& entry = *it;
+		auto relPath = entry.path().lexically_relative(src);
+		fs::path dstPath = dest / relPath;
+
+		if (entry.is_directory(ec))
 		{
-			CString errmsg;
-			if (FileSystem::ForceDirectories(dstFile.c_str(), errmsg))
+			fs::create_directories(dstPath, ec);
+			if (ec) return false;
+		}
+		else 
+		{
+			std::string filename = fs::u8string(entry.path().filename());
+			bool isDotFile = !filename.empty() && filename[0] == '.';
+
+			if (!isDotFile)
 			{
-				MoveFiles(srcFile, dstFile, isOk);
+				PrintMessage(Message::mkInfo, "Moving file %s to %s",
+					filename.c_str(), fs::u8string(dstPath.filename()).c_str());
 			}
-			else
+
+			fs::move_file(entry.path(), dstPath, ec);
+			if (ec && ec == std::errc::file_exists)
 			{
-				isOk = false;
-				PrintMessage(Message::mkError, "Could not create directory %s: %s", dest.c_str(), *errmsg);
+				ec.clear();
+
+				if (entry.path() == dstPath)
+				{
+					it.increment(ec);
+					continue;
+				}
+
+				if (fs::equivalent(entry.path(), dstPath, ec))
+				{
+					fs::remove(entry.path(), ec);
+					it.increment(ec);
+					continue;
+				}
+				ec.clear();
+
+				dstPath = fs::make_unique_filename(dstPath);
+				if (!isDotFile)
+				{
+					PrintMessage(Message::mkWarning, "File %s already exists, renaming to %s",
+						filename.c_str(), fs::u8string(dstPath.filename()).c_str());
+				}
+
+				fs::move_file(entry.path(), dstPath, ec);
+				if (ec) return false;
+			}
+			else if (ec)
+			{
+				PrintMessage(Message::mkError, "Could not move file %s: %s",
+					filename.c_str(), ec.message().c_str());
+				return false;
+			}
+
+			if (dstPath.filename() != entry.path().filename())
+			{
+				std::string newName = fs::u8string(dstPath.lexically_relative(dest));
+				std::string oldRelName = fs::u8string(relPath);
+				
+				GuardedDownloadQueue guard = DownloadQueue::Guard();
+				if (m_postInfo && m_postInfo->GetNzbInfo())
+				{
+					m_postInfo->GetNzbInfo()->RenameCompletedFile(oldRelName.c_str(), newName.c_str());
+				}
 			}
 		}
-		else
-		{
-			bool hiddenFile = srcFile[0] == '.';
-			if (hiddenFile)
-				continue;
 
-			PrintMessage(Message::mkInfo, "Moving file %s to %s", filename, dest.c_str());
-
-			if (!FileSystem::MoveFile(srcFile.c_str(), dstFile.c_str()))
-			{
-				isOk = false;
-				PrintMessage(Message::mkError, "Could not move file %s to %s: %s",
-					srcFile.c_str(), dstFile.c_str(), *FileSystem::GetLastErrorMessage());
-			}
-		}
+		it.increment(ec);
 	}
+
+	return true;
 }
 
 void MoveController::AddMessage(Message::EKind kind, const char* text)
 {
-	m_postInfo->GetNzbInfo()->AddMessage(kind, text);
+	if (m_postInfo && m_postInfo->GetNzbInfo())
+	{
+		m_postInfo->GetNzbInfo()->AddMessage(kind, text);
+	}
 }
 
 void CleanupController::StartJob(PostInfo* postInfo)
@@ -173,7 +237,7 @@ void CleanupController::Run()
 	}
 
 	BString<1024> infoName("cleanup for %s", *nzbName);
-	SetInfoName(infoName);
+	SetInfoName(*infoName);
 
 	PrintMessage(Message::mkInfo, "Cleaning up %s", *nzbName);
 
@@ -208,13 +272,24 @@ void CleanupController::Run()
 	m_postInfo->SetWorking(false);
 }
 
-void MoveController::RemoveStaleHardlinks(NzbInfo& nzbInfo, std::string_view destDir)
+void MoveController::RemoveStaleHardlinks(NzbInfo& nzbInfo, const fs::path& destDir)
 {
 	const auto& hardLinkPath = nzbInfo.GetHardLinkPath();
-	if (hardLinkPath.empty() || hardLinkPath == destDir) return;
+	if (hardLinkPath.empty()) return;
+
+	const auto path = fs::u8path(hardLinkPath);
+	if (path == destDir)
+		return;
 
 	fs::error_code ec;
-	const auto path = fs::u8path(hardLinkPath);
+	if (fs::exists(path, ec) && fs::exists(destDir, ec))
+	{
+		if (fs::equivalent(path, destDir, ec))
+			return;
+	}
+
+	ec.clear();
+
 	fs::remove_all(path, ec);
 	if (ec)
 	{

--- a/daemon/postprocess/Cleanup.h
+++ b/daemon/postprocess/Cleanup.h
@@ -37,15 +37,14 @@ public:
 
 protected:
 	void AddMessage(Message::EKind kind, const char* text) override;
+	bool MoveFiles();
+	bool MoveFiles(const fs::path& src, const fs::path& dest);
+	void RemoveStaleHardlinks(NzbInfo& nzbInfo, const fs::path& destDir);
 
 private:
-	PostInfo* m_postInfo;
-	std::string m_interDir;
-	std::string m_destDir;
-
-	bool MoveFiles();
-	void MoveFiles(const std::string& src, const std::string& dest, bool& isOk);
-	void RemoveStaleHardlinks(NzbInfo& nzbInfo, std::string_view destDir);
+	PostInfo* m_postInfo = nullptr;
+	fs::path m_interDir;
+	fs::path m_destDir;
 };
 
 class CleanupController : public Thread, public ScriptController

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -84,7 +84,7 @@ inline fs::path make_unique_filename(const fs::path& targetPath)
 	fs::path uniquePath;
 	do
 	{
-		uniquePath = baseDir / (stem + " (" + std::to_string(counter++) + ")" + ext);
+		uniquePath = baseDir / u8path(stem + " (" + std::to_string(counter++) + ")" + ext);
 	} while (fs::exists(uniquePath, ec) && !ec);
 
 	return uniquePath;
@@ -92,6 +92,13 @@ inline fs::path make_unique_filename(const fs::path& targetPath)
 
 inline void move_file(const fs::path& src, const fs::path& dest, fs::error_code& ec) noexcept
 {
+	if (fs::exists(dest, ec))
+	{
+		ec = std::make_error_code(std::errc::file_exists);
+		return;
+	}
+	if (ec) return;
+
 	fs::rename(src, dest, ec);
 	if (ec == std::errc::cross_device_link)
 	{

--- a/tests/postprocess/MoveController.cpp
+++ b/tests/postprocess/MoveController.cpp
@@ -149,6 +149,22 @@ BOOST_AUTO_TEST_CASE(UniqueFilenameNoExtension)
 	fs::remove_all(workDir);
 }
 
+BOOST_AUTO_TEST_CASE(UniqueFilenameUtf8)
+{
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_utf8";
+	fs::remove_all(workDir);
+	fs::create_directories(workDir);
+
+	const fs::path target = workDir / fs::u8path("vidéo_déjà_vu.mkv");
+	std::ofstream(target) << "existing";
+	BOOST_REQUIRE(fs::exists(target));
+
+	const fs::path result = fs::make_unique_filename(target);
+	BOOST_CHECK(result == workDir / fs::u8path("vidéo_déjà_vu (1).mkv"));
+
+	fs::remove_all(workDir);
+}
+
 BOOST_AUTO_TEST_CASE(MoveControllerCollisionKeepsBothAndRenamesRecord)
 {
 	Options::CmdOptList cmdOpts = MakeMoveTestOptions();
@@ -305,6 +321,95 @@ BOOST_AUTO_TEST_CASE(MoveControllerSameDirectoryNoOp)
 	std::string content;
 	std::getline(f, content);
 	BOOST_CHECK_EQUAL(content, "keep me safe");
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(MoveControllerCascadingCollision)
+{
+	Options::CmdOptList cmdOpts = MakeMoveTestOptions();
+	Options options(&cmdOpts, nullptr);
+
+	MoveControllerDownloadQueueMock downloadQueue;
+
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_cascade";
+	const fs::path src = workDir / "src";
+	const fs::path dst = workDir / "dst";
+	fs::remove_all(workDir);
+	fs::create_directories(src);
+	fs::create_directories(dst);
+
+	std::ofstream(src / "video.mkv") << "new data 2";
+	std::ofstream(dst / "video.mkv") << "original data";
+	std::ofstream(dst / "video (1).mkv") << "collision 1";
+	BOOST_REQUIRE(fs::exists(src / "video.mkv"));
+	BOOST_REQUIRE(fs::exists(dst / "video.mkv"));
+	BOOST_REQUIRE(fs::exists(dst / "video (1).mkv"));
+
+	auto nzbInfo = MakeMoveNzbInfo(src, dst);
+	nzbInfo->GetCompletedFiles()->emplace_back(
+		1, "video.mkv", "", CompletedFile::cfSuccess, 0, false, "", "");
+
+	RunMove(nzbInfo.get());
+	BOOST_CHECK_EQUAL(nzbInfo->GetMoveStatus(), NzbInfo::msSuccess);
+
+	BOOST_CHECK(fs::exists(dst / "video.mkv"));
+	BOOST_CHECK(fs::exists(dst / "video (1).mkv"));
+	BOOST_CHECK(fs::exists(dst / "video (2).mkv"));
+	BOOST_CHECK(!fs::exists(src / "video.mkv"));
+
+	std::ifstream newFile(dst / "video (2).mkv");
+	std::string content;
+	std::getline(newFile, content);
+	BOOST_CHECK_EQUAL(content, "new data 2");
+
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetFilename()),
+		"video (2).mkv");
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetOrigname()),
+		"video.mkv");
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(MoveControllerNestedDirectoryCollision)
+{
+	Options::CmdOptList cmdOpts = MakeMoveTestOptions();
+	Options options(&cmdOpts, nullptr);
+
+	MoveControllerDownloadQueueMock downloadQueue;
+
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_nested_collision";
+	const fs::path src = workDir / "src";
+	const fs::path dst = workDir / "dst";
+	fs::remove_all(workDir);
+	fs::create_directories(src / "sub/dir");
+	fs::create_directories(dst / "sub/dir");
+
+	std::ofstream(src / "sub/dir/inner.mkv") << "new nested data";
+	std::ofstream(dst / "sub/dir/inner.mkv") << "existing nested data";
+	BOOST_REQUIRE(fs::exists(src / "sub/dir/inner.mkv"));
+	BOOST_REQUIRE(fs::exists(dst / "sub/dir/inner.mkv"));
+
+	auto nzbInfo = MakeMoveNzbInfo(src, dst);
+	nzbInfo->GetCompletedFiles()->emplace_back(
+		1, "sub/dir/inner.mkv", "", CompletedFile::cfSuccess, 0, false, "", "");
+
+	RunMove(nzbInfo.get());
+	BOOST_CHECK_EQUAL(nzbInfo->GetMoveStatus(), NzbInfo::msSuccess);
+
+	BOOST_CHECK(fs::exists(dst / "sub/dir/inner.mkv"));
+	BOOST_CHECK(fs::exists(dst / "sub/dir/inner (1).mkv"));
+	BOOST_CHECK(!fs::exists(src / "sub/dir/inner.mkv"));
+
+	std::ifstream newFile(dst / "sub/dir/inner (1).mkv");
+	std::string content;
+	std::getline(newFile, content);
+	BOOST_CHECK_EQUAL(content, "new nested data");
+
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetFilename()),
+		"sub/dir/inner (1).mkv");
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetOrigname()),
+		"sub/dir/inner.mkv");
 
 	fs::remove_all(workDir);
 }

--- a/tests/postprocess/MoveController.cpp
+++ b/tests/postprocess/MoveController.cpp
@@ -396,9 +396,12 @@ BOOST_AUTO_TEST_CASE(MoveControllerNestedDirectoryCollision)
 	BOOST_REQUIRE(fs::exists(src / "sub/dir/inner.mkv"));
 	BOOST_REQUIRE(fs::exists(dst / "sub/dir/inner.mkv"));
 
+	const std::string expectedOrig = fs::u8string(fs::path("sub") / "dir" / "inner.mkv");
+	const std::string expectedNew = fs::u8string(fs::path("sub") / "dir" / "inner (1).mkv");
+
 	auto nzbInfo = MakeMoveNzbInfo(src, dst);
 	nzbInfo->GetCompletedFiles()->emplace_back(
-		1, "sub/dir/inner.mkv", "", CompletedFile::cfSuccess, 0, false, "", "");
+		1, expectedOrig, "", CompletedFile::cfSuccess, 0, false, "", "");
 
 	RunMove(nzbInfo.get());
 	BOOST_CHECK_EQUAL(nzbInfo->GetMoveStatus(), NzbInfo::msSuccess);
@@ -413,9 +416,6 @@ BOOST_AUTO_TEST_CASE(MoveControllerNestedDirectoryCollision)
 		std::getline(newFile, content);
 		BOOST_CHECK_EQUAL(content, "new nested data");
 	}
-
-	const std::string expectedNew = fs::u8string(fs::path("sub") / "dir" / "inner (1).mkv");
-	const std::string expectedOrig = fs::u8string(fs::path("sub") / "dir" / "inner.mkv");
 
 	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetFilename()),
 		expectedNew);

--- a/tests/postprocess/MoveController.cpp
+++ b/tests/postprocess/MoveController.cpp
@@ -1,0 +1,312 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+#include "FileSystem.h"
+#include "Cleanup.h"
+#include "Options.h"
+#include "Log.h"
+#include "Util.h"
+
+BOOST_AUTO_TEST_SUITE(PostprocessTest)
+
+class MoveControllerDownloadQueueMock final : public DownloadQueue
+{
+public:
+	MoveControllerDownloadQueueMock()
+	{
+		Init(this);
+		Loaded();
+	}
+	~MoveControllerDownloadQueueMock()
+	{
+		Final();
+	}
+	bool EditEntry(int ID, EEditAction action, const char* args) { return false; }
+	bool EditList(IdList* idList, NameList* nameList, EMatchMode matchMode,
+		EEditAction action, const char* args) { return false; }
+	void HistoryChanged() {}
+	void Save() {}
+	void SaveChanged() {}
+};
+
+static Options::CmdOptList MakeMoveTestOptions()
+{
+	Options::CmdOptList cmdOpts;
+	cmdOpts.push_back("WriteLog=none");
+	cmdOpts.push_back("NzbLog=no");
+	return cmdOpts;
+}
+
+static std::unique_ptr<NzbInfo> MakeMoveNzbInfo(const fs::path& src, const fs::path& dst)
+{
+	auto nzbInfo = std::make_unique<NzbInfo>();
+	nzbInfo->SetName("MoveControllerTest");
+	nzbInfo->SetDestDir(src.string().c_str());
+	nzbInfo->SetFinalDir(dst.string().c_str());
+	nzbInfo->EnterPostProcess();
+	return nzbInfo;
+}
+
+static void RunMove(NzbInfo* nzbInfo)
+{
+	MoveController::StartJob(nzbInfo->GetPostInfo());
+
+	for (int elapsed = 0; elapsed < 10000 && nzbInfo->GetMoveStatus() == NzbInfo::msNone; elapsed += 20)
+	{
+		Util::Sleep(20);
+	}
+	BOOST_CHECK(nzbInfo->GetMoveStatus() != NzbInfo::msNone);
+
+	// Wait for the thread to finish and clean up
+	while (nzbInfo->GetPostInfo()->GetWorking())
+	{
+		Util::Sleep(10);
+	}
+	delete nzbInfo->GetPostInfo()->GetPostThread();
+	nzbInfo->GetPostInfo()->SetPostThread(nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(UniqueFilenameNoCollision)
+{
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_1";
+	fs::remove_all(workDir);
+	fs::create_directories(workDir);
+
+	const fs::path target = workDir / "file.mkv";
+	const fs::path result = fs::make_unique_filename(target);
+	BOOST_CHECK(result == target);
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(UniqueFilenameOneCollision)
+{
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_2";
+	fs::remove_all(workDir);
+	fs::create_directories(workDir);
+
+	const fs::path target = workDir / "file.mkv";
+	std::ofstream(target.string()) << "existing";
+	BOOST_REQUIRE(fs::exists(target));
+
+	const fs::path result = fs::make_unique_filename(target);
+	BOOST_CHECK(result == workDir / "file (1).mkv");
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(UniqueFilenameMultipleCollisions)
+{
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_3";
+	fs::remove_all(workDir);
+	fs::create_directories(workDir);
+
+	const fs::path target = workDir / "file.mkv";
+	std::ofstream(target.string()) << "existing";
+	std::ofstream((workDir / "file (1).mkv").string()) << "collision1";
+	BOOST_REQUIRE(fs::exists(target));
+	BOOST_REQUIRE(fs::exists(workDir / "file (1).mkv"));
+
+	const fs::path result = fs::make_unique_filename(target);
+	BOOST_CHECK(result == workDir / "file (2).mkv");
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(UniqueFilenameNoExtension)
+{
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_4";
+	fs::remove_all(workDir);
+	fs::create_directories(workDir);
+
+	const fs::path target = workDir / "Makefile";
+	std::ofstream(target.string()) << "existing";
+	BOOST_REQUIRE(fs::exists(target));
+
+	const fs::path result = fs::make_unique_filename(target);
+	BOOST_CHECK(result == workDir / "Makefile (1)");
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(MoveControllerCollisionKeepsBothAndRenamesRecord)
+{
+	Options::CmdOptList cmdOpts = MakeMoveTestOptions();
+	Options options(&cmdOpts, nullptr);
+
+	MoveControllerDownloadQueueMock downloadQueue;
+
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_move1";
+	const fs::path src = workDir / "src";
+	const fs::path dst = workDir / "dst";
+	fs::remove_all(workDir);
+	fs::create_directories(src);
+	fs::create_directories(dst);
+
+	std::ofstream((src / "video.mkv").string()) << "new data";
+	std::ofstream((dst / "video.mkv").string()) << "old data";
+	BOOST_REQUIRE(fs::exists(src / "video.mkv"));
+	BOOST_REQUIRE(fs::exists(dst / "video.mkv"));
+
+	auto nzbInfo = MakeMoveNzbInfo(src, dst);
+	nzbInfo->GetCompletedFiles()->emplace_back(
+		1, "video.mkv", "", CompletedFile::cfSuccess, 0, false, "", "");
+
+	RunMove(nzbInfo.get());
+	BOOST_CHECK_EQUAL(nzbInfo->GetMoveStatus(), NzbInfo::msSuccess);
+
+	BOOST_CHECK(fs::exists(dst / "video.mkv"));
+	BOOST_CHECK(fs::exists(dst / "video (1).mkv"));
+	BOOST_CHECK(!fs::exists(src / "video.mkv"));
+
+	std::ifstream newFile((dst / "video (1).mkv").string());
+	std::string content;
+	std::getline(newFile, content);
+	BOOST_CHECK(content == "new data");
+
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetFilename()),
+		"video (1).mkv");
+	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetOrigname()),
+		"video.mkv");
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(MoveControllerNoCollisionMovesFile)
+{
+	Options::CmdOptList cmdOpts = MakeMoveTestOptions();
+	Options options(&cmdOpts, nullptr);
+
+	MoveControllerDownloadQueueMock downloadQueue;
+
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_move2";
+	const fs::path src = workDir / "src";
+	const fs::path dst = workDir / "dst";
+	fs::remove_all(workDir);
+	fs::create_directories(src);
+	fs::create_directories(dst);
+
+	std::ofstream((src / "video.mkv").string()) << "data";
+
+	auto nzbInfo = MakeMoveNzbInfo(src, dst);
+
+	RunMove(nzbInfo.get());
+	BOOST_CHECK_EQUAL(nzbInfo->GetMoveStatus(), NzbInfo::msSuccess);
+
+	BOOST_CHECK(fs::exists(dst / "video.mkv"));
+	BOOST_CHECK(!fs::exists(src / "video.mkv"));
+	BOOST_CHECK(nzbInfo->GetCompletedFiles()->empty());
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(MoveControllerSameInodeRemovesSource)
+{
+	Options::CmdOptList cmdOpts = MakeMoveTestOptions();
+	Options options(&cmdOpts, nullptr);
+
+	MoveControllerDownloadQueueMock downloadQueue;
+
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_move3";
+	const fs::path src = workDir / "src";
+	const fs::path dst = workDir / "dst";
+	fs::remove_all(workDir);
+	fs::create_directories(src);
+	fs::create_directories(dst);
+
+	fs::error_code ec;
+	std::ofstream((dst / "video.mkv").string()) << "data";
+	fs::create_hard_link(dst / "video.mkv", src / "video.mkv", ec);
+	BOOST_REQUIRE(!ec);
+	BOOST_CHECK(fs::equivalent(src / "video.mkv", dst / "video.mkv"));
+
+	auto nzbInfo = MakeMoveNzbInfo(src, dst);
+
+	RunMove(nzbInfo.get());
+	BOOST_CHECK_EQUAL(nzbInfo->GetMoveStatus(), NzbInfo::msSuccess);
+
+	BOOST_CHECK(fs::exists(dst / "video.mkv"));
+	BOOST_CHECK(!fs::exists(src / "video.mkv"));
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(MoveControllerNestedDirectories)
+{
+	Options::CmdOptList cmdOpts = MakeMoveTestOptions();
+	Options options(&cmdOpts, nullptr);
+
+	MoveControllerDownloadQueueMock downloadQueue;
+
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_move4";
+	const fs::path src = workDir / "src";
+	const fs::path dst = workDir / "dst";
+	fs::remove_all(workDir);
+	fs::create_directories(src / "sub/dir");
+	fs::create_directories(dst);
+
+	std::ofstream((src / "sub/dir/inner.mkv").string()) << "data";
+
+	auto nzbInfo = MakeMoveNzbInfo(src, dst);
+
+	RunMove(nzbInfo.get());
+	BOOST_CHECK_EQUAL(nzbInfo->GetMoveStatus(), NzbInfo::msSuccess);
+
+	BOOST_CHECK(fs::exists(dst / "sub/dir/inner.mkv"));
+	BOOST_CHECK(!fs::exists(src / "sub/dir/inner.mkv"));
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(MoveControllerSameDirectoryNoOp)
+{
+	Options::CmdOptList cmdOpts = MakeMoveTestOptions();
+	Options options(&cmdOpts, nullptr);
+
+	MoveControllerDownloadQueueMock downloadQueue;
+
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_move5";
+	const fs::path src = workDir / "same";
+	fs::remove_all(workDir);
+	fs::create_directories(src);
+
+	std::ofstream((src / "video.mkv").string()) << "keep me safe";
+	BOOST_REQUIRE(fs::exists(src / "video.mkv"));
+
+	auto nzbInfo = MakeMoveNzbInfo(src, src);
+
+	RunMove(nzbInfo.get());
+	BOOST_CHECK_EQUAL(nzbInfo->GetMoveStatus(), NzbInfo::msSuccess);
+
+	// The file must survive — same-directory move is a no-op
+	BOOST_CHECK(fs::exists(src / "video.mkv"));
+
+	std::ifstream f((src / "video.mkv").string());
+	std::string content;
+	std::getline(f, content);
+	BOOST_CHECK_EQUAL(content, "keep me safe");
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/postprocess/MoveController.cpp
+++ b/tests/postprocess/MoveController.cpp
@@ -195,10 +195,12 @@ BOOST_AUTO_TEST_CASE(MoveControllerCollisionKeepsBothAndRenamesRecord)
 	BOOST_CHECK(fs::exists(dst / "video (1).mkv"));
 	BOOST_CHECK(!fs::exists(src / "video.mkv"));
 
-	std::ifstream newFile((dst / "video (1).mkv").string());
-	std::string content;
-	std::getline(newFile, content);
-	BOOST_CHECK(content == "new data");
+	{
+		std::ifstream newFile(dst / "video (1).mkv");
+		std::string content;
+		std::getline(newFile, content);
+		BOOST_CHECK(content == "new data");
+	}
 
 	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetFilename()),
 		"video (1).mkv");
@@ -317,10 +319,12 @@ BOOST_AUTO_TEST_CASE(MoveControllerSameDirectoryNoOp)
 	// The file must survive — same-directory move is a no-op
 	BOOST_CHECK(fs::exists(src / "video.mkv"));
 
-	std::ifstream f((src / "video.mkv").string());
-	std::string content;
-	std::getline(f, content);
-	BOOST_CHECK_EQUAL(content, "keep me safe");
+	{
+		std::ifstream f(src / "video.mkv");
+		std::string content;
+		std::getline(f, content);
+		BOOST_CHECK_EQUAL(content, "keep me safe");
+	}
 
 	fs::remove_all(workDir);
 }
@@ -358,10 +362,12 @@ BOOST_AUTO_TEST_CASE(MoveControllerCascadingCollision)
 	BOOST_CHECK(fs::exists(dst / "video (2).mkv"));
 	BOOST_CHECK(!fs::exists(src / "video.mkv"));
 
-	std::ifstream newFile(dst / "video (2).mkv");
-	std::string content;
-	std::getline(newFile, content);
-	BOOST_CHECK_EQUAL(content, "new data 2");
+	{
+		std::ifstream newFile(dst / "video (2).mkv");
+		std::string content;
+		std::getline(newFile, content);
+		BOOST_CHECK_EQUAL(content, "new data 2");
+	}
 
 	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetFilename()),
 		"video (2).mkv");
@@ -401,15 +407,40 @@ BOOST_AUTO_TEST_CASE(MoveControllerNestedDirectoryCollision)
 	BOOST_CHECK(fs::exists(dst / "sub/dir/inner (1).mkv"));
 	BOOST_CHECK(!fs::exists(src / "sub/dir/inner.mkv"));
 
-	std::ifstream newFile(dst / "sub/dir/inner (1).mkv");
-	std::string content;
-	std::getline(newFile, content);
-	BOOST_CHECK_EQUAL(content, "new nested data");
+	{
+		std::ifstream newFile(dst / "sub/dir/inner (1).mkv");
+		std::string content;
+		std::getline(newFile, content);
+		BOOST_CHECK_EQUAL(content, "new nested data");
+	}
+
+	const std::string expectedNew = fs::u8string(fs::path("sub") / "dir" / "inner (1).mkv");
+	const std::string expectedOrig = fs::u8string(fs::path("sub") / "dir" / "inner.mkv");
 
 	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetFilename()),
-		"sub/dir/inner (1).mkv");
+		expectedNew);
 	BOOST_CHECK_EQUAL(std::string(nzbInfo->GetCompletedFiles()->at(0).GetOrigname()),
-		"sub/dir/inner.mkv");
+		expectedOrig);
+
+	fs::remove_all(workDir);
+}
+
+BOOST_AUTO_TEST_CASE(MoveControllerNonExistentSourceFails)
+{
+	Options::CmdOptList cmdOpts = MakeMoveTestOptions();
+	Options options(&cmdOpts, nullptr);
+
+	MoveControllerDownloadQueueMock downloadQueue;
+
+	const fs::path workDir = fs::temp_directory_path() / "nzbget_test_movecontroller_nonexistent";
+	const fs::path src = workDir / "non_existent_src";
+	const fs::path dst = workDir / "dst";
+	fs::remove_all(workDir);
+
+	auto nzbInfo = MakeMoveNzbInfo(src, dst);
+
+	RunMove(nzbInfo.get());
+	BOOST_CHECK_EQUAL(nzbInfo->GetMoveStatus(), NzbInfo::msFailure);
 
 	fs::remove_all(workDir);
 }

--- a/tests/postprocess/postprocess.cmake
+++ b/tests/postprocess/postprocess.cmake
@@ -1,6 +1,7 @@
 list(APPEND TESTS_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/postprocess/DirectUnpack.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/postprocess/DupeMatcher.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/postprocess/MoveController.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/postprocess/RarReader.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/postprocess/RarRenamer.cpp
 )

--- a/tests/queue/CompletedFile.cpp
+++ b/tests/queue/CompletedFile.cpp
@@ -1,0 +1,64 @@
+/*
+ *  This file is part of nzbget. See <https://nzbget.com>.
+ *
+ *  Copyright (C) 2026 Denis <denis@nzbget.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "nzbget.h"
+
+#include <boost/test/unit_test.hpp>
+#include "DownloadInfo.h"
+
+BOOST_AUTO_TEST_SUITE(QueueTest)
+
+BOOST_AUTO_TEST_CASE(CompletedFileSameFilenameTest)
+{
+	CompletedFile record(1, "DISORDER_2025-FLT/2c0837e5fa42c8cfb5d5e583168a2af4.mkv",
+		"", CompletedFile::cfSuccess, 0, false, "", "");
+
+	BOOST_CHECK(record.SameFilename("DISORDER_2025-FLT/2c0837e5fa42c8cfb5d5e583168a2af4.mkv"));
+	BOOST_CHECK(record.SameFilename("DISORDER_2025-FLT\\2c0837e5fa42c8cfb5d5e583168a2af4.mkv"));
+	BOOST_CHECK(record.SameFilename("disorder_2025-flt/2C0837E5FA42C8CFB5D5E583168A2AF4.MKV"));
+	BOOST_CHECK(!record.SameFilename("2c0837e5fa42c8cfb5d5e583168a2af4.mkv"));
+	BOOST_CHECK(!record.SameFilename("other.mkv"));
+	BOOST_CHECK(!record.SameFilename("OTHER_DIR/2c0837e5fa42c8cfb5d5e583168a2af4.mkv"));
+
+	CompletedFile bareRecord(2, "5KzdcWdGVGUG83Q9jv8KXht4O2k57w.mkv",
+		"", CompletedFile::cfSuccess, 0, false, "", "");
+	BOOST_CHECK(bareRecord.SameFilename("5KzdcWdGVGUG83Q9jv8KXht4O2k57w.mkv"));
+	BOOST_CHECK(!bareRecord.SameFilename("Some.Dir/5KzdcWdGVGUG83Q9jv8KXht4O2k57w.mkv"));
+	BOOST_CHECK(!bareRecord.SameFilename("5KzdcWdGVGUG83Q9jv8KXht4O2k57w.mp4"));
+}
+
+BOOST_AUTO_TEST_CASE(RenameCompletedFileMatchesPathQualifiedRecordTest)
+{
+	NzbInfo nzbInfo;
+	nzbInfo.GetCompletedFiles()->emplace_back(
+		1, "parent/2c0837e5fa42c8cfb5d5e583168a2af4.mkv", "",
+		CompletedFile::cfSuccess, 0, false, "", "");
+
+	bool updated = nzbInfo.RenameCompletedFile(
+		"parent/2c0837e5fa42c8cfb5d5e583168a2af4.mkv", "parent/Some.Release.mkv");
+
+	BOOST_CHECK(updated);
+	BOOST_CHECK_EQUAL(std::string(nzbInfo.GetCompletedFiles()->at(0).GetFilename()),
+		"parent/Some.Release.mkv");
+	BOOST_CHECK_EQUAL(std::string(nzbInfo.GetCompletedFiles()->at(0).GetOrigname()),
+		"parent/2c0837e5fa42c8cfb5d5e583168a2af4.mkv");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/queue/queue.cmake
+++ b/tests/queue/queue.cmake
@@ -2,6 +2,7 @@ list(APPEND TESTS_SRC
 	${CMAKE_CURRENT_SOURCE_DIR}/queue/NzbFile.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/queue/Deobfuscation.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/queue/ArchiveProcessor.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/queue/CompletedFile.cpp
 )
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/testdata/nzbfile DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
## Description

Resolve destination file collisions by assigning unique names instead of overwriting existing files, 
preserving hardlinks, and updating completed file queue records.

## Testing

- macOS Tahoe