### PR TITLE
Add NZB metadata parsing and harden path validation

### DIFF
--- a/daemon/queue/DiskState.cpp
+++ b/daemon/queue/DiskState.cpp
@@ -28,7 +28,7 @@
 #include "FileSystem.h"
 
 static const char* FORMATVERSION_SIGNATURE = "nzbget diskstate file version ";
-const int DISKSTATE_QUEUE_VERSION = 63;
+const int DISKSTATE_QUEUE_VERSION = 64;
 const int DISKSTATE_FILE_VERSION = 7;
 const int DISKSTATE_STATS_VERSION = 4;
 const int DISKSTATE_FEEDS_VERSION = 3;
@@ -538,12 +538,13 @@ error:
 void DiskState::SaveNzbInfo(NzbInfo* nzbInfo, StateDiskFile& outfile)
 {
 	outfile.PrintLine("%i", nzbInfo->GetId());
-	outfile.PrintLine("%i", (int)nzbInfo->GetKind());
+	outfile.PrintLine("%i", static_cast<int>(nzbInfo->GetKind()));
 	outfile.PrintLine("%s", nzbInfo->GetUrl());
 	outfile.PrintLine("%s", nzbInfo->GetFilename());
 	outfile.PrintLine("%s", nzbInfo->GetDestDir());
 	outfile.PrintLine("%s", nzbInfo->GetFinalDir());
 	outfile.PrintLine("%s", nzbInfo->GetHardLinkPath().c_str());
+	outfile.PrintLine("%s", nzbInfo->GetMetaName().c_str());
 	outfile.PrintLine("%s", nzbInfo->GetQueuedFilename());
 	outfile.PrintLine("%s", nzbInfo->GetName());
 	outfile.PrintLine("%s", nzbInfo->GetCategory());
@@ -670,6 +671,12 @@ bool DiskState::LoadNzbInfo(NzbInfo* nzbInfo, Servers* servers, StateDiskFile& i
 	{
 		if (!infile.ReadLine(buf, sizeof(buf))) goto error;
 		nzbInfo->SetHardLinkPath(buf);
+	}
+
+	if (formatVersion >= 64) 
+	{
+		if (!infile.ReadLine(buf, sizeof(buf))) goto error;
+		nzbInfo->SetMetaName(buf);
 	}
 
 	if (!infile.ReadLine(buf, sizeof(buf))) goto error;

--- a/daemon/queue/DownloadInfo.cpp
+++ b/daemon/queue/DownloadInfo.cpp
@@ -278,8 +278,14 @@ CString NzbInfo::BuildFinalDirName()
 		}
 	}
 
-	finalDir.AppendFmt("%c%s", PATH_SEPARATOR,
-		Util::EmptyStr(GetName()) ? "nzb" : GetName());
+	if (Util::EmptyStr(GetName()))
+	{
+		finalDir.AppendFmt("%c%s-%i", PATH_SEPARATOR, "nzb", GetId());
+	}
+	else
+	{
+		finalDir.AppendFmt("%c%s", PATH_SEPARATOR, GetName());
+	}
 
 	return finalDir;
 }

--- a/daemon/queue/DownloadInfo.cpp
+++ b/daemon/queue/DownloadInfo.cpp
@@ -190,21 +190,32 @@ void NzbInfo::SetFilename(const char* filename)
 	if ((!m_name || !hadFilename) && !Util::EmptyStr(filename))
 	{
 		CString nzbNicename = MakeNiceNzbName(m_filename, true);
+		if (nzbNicename.Empty())
+		{
+			nzbNicename.Format("nzb-%i", GetId());
+		}
 		SetName(nzbNicename);
 	}
 }
 
 CString NzbInfo::MakeNiceNzbName(const char * nzbFilename, bool removeExt)
 {
-	BString<1024> nicename = FileSystem::BaseFileName(nzbFilename);
+	std::string nicename = FileSystem::BaseFileName(nzbFilename);
 	if (removeExt)
 	{
 		// wipe out ".nzb"
-		char* p = strrchr(nicename, '.');
-		if (p && !strcasecmp(p, ".nzb")) *p = '\0';
+		auto dotpos = nicename.rfind('.');
+		if (dotpos != std::string::npos && !strcasecmp(nicename.c_str() + dotpos, ".nzb"))
+		{
+			nicename.erase(dotpos);
+		}
 	}
-	CString validname = FileSystem::MakeValidFilename(nicename);
-	return validname;
+	std::string validname = FileSystem::SanitizePathSegment(nicename);
+	if (validname.empty())
+	{
+		validname = "nzb";
+	}
+	return validname.c_str();
 }
 
 CString NzbInfo::MakeNiceUrlName(const char* urlStr, const char* nzbFilename)
@@ -237,7 +248,8 @@ void NzbInfo::BuildDestDirName()
 	}
 	else
 	{
-		m_destDir.Format("%s%c%s.#%i", g_Options->GetInterDir(), PATH_SEPARATOR, GetName(), GetId());
+		m_destDir.Format("%s%c%s.#%i", g_Options->GetInterDir(), PATH_SEPARATOR,
+			Util::EmptyStr(GetName()) ? "nzb" : GetName(), GetId());
 	}
 }
 
@@ -258,12 +270,16 @@ CString NzbInfo::BuildFinalDirName()
 
 	if (g_Options->GetAppendCategoryDir() && useCategory)
 	{
-		CString categoryDir = FileSystem::MakeValidFilename(m_category, true);
-		// we can't format with "finalDir.Format" because one of the parameter is "finalDir" itself.
-		finalDir = CString::FormatStr("%s%c%s", *finalDir, PATH_SEPARATOR, *categoryDir);
+		std::string categoryDir = FileSystem::SanitizeRelativePath(*m_category);
+		if (!categoryDir.empty())
+		{
+			// we can't format with "finalDir.Format" because one of the parameter is "finalDir" itself.
+			finalDir = CString::FormatStr("%s%c%s", *finalDir, PATH_SEPARATOR, categoryDir.c_str());
+		}
 	}
 
-	finalDir.AppendFmt("%c%s", PATH_SEPARATOR, GetName());
+	finalDir.AppendFmt("%c%s", PATH_SEPARATOR,
+		Util::EmptyStr(GetName()) ? "nzb" : GetName());
 
 	return finalDir;
 }

--- a/daemon/queue/DownloadInfo.h
+++ b/daemon/queue/DownloadInfo.h
@@ -500,6 +500,8 @@ public:
 	void SetHardLinkPath(std::string hardLinkPath) { m_hardLinkPath = std::move(hardLinkPath); }
 	const std::string& GetHardLinkPath() const { return m_hardLinkPath; }
 	void SetName(const char* name) { m_name = name; }
+	const std::string& GetMetaName() const { return m_metaName; }
+	void SetMetaName(std::string metaName) { m_metaName = std::move(metaName); }
 	int GetFileCount() { return m_fileCount; }
 	void SetFileCount(int fileCount) { m_fileCount = fileCount; }
 	int GetParkedFileCount() { return m_parkedFileCount; }
@@ -694,6 +696,7 @@ private:
 	CString m_finalDir = "";
 	CString m_category = "";
 	std::string m_hardLinkPath;
+	std::string m_metaName;
 	int m_fileCount = 0;
 	int m_parkedFileCount = 0;
 	int64 m_size = 0;

--- a/daemon/queue/NzbFile.cpp
+++ b/daemon/queue/NzbFile.cpp
@@ -292,6 +292,23 @@ void NzbFile::ProcessFiles()
 	{
 		ReadPasswordFromFilename();
 	}
+
+	m_metaName = FileSystem::SanitizePathSegment(m_metaName);
+	m_metaTitle = FileSystem::SanitizePathSegment(m_metaTitle);
+
+	if (m_metaName.empty() && !m_metaTitle.empty())
+	{
+		m_metaName = m_metaTitle;
+	}
+
+	// Sanitize control characters (\r, \n, \t, etc.) to prevent
+	// line desynchronization in the line-based DiskState file format.
+	Util::SanitizeLine(m_category);
+
+	if (!m_metaName.empty() && m_nzbInfo)
+	{
+		m_nzbInfo->SetMetaName(m_metaName);
+	}
 }
 /*
 * Attempt to Read the Password from the Filename encoded in {{ Bracets }}
@@ -416,13 +433,27 @@ void NzbFile::Parse_StartElement(const char *name, const char **atts)
 	}
 	else if (!strcmp("meta", name))
 	{
+		m_hasPassword = false;
+		m_hasCategory = false;
+		m_hasName = false;
+		m_hasTitle = false;
+
 		if (!atts)
 		{
 			m_nzbInfo->AddMessage(Message::mkWarning, tagAttrMessage);
 			return;
 		}
-		m_hasPassword = atts[0] && atts[1] && !strcmp("type", atts[0]) && !strcmp("password", atts[1]);
-		m_hasCategory = atts[0] && atts[1] && !strcmp("type", atts[0]) && !strcmp("category", atts[1]);
+
+		for (int i = 0; atts[i] && atts[i + 1]; i += 2)
+		{
+			if (!strcasecmp("type", atts[i]))
+			{
+				if (!strcasecmp("password", atts[i + 1])) m_hasPassword = true;
+				else if (!strcasecmp("category", atts[i + 1])) m_hasCategory = true;
+				else if (!strcasecmp("name", atts[i + 1])) m_hasName = true;
+				else if (!strcasecmp("title", atts[i + 1])) m_hasTitle = true;
+			}
+		}
 	}
 }
 
@@ -465,6 +496,14 @@ void NzbFile::Parse_EndElement(const char *name)
 	else if (!strcmp("meta", name) && m_hasCategory)
 	{
 		m_category = m_tagContent;
+	}
+	else if (!strcmp("meta", name) && m_hasName)
+	{
+		m_metaName = m_tagContent;
+	}
+	else if (!strcmp("meta", name) && m_hasTitle)
+	{
+		m_metaTitle = m_tagContent;
 	}
 
 	m_currentElement.clear();

--- a/daemon/queue/NzbFile.h
+++ b/daemon/queue/NzbFile.h
@@ -35,6 +35,8 @@ public:
 	const std::string& GetCategoryFromFile() const { return m_category; }
 	std::unique_ptr<NzbInfo> DetachNzbInfo() { return std::move(m_nzbInfo); }
 	const std::string& GetPassword() const { return m_password; }
+	const std::string& GetMetaName() const { return m_metaName; }
+	const std::string& GetMetaTitle() const { return m_metaTitle; }
 
 	void LogDebugInfo();
 
@@ -43,6 +45,8 @@ private:
 	std::string m_fileName;
 	std::string m_category;
 	std::string m_password;
+	std::string m_metaName;
+	std::string m_metaTitle;
 
 	ArticleInfo* AddArticle(FileInfo* fileInfo, std::unique_ptr<ArticleInfo> articleInfo);
 	void AddFileInfo(std::unique_ptr<FileInfo> fileInfo);
@@ -59,6 +63,8 @@ private:
 	bool m_ignoreNextError;
 	bool m_hasPassword = false;
 	bool m_hasCategory = false;
+	bool m_hasName = false;
+	bool m_hasTitle = false;
 	std::string m_currentElement;
 
 	static void SAX_StartElement(NzbFile* file, const char *name, const char **atts);

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -456,7 +456,7 @@ std::pair<std::string, std::string> FileSystem::SplitPathAndFilename(const std::
 
 bool FileSystem::ReservedChar(char ch)
 {
-	if ((unsigned char)ch < 32)
+	if (Util::IsControlChar(ch))
 	{
 		return true;
 	}
@@ -519,6 +519,112 @@ CString FileSystem::MakeValidFilename(const char* filename, bool allowSlashes)
 	}			
 
 	return result;
+}
+
+std::string FileSystem::SanitizePathSegment(std::string_view name)
+{
+	// Bound input length to prevent excessive allocations from untrusted metadata
+	if (name.size() > 1024)
+	{
+		name = name.substr(0, 1024);
+	}
+
+	// 1. Trim leading whitespace
+	while (!name.empty() && (name.front() == ' ' || name.front() == '\t'))
+	{
+		name.remove_prefix(1);
+	}
+	
+	// 2. Trim trailing whitespace and dots
+	while (!name.empty() && (name.back() == ' ' || name.back() == '\t' || name.back() == '.'))
+	{
+		name.remove_suffix(1);
+	}
+
+	if (name.empty())
+	{
+		return "";
+	}
+
+	// 3. Remove illegal filesystem characters
+	std::string result = MakeValidFilename(std::string(name).c_str(), false).Str();
+
+	// 4. Safely collapse consecutive dots to normalize relative paths.
+	std::string collapsed;
+	collapsed.reserve(result.size());
+	size_t dotRun = 0;
+	for (char c : result)
+	{
+		if (c == '.')
+		{
+			dotRun++;
+		}
+		else
+		{
+			if (dotRun >= 2)
+			{
+				collapsed += '_';
+			}
+			else if (dotRun == 1)
+			{
+				collapsed += '.';
+			}
+			dotRun = 0;
+			collapsed += c;
+		}
+	}
+	if (dotRun >= 2)
+	{
+		collapsed += '_';
+	}
+	else if (dotRun == 1)
+	{
+		collapsed += '.';
+	}
+	result = std::move(collapsed);
+
+	// 5. Trim trailing dots/spaces that might have been exposed by MakeValidFilename or replacement
+	while (!result.empty() && (result.back() == '.' || result.back() == ' '))
+	{
+		result.pop_back();
+	}
+
+	// 6. Final safety check against Windows reserved names or empty path segments
+	if (result.empty() || result == "." || result == "..")
+	{
+		return "";
+	}
+
+	return result;
+}
+
+std::string FileSystem::SanitizeRelativePath(std::string_view path)
+{
+	std::string clean;
+	size_t start = 0;
+	while (start < path.size())
+	{
+		size_t end = path.find_first_of("/\\", start);
+		size_t len = (end == std::string_view::npos) ? (path.size() - start) : (end - start);
+		if (len > 0)
+		{
+			std::string_view seg = path.substr(start, len);
+			std::string cleanSeg = SanitizePathSegment(seg);
+			if (!cleanSeg.empty())
+			{
+				if (!clean.empty())
+				{
+					clean += PATH_SEPARATOR;
+				}
+				clean += cleanSeg;
+			}
+		}
+
+		if (end == std::string_view::npos) break;
+		start = end + 1;
+	}
+
+	return clean;
 }
 
 CString FileSystem::MakeUniqueFilename(const char* destDir, const char* basename)

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -526,7 +526,14 @@ std::string FileSystem::SanitizePathSegment(std::string_view name)
 	// Bound input length to prevent excessive allocations from untrusted metadata
 	if (name.size() > 1024)
 	{
-		name = name.substr(0, 1024);
+		size_t cut = 1024;
+		// Back up over any trailing UTF-8 continuation bytes (10xxxxxx) to avoid
+		// splitting a multi-byte sequence
+		while (cut > 0 && (static_cast<unsigned char>(name[cut]) & 0xC0) == 0x80)
+		{
+			--cut;
+		}
+		name = name.substr(0, cut);
 	}
 
 	// 1. Trim leading whitespace

--- a/daemon/util/FileSystem.h
+++ b/daemon/util/FileSystem.h
@@ -136,6 +136,8 @@ public:
 	static bool AllocateFile(const char* filename, int64 size, bool sparse, CString& errmsg);
 	static bool TruncateFile(const char* filename, int size);
 	static CString MakeValidFilename(const char* filename, bool allowSlashes = false);
+	static std::string SanitizePathSegment(std::string_view name);
+	static std::string SanitizeRelativePath(std::string_view path);
 	static bool ReservedChar(char ch);
 	static CString MakeUniqueFilename(const char* destDir, const char* basename);
 	static bool MoveFile(const char* srcFilename, const char* dstFilename);

--- a/daemon/util/Util.cpp
+++ b/daemon/util/Util.cpp
@@ -24,6 +24,7 @@
 #include <optional>
 #include <sstream>
 #include <array>
+#include <algorithm>
 #include "Util.h"
 
 #ifdef WIN32
@@ -571,6 +572,12 @@ void Util::Trim(std::string& str)
 {
 	TrimLeft(str);
 	TrimRight(str);
+}
+
+void Util::SanitizeLine(std::string& str)
+{
+	std::replace_if(str.begin(), str.end(), IsControlChar, ' ');
+	Trim(str);
 }
 
 char* Util::ReduceStr(char* str, const char* from, const char* to)

--- a/daemon/util/Util.h
+++ b/daemon/util/Util.h
@@ -110,6 +110,13 @@ public:
 	static void TrimLeft(std::string& str);
 	static char* Trim(char* str);
 	static void Trim(std::string& str);
+	static constexpr bool IsControlChar(char c) noexcept
+	{
+		constexpr unsigned char ASCII_SPACE = 32;
+		constexpr unsigned char ASCII_DEL = 127;
+		return static_cast<unsigned char>(c) < ASCII_SPACE || static_cast<unsigned char>(c) == ASCII_DEL;
+	}
+	static void SanitizeLine(std::string& str);
 	static bool EmptyStr(const char* str) { return !str || !*str; }
 	static std::vector<CString> SplitStr(const char* str, const char* separators);
 	static bool EndsWith(std::string_view str, std::string_view suffix, bool caseSensitive);

--- a/tests/queue/NzbFile.cpp
+++ b/tests/queue/NzbFile.cpp
@@ -133,6 +133,18 @@ BOOST_AUTO_TEST_CASE(SanitizePathSegmentTest)
 	std::string longName(2000, 'a');
 	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment(longName).size(), 1024u);
 
+	// UTF-8 boundary truncation: multi-byte character straddling byte 1024
+	std::string splitUtf8 = std::string(1023, 'a') + "\xC3\xA9" + "tail";
+	std::string cleanSplit = FileSystem::SanitizePathSegment(splitUtf8);
+	BOOST_CHECK_EQUAL(cleanSplit.size(), 1023u);
+	BOOST_CHECK_EQUAL(cleanSplit.back(), 'a');
+
+	// UTF-8 multi-byte character entirely within 1024 limit is preserved
+	std::string intactUtf8 = std::string(1022, 'a') + "\xC3\xA9" + "tail";
+	std::string cleanIntact = FileSystem::SanitizePathSegment(intactUtf8);
+	BOOST_CHECK_EQUAL(cleanIntact.size(), 1024u);
+	BOOST_CHECK_EQUAL(cleanIntact.substr(1022), "\xC3\xA9");
+
 	// Drive and UNC paths
 	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("C:\\Windows"), "C__Windows");
 	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("\\\\server\\share"), "__server_share");
@@ -296,6 +308,24 @@ BOOST_AUTO_TEST_CASE(EmptyNzbNameFallbackTest)
 
 	// Consecutive dots normalized
 	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("My..Release...nzb", true), "My_Release");
+}
+
+BOOST_AUTO_TEST_CASE(BuildFinalDirNameUniqueIdTest)
+{
+	NzbInfo nzbInfo1;
+	nzbInfo1.SetName("");
+	std::string finalDir1 = *nzbInfo1.BuildFinalDirName();
+	std::string expectedSuffix1 = "nzb-" + std::to_string(nzbInfo1.GetId());
+	BOOST_CHECK(finalDir1.rfind(expectedSuffix1) != std::string::npos);
+
+	NzbInfo nzbInfo2;
+	nzbInfo2.SetName("");
+	std::string finalDir2 = *nzbInfo2.BuildFinalDirName();
+	std::string expectedSuffix2 = "nzb-" + std::to_string(nzbInfo2.GetId());
+	BOOST_CHECK(finalDir2.rfind(expectedSuffix2) != std::string::npos);
+
+	// Both empty downloads must have different final directories
+	BOOST_CHECK_NE(finalDir1, finalDir2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/queue/NzbFile.cpp
+++ b/tests/queue/NzbFile.cpp
@@ -22,8 +22,10 @@
 #include "nzbget.h"
 
 #include <boost/test/unit_test.hpp>
+#include <fstream>
 #include "Options.h"
 #include "NzbFile.h"
+#include "DownloadInfo.h"
 #include "FileSystem.h"
 
 BOOST_AUTO_TEST_SUITE(QueueTest)
@@ -89,6 +91,211 @@ BOOST_AUTO_TEST_CASE(NZBParserTest)
 	TestNzb("passwd{{thisisthepassword}}", "");
 	TestNzb("passwdMeta", "");
 	TestNzb("passwdEntity", "");
+}
+
+BOOST_AUTO_TEST_CASE(SanitizePathSegmentTest)
+{
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("Clean.Release.Name"), "Clean.Release.Name");
+	std::string testPath = FileSystem::SanitizePathSegment("../../etc/cron.d");
+	BOOST_CHECK(testPath.find('/') == std::string::npos);
+	BOOST_CHECK(testPath.find('\\') == std::string::npos);
+	BOOST_CHECK(testPath.find("..") == std::string::npos);
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment(".."), "");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("."), "");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment(""), "");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("name:with*bad?chars"), "name_with_bad_chars");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("folder/sub\\name"), "folder_sub_name");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("trailing.dots...   "), "trailing.dots");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("   leading.space"), "leading.space");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("CON"), "_CON");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("NUL.txt"), "_NUL.txt");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("AUX"), "_AUX");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("COM1"), "_COM1");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("PRN.dat"), "_PRN.dat");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("LPT1"), "_LPT1");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("Vidéo.2026.mkv"), "Vidéo.2026.mkv");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("Mädchen.mp4"), "Mädchen.mp4");
+
+	// Consecutive dots and spaces
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("..."), "");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment(".. "), "");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("prefix..middle...suffix"), "prefix_middle_suffix");
+	std::string dotPath1 = FileSystem::SanitizePathSegment(".../");
+	BOOST_CHECK(dotPath1.find('/') == std::string::npos);
+	BOOST_CHECK(dotPath1.find("..") == std::string::npos);
+	std::string dotPath2 = FileSystem::SanitizePathSegment("folder/...");
+	BOOST_CHECK(dotPath2.find('/') == std::string::npos);
+	BOOST_CHECK(dotPath2.find("..") == std::string::npos);
+
+	// Long dot runs and length bounding
+	std::string longDots(10000, '.');
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment(longDots), "");
+	std::string longName(2000, 'a');
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment(longName).size(), 1024u);
+
+	// Drive and UNC paths
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("C:\\Windows"), "C__Windows");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizePathSegment("\\\\server\\share"), "__server_share");
+}
+
+BOOST_AUTO_TEST_CASE(SanitizeRelativePathTest)
+{
+	std::string sep(1, PATH_SEPARATOR);
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("Movies"), "Movies");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("TV/HD"), "TV" + sep + "HD");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("TV / HD"), "TV" + sep + "HD");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("TV>HD"), "TV_HD");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("TV > HD"), "TV _ HD");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("TV\\Shows"), "TV" + sep + "Shows");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("TV/../../HD"), "TV" + sep + "HD");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("TV/./HD"), "TV" + sep + "HD");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("TV/.."), "TV");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("TV/../../../../../etc"), "TV" + sep + "etc");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("../../Movies/4K"), "Movies" + sep + "4K");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("/var/www/"), "var" + sep + "www");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("C:\\Movies\\SciFi"), "C_" + sep + "Movies" + sep + "SciFi");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("Séries/HD"), "Séries" + sep + "HD");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath(".."), "");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("../.."), "");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath(""), "");
+
+	// Consecutive dots in relative paths
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("myfolder/.../file"), "myfolder" + sep + "file");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("myfolder/.. /file"), "myfolder" + sep + "file");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath(".../file"), "file");
+
+	// Absolute and UNC path normalization
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("\\\\remote-server\\share\\data"), "remote-server" + sep + "share" + sep + "data");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("//remote-server/share/data"), "remote-server" + sep + "share" + sep + "data");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("C:\\Windows\\System32"), "C_" + sep + "Windows" + sep + "System32");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("C:/Windows/System32"), "C_" + sep + "Windows" + sep + "System32");
+
+	// Reserved device names in path components
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("LPT1/subfolder"), "_LPT1" + sep + "subfolder");
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath("movies/CON/item"), "movies" + sep + "_CON" + sep + "item");
+}
+
+namespace
+{
+	void WriteTempNzb(const fs::path& filePath, std::string_view headMeta)
+	{
+		std::ofstream out(filePath.string());
+		out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		    << "<!DOCTYPE nzb PUBLIC \"-//newzBin//DTD NZB 1.0//EN\" \"http://www.newzbin.com/DTD/nzb/nzb-1.0.dtd\">\n"
+		    << "<nzb xmlns=\"http://www.newzbin.com/DTD/2003/nzb\">\n"
+		    << "<head>\n"
+		    << headMeta << "\n"
+		    << "</head>\n"
+		    << "<file poster=\"poster@test.com\" date=\"1335508618\" subject=\"&quot;testfile.mkv&quot; yEnc (1/1)\">\n"
+		    << "<groups><group>alt.binaries.test</group></groups>\n"
+		    << "<segments><segment bytes=\"100\" number=\"1\">test@msgid</segment></segments>\n"
+		    << "</file>\n"
+		    << "</nzb>\n";
+	}
+}
+
+BOOST_AUTO_TEST_CASE(NzbFileMetaParsingTest)
+{
+	const fs::path tempNzb = fs::temp_directory_path() / "nzbget_test_meta_name.nzb";
+	WriteTempNzb(tempNzb,
+		"<meta type=\"name\">My.Clean.Release.Name.S01E01 &amp; Special.Edition</meta>\n"
+		"<meta type=\"title\">My.Clean.Release.Name.S01E01.mkv</meta>\n"
+		"<meta type=\"category\">TV / HD</meta>\n"
+		"<meta type=\"password\">secret123</meta>");
+
+	NzbFile nzbFile(tempNzb.string().c_str(), "");
+	BOOST_REQUIRE(nzbFile.Parse());
+
+	BOOST_CHECK_EQUAL(nzbFile.GetMetaName(), "My.Clean.Release.Name.S01E01 & Special.Edition");
+	BOOST_CHECK_EQUAL(nzbFile.GetMetaTitle(), "My.Clean.Release.Name.S01E01.mkv");
+	BOOST_CHECK_EQUAL(nzbFile.GetPassword(), "secret123");
+	BOOST_CHECK_EQUAL(nzbFile.GetCategoryFromFile(), "TV / HD");
+
+	auto nzbInfo = nzbFile.DetachNzbInfo();
+	BOOST_REQUIRE(nzbInfo);
+	BOOST_CHECK_EQUAL(nzbInfo->GetMetaName(), "My.Clean.Release.Name.S01E01 & Special.Edition");
+
+	fs::remove(tempNzb);
+}
+
+BOOST_AUTO_TEST_CASE(NzbFileMetaTitleFallbackTest)
+{
+	const fs::path tempNzb = fs::temp_directory_path() / "nzbget_test_meta_title_fallback.nzb";
+	WriteTempNzb(tempNzb, "<meta type=\"title\">Fallback.Release.Title.mkv</meta>");
+
+	NzbFile nzbFile(tempNzb.string().c_str(), "");
+	BOOST_REQUIRE(nzbFile.Parse());
+
+	BOOST_CHECK_EQUAL(nzbFile.GetMetaName(), "Fallback.Release.Title.mkv");
+	BOOST_CHECK_EQUAL(nzbFile.GetMetaTitle(), "Fallback.Release.Title.mkv");
+
+	auto nzbInfo = nzbFile.DetachNzbInfo();
+	BOOST_REQUIRE(nzbInfo);
+	BOOST_CHECK_EQUAL(nzbInfo->GetMetaName(), "Fallback.Release.Title.mkv");
+
+	fs::remove(tempNzb);
+}
+
+BOOST_AUTO_TEST_CASE(NzbFileMetaPathValidationTest)
+{
+	const fs::path tempNzb = fs::temp_directory_path() / "nzbget_test_meta_validation.nzb";
+	WriteTempNzb(tempNzb,
+		"<meta type=\"name\">../../../../test/folder/release</meta>\n"
+		"<meta type=\"category\">../../../../media/downloads</meta>");
+
+	NzbFile nzbFile(tempNzb.string().c_str(), "");
+	BOOST_REQUIRE(nzbFile.Parse());
+
+	// Slashes and .. in meta name must be normalized and cannot escape base directories
+	BOOST_CHECK(nzbFile.GetMetaName().find('/') == std::string::npos);
+	BOOST_CHECK(nzbFile.GetMetaName().find('\\') == std::string::npos);
+	BOOST_CHECK(nzbFile.GetMetaName().find("..") == std::string::npos);
+
+	// Relative path separators and .. must be safely normalized when generating category path
+	std::string sep(1, PATH_SEPARATOR);
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath(nzbFile.GetCategoryFromFile()), "media" + sep + "downloads");
+
+	fs::remove(tempNzb);
+}
+
+BOOST_AUTO_TEST_CASE(NzbFileCategoryControlCharsTest)
+{
+	const fs::path tempNzb = fs::temp_directory_path() / "nzbget_test_meta_control_chars.nzb";
+	WriteTempNzb(tempNzb,
+		"<meta type=\"category\">\r\n\t  Movies\r\n/\t4K  \r\n</meta>");
+
+	NzbFile nzbFile(tempNzb.string().c_str(), "");
+	BOOST_REQUIRE(nzbFile.Parse());
+
+	// Control characters must be stripped to protect line-based DiskState persistence
+	const std::string& category = nzbFile.GetCategoryFromFile();
+	BOOST_CHECK(category.find('\n') == std::string::npos);
+	BOOST_CHECK(category.find('\r') == std::string::npos);
+	BOOST_CHECK(category.find('\t') == std::string::npos);
+
+	std::string sep(1, PATH_SEPARATOR);
+	BOOST_CHECK_EQUAL(FileSystem::SanitizeRelativePath(category), "Movies" + sep + "4K");
+
+	fs::remove(tempNzb);
+}
+
+BOOST_AUTO_TEST_CASE(EmptyNzbNameFallbackTest)
+{
+	// MakeNiceNzbName must never return empty string
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("   .nzb", true), "nzb");
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName(".nzb", true), "nzb");
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("...", true), "nzb");
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("   ", true), "nzb");
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("", true), "nzb");
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("   .nzb", false), ".nzb");
+
+	// Valid names must not be altered
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("My.Release.nzb", true), "My.Release");
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("My.Release.nzb", false), "My.Release.nzb");
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("My.Release", false), "My.Release");
+
+	// Consecutive dots normalized
+	BOOST_CHECK_EQUAL(NzbInfo::MakeNiceNzbName("My..Release...nzb", true), "My_Release");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/util/Util.cpp
+++ b/tests/util/Util.cpp
@@ -523,4 +523,42 @@ BOOST_AUTO_TEST_CASE(TestAppendRPCJsonParsing)
 	}
 }
 
+BOOST_AUTO_TEST_CASE(SanitizeLineTest)
+{
+	// IsControlChar checks
+	BOOST_CHECK(Util::IsControlChar('\0'));
+	BOOST_CHECK(Util::IsControlChar('\r'));
+	BOOST_CHECK(Util::IsControlChar('\n'));
+	BOOST_CHECK(Util::IsControlChar('\t'));
+	BOOST_CHECK(Util::IsControlChar(127));
+	BOOST_CHECK(!Util::IsControlChar(' '));
+	BOOST_CHECK(!Util::IsControlChar('A'));
+	BOOST_CHECK(!Util::IsControlChar('z'));
+	// UTF-8 bytes (> 127) must NOT be identified as control characters
+	BOOST_CHECK(!Util::IsControlChar(static_cast<char>(0xC3)));
+	BOOST_CHECK(!Util::IsControlChar(static_cast<char>(0xA9)));
+
+	// SanitizeLine trimming and replacement
+	std::string s1 = "\r\n\t  hello  \r\n";
+	Util::SanitizeLine(s1);
+	BOOST_CHECK_EQUAL(s1, "hello");
+
+	std::string s2 = "TV\r\nHD";
+	Util::SanitizeLine(s2);
+	BOOST_CHECK_EQUAL(s2, "TV  HD");
+
+	std::string s3 = "Movies\t4K";
+	Util::SanitizeLine(s3);
+	BOOST_CHECK_EQUAL(s3, "Movies 4K");
+
+	// UTF-8 multi-byte characters must be preserved intact
+	std::string s4 = "\r\n  Séries / Vidéo  \n";
+	Util::SanitizeLine(s4);
+	BOOST_CHECK_EQUAL(s4, "Séries / Vidéo");
+
+	std::string s5 = "Mädchen\r\n4K";
+	Util::SanitizeLine(s5);
+	BOOST_CHECK_EQUAL(s5, "Mädchen  4K");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description

- Adds support for parsing release metadata in NZB files;
- Hardens path and name handling across download queues and disk state persistence.

## Testing

- macOS Tahoe